### PR TITLE
ISSUE-97 Keystore/get method - fix contract

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/LinagoraKeystoreGetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/LinagoraKeystoreGetMethodContract.scala
@@ -83,7 +83,9 @@ trait LinagoraKeystoreGetMethodContract {
       .body()
       .asString()
 
-    assertThatJson(response).isEqualTo(
+    assertThatJson(response)
+      .when(net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER)
+      .isEqualTo(
       s"""{
          |  "sessionState": "${SESSION_STATE.value}",
          |  "methodResponses": [


### PR DESCRIPTION
When I run `DistributedLinagoraKeystoreGetMethodTest`, I get a fail test, because the element in the list has not right ordered.