### PR TITLE
JAMES-3589 Apply state preservation fix

### DIFF
--- a/tmail-backend/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/MatcherSplitter.java
+++ b/tmail-backend/mailetcontainer-impl/src/main/java/org/apache/james/mailetcontainer/impl/MatcherSplitter.java
@@ -151,6 +151,7 @@ public class MatcherSplitter {
 
                     Mail newMail = MailImpl.duplicate(mail);
                     newMail.setRecipients(matchedRcpts);
+                    newMail.setState(mail.getState());
 
                     // Set a header because the matcher matched. This can be
                     // used later when processing the route


### PR DESCRIPTION
Running CustomMailetProcessing fix inside James memory server
against the mailet integration test suite I realise the fix was
actually missing.