### PR TITLE
ISSUE-328: ES 6 implementation of EmailAddress Search engine

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -62,6 +62,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-es-v6</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>mailbox-encrypted-cassandra</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -89,6 +89,7 @@ import com.linagora.tmail.encrypted.cassandra.KeystoreCassandraModule;
 import com.linagora.tmail.james.jmap.ShortLivedTokenModule;
 import com.linagora.tmail.james.jmap.jwt.ShortLivedTokenRoutesModule;
 import com.linagora.tmail.james.jmap.longlivedtoken.LongLivedTokenStoreCassandraModule;
+import com.linagora.tmail.james.jmap.method.ContactAutocompleteMethodModule;
 import com.linagora.tmail.james.jmap.method.CustomMethodModule;
 import com.linagora.tmail.james.jmap.method.EmailSendMethodModule;
 import com.linagora.tmail.james.jmap.method.EncryptedEmailDetailedViewGetMethodModule;
@@ -99,6 +100,7 @@ import com.linagora.tmail.james.jmap.method.KeystoreGetMethodModule;
 import com.linagora.tmail.james.jmap.method.KeystoreSetMethodModule;
 import com.linagora.tmail.james.jmap.method.LongLivedTokenGetMethodModule;
 import com.linagora.tmail.james.jmap.method.LongLivedTokenSetMethodModule;
+import com.linagora.tmail.james.jmap.module.ES6ContactAutoCompleteModule;
 import com.linagora.tmail.james.jmap.oidc.WebFingerModule;
 import com.linagora.tmail.james.jmap.team.mailboxes.TeamMailboxJmapModule;
 import com.linagora.tmail.james.jmap.ticket.CassandraTicketStoreModule;
@@ -131,6 +133,7 @@ public class DistributedServer {
         new WebAdminMailOverWebModule());
 
     public static final Module JMAP = Modules.override(
+        new ContactAutocompleteMethodModule(),
         new CassandraJmapModule(),
         new CustomMethodModule(),
         new EncryptedEmailContentStoreCassandraModule(),
@@ -209,7 +212,8 @@ public class DistributedServer {
                 new DistributedTaskSerializationModule(),
                 new TeamMailboxModule(),
                 new RedisRateLimiterModule(),
-                new CassandraRateLimitingModule());
+                new CassandraRateLimitingModule(),
+                new ES6ContactAutoCompleteModule());
 
     public static void main(String[] args) throws Exception {
         DistributedJamesConfiguration configuration = DistributedJamesConfiguration.builder()

--- a/tmail-backend/jmap/extensions-es-v6/pom.xml
+++ b/tmail-backend/jmap/extensions-es-v6/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tmail-backend</artifactId>
+        <groupId>com.linagora.tmail</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jmap-extensions-es-v6</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>backends-es-v6</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>backends-es-v6</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ContactMappingFactory.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ContactMappingFactory.java
@@ -1,0 +1,148 @@
+package com.linagora.tmail.james.jmap;
+
+import static org.apache.james.backends.es.NodeMappingFactory.ANALYZER;
+import static org.apache.james.backends.es.NodeMappingFactory.KEYWORD;
+import static org.apache.james.backends.es.NodeMappingFactory.PROPERTIES;
+import static org.apache.james.backends.es.NodeMappingFactory.SEARCH_ANALYZER;
+import static org.apache.james.backends.es.NodeMappingFactory.TYPE;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+import java.io.IOException;
+
+import org.apache.james.backends.es.ElasticSearchConfiguration;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+public class ContactMappingFactory {
+
+    public static final String ACCOUNT_ID = "accountId";
+    public static final String DOMAIN = "domain";
+    public static final String CONTACT_ID = "contactId";
+    public static final String EMAIL = "email";
+    public static final String FIRSTNAME = "firstname";
+    public static final String SURNAME = "surname";
+    public static final String EMAIL_AUTO_COMPLETE_ANALYZER = "email_ngram_filter_analyzer";
+    public static final String NAME_AUTO_COMPLETE_ANALYZER = "name_edge_ngram_filter_analyzer";
+    public static final String REBUILT_KEYWORD_ANALYZER = "rebuilt_keyword";
+    public static final String NGRAM_FILTER = "ngram_filter";
+    public static final String EDGE_NGRAM_FILTER = "edge_ngram_filter";
+    public static final String FILTER = "filter";
+    public static final String STANDARD = "standard";
+    public static final String TEXT = "text";
+    public static final String LOWERCASE = "lowercase";
+    public static final String MIN_GRAM = "min_gram";
+    public static final String MAX_NGRAM = "max_gram";
+    public static final String TOKENIZER = "tokenizer";
+
+    private final ElasticSearchConfiguration elasticSearchConfiguration;
+    private final ElasticSearchContactConfiguration contactConfiguration;
+
+    public ContactMappingFactory(ElasticSearchConfiguration configuration, ElasticSearchContactConfiguration contactConfiguration) {
+        this.elasticSearchConfiguration = configuration;
+        this.contactConfiguration = contactConfiguration;
+    }
+
+    public XContentBuilder generalContactIndicesSetting() throws IOException {
+        return jsonBuilder()
+            .startObject()
+                .startObject("settings")
+                    .field("number_of_shards", elasticSearchConfiguration.getNbShards())
+                    .field("number_of_replicas", elasticSearchConfiguration.getNbReplica())
+                    .field("index.write.wait_for_active_shards", elasticSearchConfiguration.getWaitForActiveShards())
+                    .startObject("analysis")
+                        .startObject(ANALYZER)
+                            .startObject(EMAIL_AUTO_COMPLETE_ANALYZER)
+                                .field(TOKENIZER, "uax_url_email")
+                                .startArray(FILTER)
+                                    .value(NGRAM_FILTER)
+                                    .value(LOWERCASE)
+                            .endArray()
+                            .endObject()
+                            .startObject(NAME_AUTO_COMPLETE_ANALYZER)
+                                .field(TOKENIZER, STANDARD)
+                                .startArray(FILTER)
+                                    .value(EDGE_NGRAM_FILTER)
+                                    .value(LOWERCASE)
+                                .endArray()
+                            .endObject()
+                            .startObject(REBUILT_KEYWORD_ANALYZER)
+                                .field(TOKENIZER, KEYWORD)
+                                .startArray(FILTER)
+                                    .value(LOWERCASE)
+                                .endArray()
+                            .endObject()
+                        .endObject()
+                        .startObject(FILTER)
+                            .startObject(NGRAM_FILTER)
+                                .field(TYPE, "ngram")
+                                .field(MIN_GRAM, contactConfiguration.getMinNgram())
+                                .field(MAX_NGRAM, contactConfiguration.getMaxNgram())
+                            .endObject()
+                            .startObject(EDGE_NGRAM_FILTER)
+                                .field(TYPE, "edge_ngram")
+                                .field(MIN_GRAM, contactConfiguration.getMinNgram())
+                                .field(MAX_NGRAM, contactConfiguration.getMaxNgram())
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject();
+        }
+
+    public XContentBuilder userContactMappingContent() throws IOException {
+        return jsonBuilder()
+            .startObject()
+                    .startObject(PROPERTIES)
+                        .startObject(ACCOUNT_ID)
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(CONTACT_ID)
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(EMAIL)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, EMAIL_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, REBUILT_KEYWORD_ANALYZER)
+                        .endObject()
+                        .startObject(FIRSTNAME)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, NAME_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, STANDARD)
+                        .endObject()
+                        .startObject(SURNAME)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, NAME_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, STANDARD)
+                        .endObject()
+                    .endObject()
+            .endObject();
+    }
+
+    public XContentBuilder domainContactMappingContent() throws IOException {
+        return jsonBuilder()
+            .startObject()
+                    .startObject(PROPERTIES)
+                        .startObject(DOMAIN)
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(CONTACT_ID)
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(EMAIL)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, EMAIL_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, REBUILT_KEYWORD_ANALYZER)
+                        .endObject()
+                        .startObject(FIRSTNAME)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, NAME_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, STANDARD)
+                        .endObject()
+                        .startObject(SURNAME)
+                            .field(TYPE, TEXT)
+                            .field(ANALYZER, NAME_AUTO_COMPLETE_ANALYZER)
+                            .field(SEARCH_ANALYZER, STANDARD)
+                        .endObject()
+                    .endObject()
+            .endObject();
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ES6EmailAddressContactSearchEngine.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ES6EmailAddressContactSearchEngine.java
@@ -1,0 +1,110 @@
+package com.linagora.tmail.james.jmap;
+
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.ACCOUNT_ID;
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.CONTACT_ID;
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.DOMAIN;
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.EMAIL;
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.FIRSTNAME;
+import static com.linagora.tmail.james.jmap.ContactMappingFactory.SURNAME;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.mail.internet.AddressException;
+
+import org.apache.james.backends.es.DocumentId;
+import org.apache.james.backends.es.ElasticSearchIndexer;
+import org.apache.james.backends.es.ReactorElasticSearchClient;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.api.model.AccountId;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.reactivestreams.Publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.james.jmap.contact.ContactFields;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContact;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngine;
+import com.linagora.tmail.james.jmap.dto.DomainContactDocument;
+import com.linagora.tmail.james.jmap.dto.UserContactDocument;
+
+import reactor.core.publisher.Mono;
+
+public class ES6EmailAddressContactSearchEngine implements EmailAddressContactSearchEngine {
+    private static final String DELIMITER = ":";
+
+    private final ElasticSearchIndexer userContactIndexer;
+    private final ElasticSearchIndexer domainContactIndexer;
+    private final ReactorElasticSearchClient client;
+    private final ElasticSearchContactConfiguration configuration;
+    private final ObjectMapper mapper;
+
+    @Inject
+    public ES6EmailAddressContactSearchEngine(ReactorElasticSearchClient client, ElasticSearchContactConfiguration contactConfiguration) {
+        this.client = client;
+        this.userContactIndexer = new ElasticSearchIndexer(client, contactConfiguration.getUserContactWriteAliasName());
+        this.domainContactIndexer = new ElasticSearchIndexer(client, contactConfiguration.getDomainContactWriteAliasName());
+        this.configuration = contactConfiguration;
+        this.mapper = new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+    }
+
+    @Override
+    public Publisher<EmailAddressContact> index(AccountId accountId, ContactFields fields) {
+        EmailAddressContact emailAddressContact = EmailAddressContact.of(fields);
+        return Mono.fromCallable(() -> mapper.writeValueAsString(new UserContactDocument(accountId, emailAddressContact)))
+            .flatMap(content -> userContactIndexer.index(computeUserContactDocumentId(accountId, fields.address()), content,
+                RoutingKey.fromString(fields.address().asString())))
+            .thenReturn(emailAddressContact);
+    }
+
+    @Override
+    public Publisher<EmailAddressContact> index(Domain domain, ContactFields fields) {
+        EmailAddressContact emailAddressContact = EmailAddressContact.of(fields);
+        return Mono.fromCallable(() -> mapper.writeValueAsString(new DomainContactDocument(domain, emailAddressContact)))
+            .flatMap(content -> domainContactIndexer.index(computeDomainContactDocumentId(domain, fields.address()), content,
+                RoutingKey.fromString(fields.address().asString())))
+            .thenReturn(emailAddressContact);
+    }
+
+    @Override
+    public Publisher<EmailAddressContact> autoComplete(AccountId accountId, String part) {
+        SearchRequest request = new SearchRequest(configuration.getUserContactReadAliasName().getValue(), configuration.getDomainContactReadAliasName().getValue())
+            .source(new SearchSourceBuilder()
+                .query(QueryBuilders.boolQuery()
+                    .must(QueryBuilders.multiMatchQuery(part, EMAIL, FIRSTNAME, SURNAME))
+                    .should(QueryBuilders.termQuery(ACCOUNT_ID, accountId.getIdentifier()))
+                    .should(QueryBuilders.termQuery(DOMAIN, Username.of(accountId.getIdentifier()).getDomainPart()
+                        .map(Domain::asString)
+                        .orElse("")))
+                    .minimumShouldMatch(1)));
+
+        return client.search(request, RequestOptions.DEFAULT)
+            .flatMapIterable(searchResponse -> ImmutableList.copyOf(searchResponse.getHits().getHits()))
+            .map(Throwing.function(this::extractContentFromHit).sneakyThrow());
+    }
+
+    private DocumentId computeUserContactDocumentId(AccountId accountId, MailAddress mailAddress) {
+        return DocumentId.fromString(String.join(DELIMITER, accountId.getIdentifier(), mailAddress.asString()));
+    }
+
+    private DocumentId computeDomainContactDocumentId(Domain domain, MailAddress mailAddress) {
+        return DocumentId.fromString(String.join(DELIMITER, domain.asString(), mailAddress.asString()));
+    }
+
+    private EmailAddressContact extractContentFromHit(SearchHit hit) throws AddressException {
+        return new EmailAddressContact(UUID.fromString((String) hit.getSourceAsMap().get(CONTACT_ID)),
+            new ContactFields(new MailAddress(((String) hit.getSourceAsMap().get(EMAIL))),
+                (String) hit.getSourceAsMap().get(FIRSTNAME),
+                (String) hit.getSourceAsMap().get(SURNAME)));
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ElasticSearchContactConfiguration.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/ElasticSearchContactConfiguration.java
@@ -1,0 +1,238 @@
+package com.linagora.tmail.james.jmap;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.james.backends.es.IndexName;
+import org.apache.james.backends.es.ReadAliasName;
+import org.apache.james.backends.es.WriteAliasName;
+
+public class ElasticSearchContactConfiguration {
+
+    public static class Builder {
+        private Optional<IndexName> userContactIndexName;
+        private Optional<IndexName> domainContactIndexName;
+        private Optional<ReadAliasName> userContactReadAliasName;
+        private Optional<WriteAliasName> userContactWriteAliasName;
+        private Optional<ReadAliasName> domainContactReadAliasName;
+        private Optional<WriteAliasName> domainContactWriteAliasName;
+        private Optional<Integer> maxNgram;
+        private Optional<Integer> minNgram;
+
+        Builder() {
+            userContactIndexName = Optional.empty();
+            domainContactIndexName = Optional.empty();
+            userContactReadAliasName = Optional.empty();
+            userContactWriteAliasName = Optional.empty();
+            domainContactReadAliasName = Optional.empty();
+            domainContactWriteAliasName = Optional.empty();
+            maxNgram = Optional.empty();
+            minNgram = Optional.empty();
+        }
+
+        Builder userContactIndexName(Optional<IndexName> userContactIndexName) {
+            this.userContactIndexName = userContactIndexName;
+            return this;
+        }
+
+        Builder domainContactIndexName(Optional<IndexName> domainContactIndexName) {
+            this.domainContactIndexName = domainContactIndexName;
+            return this;
+        }
+
+        Builder userContactReadAliasName(Optional<ReadAliasName> userContactReadAliasName) {
+            this.userContactReadAliasName = userContactReadAliasName;
+            return this;
+        }
+
+        Builder userContactWriteAliasName(Optional<WriteAliasName> userContactWriteAliasName) {
+            this.userContactWriteAliasName = userContactWriteAliasName;
+            return this;
+        }
+
+        Builder domainContactReadAliasName(Optional<ReadAliasName> domainContactReadAliasName) {
+            this.domainContactReadAliasName = domainContactReadAliasName;
+            return this;
+        }
+
+        Builder domainContactWriteAliasName(Optional<WriteAliasName> domainContactWriteAliasName) {
+            this.domainContactWriteAliasName = domainContactWriteAliasName;
+            return this;
+        }
+
+        Builder maxNgram(Optional<Integer> maxNgramDiff) {
+            this.maxNgram = maxNgramDiff;
+            return this;
+        }
+
+        Builder minNgram(Optional<Integer> minNgram) {
+            this.minNgram = minNgram;
+            return this;
+        }
+
+        public ElasticSearchContactConfiguration build() {
+            return new ElasticSearchContactConfiguration(
+                userContactIndexName.orElse(DEFAULT_INDEX_USER_CONTACT_NAME),
+                domainContactIndexName.orElse(DEFAULT_INDEX_DOMAIN_CONTACT_NAME),
+                userContactReadAliasName.orElse(DEFAULT_ALIAS_READ_USER_CONTACT_NAME),
+                userContactWriteAliasName.orElse(DEFAULT_ALIAS_WRITE_USER_CONTACT_NAME),
+                domainContactReadAliasName.orElse(DEFAULT_ALIAS_READ_DOMAIN_CONTACT_NAME),
+                domainContactWriteAliasName.orElse(DEFAULT_ALIAS_WRITE_DOMAIN_CONTACT_NAME),
+                maxNgram.orElse(DEFAULT_MAX_NGRAM),
+                minNgram.orElse(DEFAULT_MIN_NGRAM));
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static final String ELASTICSEARCH_INDEX_USER_CONTACT_NAME = "elasticsearch.index.contact.user.name";
+    private static final String ELASTICSEARCH_INDEX_DOMAIN_CONTACT_NAME = "elasticsearch.index.contact.domain.name";
+    private static final String ELASTICSEARCH_ALIAS_READ_USER_CONTACT_NAME = "elasticsearch.alias.read.contact.user.name";
+    private static final String ELASTICSEARCH_ALIAS_WRITE_USER_CONTACT_NAME = "elasticsearch.alias.write.contact.user.name";
+    private static final String ELASTICSEARCH_ALIAS_READ_DOMAIN_CONTACT_NAME = "elasticsearch.alias.read.contact.domain.name";
+    private static final String ELASTICSEARCH_ALIAS_WRITE_DOMAIN_CONTACT_NAME = "elasticsearch.alias.write.contact.domain.name";
+    private static final String ELASTICSEARCH_INDEX_CONTACT_MAX_NGRAM = "elasticsearch.index.contact.max.ngram";
+    private static final String ELASTICSEARCH_INDEX_CONTACT_MIN_NGRAM = "elasticsearch.index.contact.min.ngram";
+
+    public static final IndexName DEFAULT_INDEX_USER_CONTACT_NAME = new IndexName("user_contact");
+    public static final IndexName DEFAULT_INDEX_DOMAIN_CONTACT_NAME = new IndexName("domain_contact");
+    public static final WriteAliasName DEFAULT_ALIAS_WRITE_USER_CONTACT_NAME = new WriteAliasName("user_contact_write_alias");
+    public static final ReadAliasName DEFAULT_ALIAS_READ_USER_CONTACT_NAME = new ReadAliasName("user_contact_read_alias");
+    public static final WriteAliasName DEFAULT_ALIAS_WRITE_DOMAIN_CONTACT_NAME = new WriteAliasName("domain_contact_write_alias");
+    public static final ReadAliasName DEFAULT_ALIAS_READ_DOMAIN_CONTACT_NAME = new ReadAliasName("domain_contact_read_alias");
+    public static final Integer DEFAULT_MAX_NGRAM = 30;
+    public static final Integer DEFAULT_MIN_NGRAM = 3;
+
+    public static final ElasticSearchContactConfiguration DEFAULT_CONFIGURATION = builder().build();
+
+    public static ElasticSearchContactConfiguration fromProperties(Configuration configuration) {
+        return builder()
+            .userContactIndexName(computeUserContactIndexName(configuration))
+            .domainContactIndexName(computeDomainContactIndexName(configuration))
+            .userContactReadAliasName(computeUserContactReadAlias(configuration))
+            .userContactWriteAliasName(computeUserContactWriteAlias(configuration))
+            .domainContactReadAliasName(computeDomainContactReadAlias(configuration))
+            .domainContactWriteAliasName(computeDomainContactWriteAlias(configuration))
+            .maxNgram(computeMaxNgram(configuration))
+            .minNgram(computeMinNgram(configuration))
+            .build();
+    }
+
+    static Optional<IndexName> computeUserContactIndexName(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_INDEX_USER_CONTACT_NAME))
+                .map(IndexName::new);
+    }
+
+    static Optional<IndexName> computeDomainContactIndexName(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_INDEX_DOMAIN_CONTACT_NAME))
+            .map(IndexName::new);
+    }
+
+    static Optional<WriteAliasName> computeUserContactWriteAlias(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_WRITE_USER_CONTACT_NAME))
+                .map(WriteAliasName::new);
+    }
+
+    static Optional<ReadAliasName> computeUserContactReadAlias(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_READ_USER_CONTACT_NAME))
+                .map(ReadAliasName::new);
+    }
+
+    static Optional<WriteAliasName> computeDomainContactWriteAlias(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_WRITE_DOMAIN_CONTACT_NAME))
+            .map(WriteAliasName::new);
+    }
+
+    static Optional<ReadAliasName> computeDomainContactReadAlias(Configuration configuration) {
+        return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_READ_DOMAIN_CONTACT_NAME))
+            .map(ReadAliasName::new);
+    }
+
+    static Optional<Integer> computeMaxNgram(Configuration configuration) {
+        return Optional.ofNullable(configuration.getInteger(ELASTICSEARCH_INDEX_CONTACT_MAX_NGRAM, null));
+    }
+
+    static Optional<Integer> computeMinNgram(Configuration configuration) {
+        return Optional.ofNullable(configuration.getInteger(ELASTICSEARCH_INDEX_CONTACT_MIN_NGRAM, null));
+    }
+
+    private final IndexName userContactIndexName;
+    private final IndexName domainContactIndexName;
+    private final ReadAliasName userContactReadAliasName;
+    private final WriteAliasName userContactWriteAliasName;
+    private final ReadAliasName domainContactReadAliasName;
+    private final WriteAliasName domainContactWriteAliasName;
+    private final int maxNgram;
+    private final int minNgram;
+
+    private ElasticSearchContactConfiguration(IndexName userContactIndexName, IndexName domainContactIndexName, ReadAliasName userContactReadAliasName,
+                                              WriteAliasName userContactWriteAliasName, ReadAliasName domainContactReadAliasName, WriteAliasName domainContactWriteAliasName,
+                                              int maxNgram, int minNgram) {
+        this.userContactIndexName = userContactIndexName;
+        this.domainContactIndexName = domainContactIndexName;
+        this.userContactReadAliasName = userContactReadAliasName;
+        this.userContactWriteAliasName = userContactWriteAliasName;
+        this.domainContactReadAliasName = domainContactReadAliasName;
+        this.domainContactWriteAliasName = domainContactWriteAliasName;
+        this.maxNgram = maxNgram;
+        this.minNgram = minNgram;
+    }
+
+    public IndexName getUserContactIndexName() {
+        return userContactIndexName;
+    }
+
+    public IndexName getDomainContactIndexName() {
+        return domainContactIndexName;
+    }
+
+    public ReadAliasName getUserContactReadAliasName() {
+        return userContactReadAliasName;
+    }
+
+    public WriteAliasName getUserContactWriteAliasName() {
+        return userContactWriteAliasName;
+    }
+
+    public ReadAliasName getDomainContactReadAliasName() {
+        return domainContactReadAliasName;
+    }
+
+    public WriteAliasName getDomainContactWriteAliasName() {
+        return domainContactWriteAliasName;
+    }
+
+    public int getMaxNgram() {
+        return maxNgram;
+    }
+
+    public int getMinNgram() {
+        return minNgram;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof ElasticSearchContactConfiguration) {
+            ElasticSearchContactConfiguration that = (ElasticSearchContactConfiguration) o;
+
+            return Objects.equals(this.userContactIndexName, that.userContactIndexName)
+                && Objects.equals(this.domainContactIndexName, that.domainContactIndexName)
+                && Objects.equals(this.userContactReadAliasName, that.userContactReadAliasName)
+                && Objects.equals(this.userContactWriteAliasName, that.userContactWriteAliasName)
+                && Objects.equals(this.domainContactReadAliasName, that.domainContactReadAliasName)
+                && Objects.equals(this.domainContactWriteAliasName, that.domainContactWriteAliasName)
+                && Objects.equals(this.maxNgram, that.maxNgram)
+                && Objects.equals(this.minNgram, that.minNgram);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(userContactIndexName, domainContactIndexName, userContactReadAliasName, userContactWriteAliasName,
+            domainContactReadAliasName, domainContactWriteAliasName, maxNgram, minNgram);
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/dto/DomainContactDocument.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/dto/DomainContactDocument.java
@@ -1,0 +1,49 @@
+package com.linagora.tmail.james.jmap.dto;
+
+import java.util.UUID;
+
+import org.apache.james.core.Domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContact;
+
+public class DomainContactDocument {
+    private final String domain;
+    private final UUID contactId;
+    private final String email;
+    private final String firstname;
+    private final String surname;
+
+    public DomainContactDocument(Domain domain, EmailAddressContact contact) {
+        this.domain = domain.asString();
+        this.contactId = contact.id();
+        this.email = contact.fields().address().asString();
+        this.firstname = contact.fields().firstname();
+        this.surname = contact.fields().surname();
+    }
+
+    @JsonProperty("domain")
+    public String getDomain() {
+        return domain;
+    }
+
+    @JsonProperty("contactId")
+    public UUID getContactId() {
+        return contactId;
+    }
+
+    @JsonProperty("email")
+    public String getEmail() {
+        return email;
+    }
+
+    @JsonProperty("firstname")
+    public String getFirstname() {
+        return firstname;
+    }
+
+    @JsonProperty("surname")
+    public String getSurname() {
+        return surname;
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/dto/UserContactDocument.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/dto/UserContactDocument.java
@@ -1,0 +1,49 @@
+package com.linagora.tmail.james.jmap.dto;
+
+import java.util.UUID;
+
+import org.apache.james.jmap.api.model.AccountId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContact;
+
+public class UserContactDocument {
+    private final String accountId;
+    private final UUID contactId;
+    private final String email;
+    private final String firstname;
+    private final String surname;
+
+    public UserContactDocument(AccountId accountId, EmailAddressContact contact) {
+        this.accountId = accountId.getIdentifier();
+        this.contactId = contact.id();
+        this.email = contact.fields().address().asString();
+        this.firstname = contact.fields().firstname();
+        this.surname = contact.fields().surname();
+    }
+
+    @JsonProperty("accountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    @JsonProperty("contactId")
+    public UUID getContactId() {
+        return contactId;
+    }
+
+    @JsonProperty("email")
+    public String getEmail() {
+        return email;
+    }
+
+    @JsonProperty("firstname")
+    public String getFirstname() {
+        return firstname;
+    }
+
+    @JsonProperty("surname")
+    public String getSurname() {
+        return surname;
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/module/ContactIndexCreationUtil.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/module/ContactIndexCreationUtil.java
@@ -1,0 +1,32 @@
+package com.linagora.tmail.james.jmap.module;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.james.backends.es.ElasticSearchConfiguration;
+import org.apache.james.backends.es.IndexCreationFactory;
+import org.apache.james.backends.es.ReactorElasticSearchClient;
+
+import com.linagora.tmail.james.jmap.ContactMappingFactory;
+import com.linagora.tmail.james.jmap.ElasticSearchContactConfiguration;
+
+public class ContactIndexCreationUtil {
+    public static void createIndices(ReactorElasticSearchClient client,
+                                     ElasticSearchConfiguration elasticSearchConfiguration,
+                                     ElasticSearchContactConfiguration contactConfiguration) throws IOException {
+        ContactMappingFactory contactMappingFactory = new ContactMappingFactory(elasticSearchConfiguration, contactConfiguration);
+        new IndexCreationFactory(elasticSearchConfiguration)
+            .useIndex(contactConfiguration.getUserContactIndexName())
+            .addAlias(contactConfiguration.getUserContactReadAliasName())
+            .addAlias(contactConfiguration.getUserContactWriteAliasName())
+            .createIndexAndAliases(client, Optional.of(contactMappingFactory.generalContactIndicesSetting()),
+                Optional.of(contactMappingFactory.userContactMappingContent()));
+
+        new IndexCreationFactory(elasticSearchConfiguration)
+            .useIndex(contactConfiguration.getDomainContactIndexName())
+            .addAlias(contactConfiguration.getDomainContactReadAliasName())
+            .addAlias(contactConfiguration.getDomainContactWriteAliasName())
+            .createIndexAndAliases(client, Optional.of(contactMappingFactory.generalContactIndicesSetting()),
+                Optional.of(contactMappingFactory.domainContactMappingContent()));
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/module/ES6ContactAutoCompleteModule.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/main/java/com/linagora/tmail/james/jmap/module/ES6ContactAutoCompleteModule.java
@@ -1,0 +1,78 @@
+package com.linagora.tmail.james.jmap.module;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.backends.es.ElasticSearchConfiguration;
+import org.apache.james.backends.es.ReactorElasticSearchClient;
+import org.apache.james.lifecycle.api.Startable;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.linagora.tmail.james.jmap.ES6EmailAddressContactSearchEngine;
+import com.linagora.tmail.james.jmap.ElasticSearchContactConfiguration;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngine;
+
+public class ES6ContactAutoCompleteModule extends AbstractModule {
+    public static final String ELASTICSEARCH_CONFIGURATION_NAME = "elasticsearch";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ES6ContactAutoCompleteModule.class);
+
+    static class ContactIndexCreator implements Startable {
+
+        private final ElasticSearchConfiguration elasticSearchConfiguration;
+        private final ElasticSearchContactConfiguration contactConfiguration;
+        private final ReactorElasticSearchClient client;
+
+        @Inject
+        ContactIndexCreator(ElasticSearchConfiguration configuration,
+                            ElasticSearchContactConfiguration contactConfiguration,
+                            ReactorElasticSearchClient client) {
+            this.elasticSearchConfiguration = configuration;
+            this.contactConfiguration = contactConfiguration;
+            this.client = client;
+        }
+
+        void createIndex() throws IOException {
+            ContactIndexCreationUtil.createIndices(client, elasticSearchConfiguration, contactConfiguration);
+        }
+    }
+
+    @Override
+    protected void configure() {
+        bind(ES6EmailAddressContactSearchEngine.class).in(Scopes.SINGLETON);
+
+        bind(EmailAddressContactSearchEngine.class).to(ES6EmailAddressContactSearchEngine.class);
+    }
+
+    @Provides
+    @Singleton
+    private ElasticSearchContactConfiguration getElasticSearchContactConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            Configuration configuration = propertiesProvider.getConfiguration(ELASTICSEARCH_CONFIGURATION_NAME);
+            return ElasticSearchContactConfiguration.fromProperties(configuration);
+        } catch (FileNotFoundException e) {
+            LOGGER.warn("Could not find " + ELASTICSEARCH_CONFIGURATION_NAME + " configuration file. Using default contact configuration");
+            return ElasticSearchContactConfiguration.DEFAULT_CONFIGURATION;
+        }
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation createIndex(ContactIndexCreator instance) {
+        return InitilizationOperationBuilder
+            .forClass(ContactIndexCreator.class)
+            .init(instance::createIndex);
+    }
+}

--- a/tmail-backend/jmap/extensions-es-v6/src/test/java/com/linagora/tmail/james/jmap/model/ES6EmailAddressContactAutoCompleteTest.java
+++ b/tmail-backend/jmap/extensions-es-v6/src/test/java/com/linagora/tmail/james/jmap/model/ES6EmailAddressContactAutoCompleteTest.java
@@ -1,0 +1,83 @@
+package com.linagora.tmail.james.jmap.model;
+
+import static com.linagora.tmail.james.jmap.ElasticSearchContactConfiguration.DEFAULT_CONFIGURATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.james.backends.es.DockerElasticSearchExtension;
+import org.apache.james.backends.es.ElasticSearchConfiguration;
+import org.apache.james.backends.es.IndexCreationFactory;
+import org.apache.james.backends.es.ReactorElasticSearchClient;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.awaitility.core.ConditionFactory;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.james.jmap.ContactMappingFactory;
+import com.linagora.tmail.james.jmap.ES6EmailAddressContactSearchEngine;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngine;
+import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngineContract;
+
+public class ES6EmailAddressContactAutoCompleteTest implements EmailAddressContactSearchEngineContract {
+    private static final ConditionFactory CALMLY_AWAIT = Awaitility
+        .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
+        .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
+        .await();
+
+    @RegisterExtension
+    public final DockerElasticSearchExtension elasticSearch = new DockerElasticSearchExtension();
+
+    ReactorElasticSearchClient client;
+    ES6EmailAddressContactSearchEngine searchEngine;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ContactMappingFactory contactMappingFactory = new ContactMappingFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION, DEFAULT_CONFIGURATION);
+        client = elasticSearch.getDockerElasticSearch().clientProvider().get();
+
+        createUserContactIndex(client, contactMappingFactory);
+        createDomainContactIndex(client, contactMappingFactory);
+
+        searchEngine = new ES6EmailAddressContactSearchEngine(client, DEFAULT_CONFIGURATION);
+    }
+
+    @Override
+    public EmailAddressContactSearchEngine testee() {
+        return searchEngine;
+    }
+
+    @Override
+    public void awaitDocumentsIndexed(long documentCount) {
+        CALMLY_AWAIT.atMost(Durations.TEN_SECONDS)
+            .untilAsserted(() -> assertThat(client.search(
+                    new SearchRequest(DEFAULT_CONFIGURATION.getUserContactIndexName().getValue(), DEFAULT_CONFIGURATION.getDomainContactIndexName().getValue())
+                        .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
+                    RequestOptions.DEFAULT)
+                .block()
+                .getHits().getTotalHits()).isEqualTo(documentCount));
+    }
+
+    private ReactorElasticSearchClient createUserContactIndex(ReactorElasticSearchClient client, ContactMappingFactory contactMappingFactory) throws IOException {
+        return new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
+            .useIndex(DEFAULT_CONFIGURATION.getUserContactIndexName())
+            .addAlias(DEFAULT_CONFIGURATION.getUserContactReadAliasName())
+            .addAlias(DEFAULT_CONFIGURATION.getUserContactWriteAliasName())
+            .createIndexAndAliases(client, Optional.of(contactMappingFactory.generalContactIndicesSetting()), Optional.of(contactMappingFactory.userContactMappingContent()));
+    }
+
+    private ReactorElasticSearchClient createDomainContactIndex(ReactorElasticSearchClient client, ContactMappingFactory contactMappingFactory) throws IOException {
+        return new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
+            .useIndex(DEFAULT_CONFIGURATION.getDomainContactIndexName())
+            .addAlias(DEFAULT_CONFIGURATION.getDomainContactReadAliasName())
+            .addAlias(DEFAULT_CONFIGURATION.getDomainContactWriteAliasName())
+            .createIndexAndAliases(client, Optional.of(contactMappingFactory.generalContactIndicesSetting()), Optional.of(contactMappingFactory.domainContactMappingContent()));
+    }
+}

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -46,6 +46,7 @@
 
         <module>jmap/extensions</module>
         <module>jmap/extensions-cassandra</module>
+        <module>jmap/extensions-es-v6</module>
         <module>jmap/extensions-es-v7</module>
 
         <module>rate-limiter/rate-limiter-api</module>
@@ -171,6 +172,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jmap-extensions-cassandra</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jmap-extensions-es-v6</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
With ES6, we don't have to specify `max.diff.ngram` anymore.