### PR TITLE
[PERFORMANCE] Rely on MIME4J 0.8.5-SNAPSHOT for TMail

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -12,6 +12,16 @@
     <artifactId>distributed-es6-backport</artifactId>
 
     <dependencies>
+        <!-- Force the version of Mime4J used as a dependency -->
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>backends-es-v6</artifactId>

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -12,6 +12,16 @@
     <artifactId>distributed</artifactId>
 
     <dependencies>
+        <!-- Force the version of Mime4J used as a dependency -->
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>blobid-list</artifactId>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -12,6 +12,16 @@
     <artifactId>memory</artifactId>
 
     <dependencies>
+        <!-- Force the version of Mime4J used as a dependency -->
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>encrypted-mailbox-guice</artifactId>

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -42,7 +42,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.version>3.7.0-SNAPSHOT</james.version>
         <james.protocols.groupId>${james.groupId}.protocols</james.protocols.groupId>
-        <apache-mime4j.version>0.8.3</apache-mime4j.version>
+        <apache-mime4j.version>0.8.5-SNAPSHOT</apache-mime4j.version>
 
         <feign.version>10.3.0</feign.version>
         <guavate.version>1.0.0</guavate.version>


### PR DESCRIPTION
The newest commits shipped on MIME4J ships some nice-to-have performance improvments we might want to benefit from 
prior a mime4J release that anyway takes time.

In the meantime, TMAIL, not subject to the release pluging not accepting `-SNAPSHOT` (a bocker for `apache/james-project`) can start using the fully compatible version of MIME4J.