### PR TITLE
JAMES-3647 Adopt eclipse-temurin:11-jre-focal docker image

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -356,7 +356,7 @@
                 </executions>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>linagora/tmail-backend-distributed-esv6</image>

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -355,7 +355,7 @@
                 </executions>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>linagora/tmail-backend-distributed</image>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -164,7 +164,7 @@
                 </executions>
                 <configuration>
                     <from>
-                        <image>adoptopenjdk:11-jdk-hotspot</image>
+                        <image>eclipse-temurin:11-jre-focal</image>
                     </from>
                     <to>
                         <image>linagora/tmail-backend-memory</image>


### PR DESCRIPTION
DEPRECATION NOTICE of adoptopenjdk:

This image is officially deprecated in favor of the eclipse-temurin image,
and will receive no further updates after 2021-08-01 (Aug 01, 2021). Please
adjust your usage accordingly.

https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&ordering=last_updated&name=11