### PR TITLE
ISSUE-158 Fix missing james-server-mailetcontainer-camel dependency

### DIFF
--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -248,6 +248,11 @@
                 <groupId>${james.groupId}</groupId>
                 <artifactId>james-server-mailetcontainer-camel</artifactId>
                 <version>${james.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-mailetcontainer-camel</artifactId>
+                <version>${james.version}</version>
                 <type>test-jar</type>
             </dependency>
 


### PR DESCRIPTION
When I tried maven to compile a master, I got an error about missing dependency. 
`james-server-mailetcontainer-camel` in `mailetcontainer-impl` artifact

Commit causes error: a6600d49b435db3bfbaefd846606d1446d6f08ff 