### PR TITLE
Bind DAOs as SINGLETON to avoid re-preparing Cassandra queries

### DIFF
--- a/tmail-backend/rate-limiter/rate-limiter-cassandra/src/main/scala/com/linagora/tmail/rate/limiter/api/cassandra/module/CassandraRateLimitingModule.scala
+++ b/tmail-backend/rate-limiter/rate-limiter-cassandra/src/main/scala/com/linagora/tmail/rate/limiter/api/cassandra/module/CassandraRateLimitingModule.scala
@@ -1,7 +1,8 @@
 package com.linagora.tmail.rate.limiter.api.cassandra.module
 
-import com.google.inject.AbstractModule
 import com.google.inject.multibindings.Multibinder
+import com.google.inject.{AbstractModule, Scopes}
+import com.linagora.tmail.rate.limiter.api.cassandra.dao.{CassandraRateLimitPlanDAO, CassandraRateLimitPlanUserDAO}
 import com.linagora.tmail.rate.limiter.api.cassandra.table.{CassandraRateLimitPlanTable, CassandraRateLimitPlanUserTable}
 import com.linagora.tmail.rate.limiter.api.cassandra.{CassandraRateLimitingPlanRepository, CassandraRateLimitingPlanUserRepository}
 import com.linagora.tmail.rate.limiter.api.{RateLimitingPlanRepository, RateLimitingPlanUserRepository}
@@ -9,6 +10,9 @@ import org.apache.james.backends.cassandra.components.CassandraModule
 
 class CassandraRateLimitingModule() extends AbstractModule {
   override def configure(): Unit = {
+    bind(classOf[CassandraRateLimitPlanDAO]).in(Scopes.SINGLETON)
+    bind(classOf[CassandraRateLimitPlanUserDAO]).in(Scopes.SINGLETON)
+
     bind(classOf[RateLimitingPlanUserRepository]).to(classOf[CassandraRateLimitingPlanUserRepository])
     bind(classOf[RateLimitingPlanRepository]).to(classOf[CassandraRateLimitingPlanRepository])
 


### PR DESCRIPTION
Sample logs:

```
Re-preparing already prepared query is generally an anti-pattern and will likely affect performance. Consider preparing the statement only once. Query='INSERT INTO rate_limit_plan (plan_id,plan_name,operation_limitation_name,rate_limitations) VALUES (:plan_id,:plan_name,:operation_limitation_name,:rate_limitations);'
```