### PR TITLE
JAMES-3150 SingleSaveBlobStoreDAO should not fail to delete blobs in …

### DIFF
--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
@@ -93,11 +93,7 @@ public class SingleSaveBlobStoreDAO implements BlobStoreDAO {
 
     @Override
     public Mono<Void> delete(BucketName bucketName, BlobId blobId) {
-        if (defaultBucketName.equals(bucketName)) {
-            return Mono.error(new ObjectStoreException("Can not delete in the default bucket when single save is enabled"));
-        } else {
-            return Mono.from(blobStoreDAO.delete(bucketName, blobId));
-        }
+        return Mono.from(blobStoreDAO.delete(bucketName, blobId));
     }
 
     @Override

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
@@ -1,5 +1,7 @@
 package com.linagora.tmail.blob.blobid.list
 
+import java.io.ByteArrayInputStream
+
 import com.google.common.io.ByteSource
 import org.apache.james.blob.api.BlobStoreDAOFixture.{SHORT_BYTEARRAY, TEST_BUCKET_NAME}
 import org.apache.james.blob.api.{BlobId, BlobStoreDAOContract, BucketName, ObjectStoreException}
@@ -7,8 +9,6 @@ import org.assertj.core.api.Assertions.{assertThat, assertThatCode, assertThatTh
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.jupiter.api.Test
 import reactor.core.scala.publisher.SMono
-
-import java.io.ByteArrayInputStream
 
 trait SingleSaveBlobStoreContract extends BlobStoreDAOContract {
 
@@ -133,20 +133,6 @@ trait SingleSaveBlobStoreContract extends BlobStoreDAOContract {
 
     assertThat(SMono.fromPublisher(testee.readBytes(defaultBucketName, blobId)).block())
       .isEqualTo(SHORT_BYTEARRAY)
-  }
-
-  @Test
-  def deleteShouldFailWithDefaultBucket(): Unit = {
-    val blobId: BlobId = blobIdFactory.randomId()
-    SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
-
-    val deleteBlobThrowingCallable: ThrowingCallable = () =>
-      SMono.fromPublisher(testee.delete(defaultBucketName, blobId)).block()
-
-    assertThatThrownBy(deleteBlobThrowingCallable)
-      .isInstanceOf(classOf[ObjectStoreException])
-    assertThatThrownBy(deleteBlobThrowingCallable)
-      .hasMessage("Can not delete in the default bucket when single save is enabled")
   }
 
   @Test


### PR DESCRIPTION
…default bucket

Concurrent deletion do not occur thanks to the GenerationBlobId