### PR TITLE
[UPGRADE] async-profiler 2.0 -> 2.7

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -348,10 +348,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0/async-profiler-2.0-linux-x64.tar.gz</url>
+                            <url>https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-x64.tar.gz</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <md5>50764faa05521fdc36a5e3f6d6628d75</md5>
+                            <md5>49a792398a9d67e19fba8fc34e66ff66</md5>
                         </configuration>
                     </execution>
                 </executions>
@@ -439,7 +439,7 @@
                                 <into>/root/extensions-jars</into>
                             </path>
                             <path>
-                                <from>target/async-profiler-2.0-linux-x64</from>
+                                <from>target/async-profiler-2.7-linux-x64</from>
                                 <into>/root/async-profiler</into>
                             </path>
                         </paths>

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -348,10 +348,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0/async-profiler-2.0-linux-x64.tar.gz</url>
+                            <url>https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-x64.tar.gz</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <md5>50764faa05521fdc36a5e3f6d6628d75</md5>
+                            <md5>49a792398a9d67e19fba8fc34e66ff66</md5>
                         </configuration>
                     </execution>
                 </executions>
@@ -436,7 +436,7 @@
                                 <into>/root/glowroot</into>
                             </path>
                             <path>
-                                <from>target/async-profiler-2.0-linux-x64</from>
+                                <from>target/async-profiler-2.7-linux-x64</from>
                                 <into>/root/async-profiler</into>
                             </path>
                             <path>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -153,10 +153,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/glowroot/glowroot/releases/download/v0.13.6/glowroot-0.13.6-dist.zip</url>
+                            <url>https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-x64.tar.gz</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <md5>f9026dbab1fbade067ca549913802fcc</md5>
+                            <md5>49a792398a9d67e19fba8fc34e66ff66</md5>
                         </configuration>
                     </execution>
                     <execution>
@@ -255,7 +255,7 @@
                                 <into>/root/glowroot</into>
                             </path>
                             <path>
-                                <from>target/async-profiler-2.0-linux-x64</from>
+                                <from>target/async-profiler-2.7-linux-x64</from>
                                 <into>/root/async-profiler</into>
                             </path>
                             <path>


### PR DESCRIPTION
 - Allows using perf_event inside container, which includes system calls in the stacktrace
 - Include line numbers in the flame graph
 - Better container support