### PR TITLE
Fix SingleSaveBlobStoreDAO save blob and deleteBucket methods

### DIFF
--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
@@ -12,7 +12,6 @@ import org.apache.james.blob.api.ObjectStoreException;
 import org.apache.james.blob.api.ObjectStoreIOException;
 import org.reactivestreams.Publisher;
 
-import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSource;
 
 import reactor.core.publisher.Mono;
@@ -41,54 +40,55 @@ public class SingleSaveBlobStoreDAO implements BlobStoreDAO {
         return blobStoreDAO.readBytes(bucketName, blobId);
     }
 
-    private boolean isBucketNameDefault(BucketName bucketName) {
-        Preconditions.checkNotNull(bucketName);
-        return defaultBucketName.equals(bucketName);
-    }
-
-    private Mono<Void> saveBlobId(BlobId blobId, BucketName bucketName) {
-        if (isBucketNameDefault(bucketName)) {
-            return Mono.from(blobIdList.store(blobId))
-                .then();
+    @Override
+    public Mono<Void> save(BucketName bucketName, BlobId blobId, byte[] data) {
+        if (defaultBucketName.equals(bucketName)) {
+            return Mono.from(blobIdList.isStored(blobId))
+                .flatMap(isStored -> {
+                    if (isStored) {
+                        return Mono.empty();
+                    }
+                    return Mono.from(blobStoreDAO.save(bucketName, blobId, data))
+                        .then(Mono.from(blobIdList.store(blobId)))
+                        .then();
+                });
         } else {
-            return Mono.empty();
+            return Mono.from(blobStoreDAO.save(bucketName, blobId, data));
         }
     }
 
     @Override
-    public Mono<Void> save(BucketName bucketName, BlobId blobId, byte[] data) {
-        return Mono.from(blobIdList.isStored(blobId))
-                .flatMap(isStored -> {
-                    if (isStored && isBucketNameDefault(bucketName)) {
-                        return Mono.empty();
-                    }
-                    return Mono.from(blobStoreDAO.save(bucketName, blobId, data))
-                        .then(saveBlobId(blobId, bucketName));
-                });
-    }
-
-    @Override
     public Publisher<Void> save(BucketName bucketName, BlobId blobId, InputStream inputStream) {
-        return Mono.from(blobIdList.isStored(blobId))
+        if (defaultBucketName.equals(bucketName)) {
+            return Mono.from(blobIdList.isStored(blobId))
                 .flatMap(isStored -> {
-                    if (isStored && isBucketNameDefault(bucketName)) {
+                    if (isStored) {
                         return Mono.empty();
                     }
                     return Mono.from(blobStoreDAO.save(bucketName, blobId, inputStream))
-                        .then(saveBlobId(blobId, bucketName));
+                        .then(Mono.from(blobIdList.store(blobId)))
+                        .then();
                 });
+        } else {
+            return Mono.from(blobStoreDAO.save(bucketName, blobId, inputStream));
+        }
     }
 
     @Override
     public Publisher<Void> save(BucketName bucketName, BlobId blobId, ByteSource content) {
-        return Mono.from(blobIdList.isStored(blobId))
+        if (defaultBucketName.equals(bucketName)) {
+            return Mono.from(blobIdList.isStored(blobId))
                 .flatMap(isStored -> {
-                    if (isStored && isBucketNameDefault(bucketName)) {
+                    if (isStored) {
                         return Mono.empty();
                     }
                     return Mono.from(blobStoreDAO.save(bucketName, blobId, content))
-                        .then(saveBlobId(blobId, bucketName));
+                        .then(Mono.from(blobIdList.store(blobId)))
+                        .then();
                 });
+        } else {
+            return Mono.from(blobStoreDAO.save(bucketName, blobId, content));
+        }
     }
 
     @Override

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreTest.java
@@ -1,12 +1,5 @@
 package com.linagora.tmail.blob.blobid.list;
 
-import static org.apache.james.blob.api.BlobStoreDAOFixture.CUSTOM_BUCKET_NAME;
-import static org.apache.james.blob.api.BlobStoreDAOFixture.OTHER_TEST_BLOB_ID;
-import static org.apache.james.blob.api.BlobStoreDAOFixture.SHORT_BYTEARRAY;
-import static org.apache.james.blob.api.BlobStoreDAOFixture.TEST_BLOB_ID;
-import static org.apache.james.blob.api.BlobStoreDAOFixture.TEST_BUCKET_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -18,15 +11,11 @@ import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.memory.MemoryBlobStoreDAO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.blob.blobid.list.cassandra.CassandraBlobIdList;
 import com.linagora.tmail.blob.blobid.list.cassandra.CassandraBlobIdListDAO;
 import com.linagora.tmail.blob.blobid.list.cassandra.CassandraBlobIdListModule;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 public class SingleSaveBlobStoreTest implements SingleSaveBlobStoreContract {
 
@@ -43,11 +32,6 @@ public class SingleSaveBlobStoreTest implements SingleSaveBlobStoreContract {
         CassandraBlobIdListDAO cassandraBlobIdListDAO = new CassandraBlobIdListDAO(cassandra.getConf());
         cassandraBlobIdList = new CassandraBlobIdList(cassandraBlobIdListDAO);
         blobStoreDAO = new SingleSaveBlobStoreDAO(new MemoryBlobStoreDAO(), cassandraBlobIdList, defaultBucketName());
-    }
-
-    @Override
-    public SingleSaveBlobStoreDAO singleSaveBlobStoreDAO() {
-        return new SingleSaveBlobStoreDAO(blobStoreDAO, blobIdList(), defaultBucketName());
     }
 
     @Override
@@ -68,18 +52,6 @@ public class SingleSaveBlobStoreTest implements SingleSaveBlobStoreContract {
     @Override
     public BucketName defaultBucketName() {
         return BucketName.DEFAULT;
-    }
-
-    @Override
-    @Test
-    public void listBucketsShouldReturnAllBucketsInUse() {
-        BlobStoreDAO store = testee();
-
-        Mono.from(store.save(TEST_BUCKET_NAME, TEST_BLOB_ID, SHORT_BYTEARRAY)).block();
-        Mono.from(store.save(CUSTOM_BUCKET_NAME, OTHER_TEST_BLOB_ID, SHORT_BYTEARRAY)).block();
-
-        assertThat(Flux.from(store.listBuckets()).collectList().block())
-            .containsOnly(TEST_BUCKET_NAME, CUSTOM_BUCKET_NAME);
     }
 
     @Override


### PR DESCRIPTION
A SingleSaveBlobStore is supposed to only write on the default bucket, and it should not be allowed to delete the default bucket either.

Added some tests to check added above behaviors and also fixed and refactor the contract as things were not making sense with those rules.