### PR TITLE
ISSUE-367: Avoid duplicated Test if a domain exists route's path

### DIFF
--- a/tmail-backend/webadmin/webadmin-email-address-contact/src/main/java/com/linagora/tmail/webadmin/EmailAddressContactRoutes.java
+++ b/tmail-backend/webadmin/webadmin-email-address-contact/src/main/java/com/linagora/tmail/webadmin/EmailAddressContactRoutes.java
@@ -35,7 +35,7 @@ public class EmailAddressContactRoutes implements Routes {
     private static final String CONTACT_DOMAIN_PARAM = ":dom";
     private static final String CONTACT_ADDRESS_PARAM = ":address";
 
-    private static final String ALL_DOMAINS_PATH = Constants.SEPARATOR + "domains" + Constants.SEPARATOR + "contacts";
+    private static final String ALL_DOMAINS_PATH = Constants.SEPARATOR + "domains" + Constants.SEPARATOR + "contacts" + Constants.SEPARATOR + "all";
     private static final String BASE_PATH = Constants.SEPARATOR + "domains" + Constants.SEPARATOR + CONTACT_DOMAIN_PARAM + Constants.SEPARATOR + "contacts";
     private static final String CRUD_PATH = BASE_PATH + Constants.SEPARATOR + CONTACT_ADDRESS_PARAM;
 

--- a/tmail-backend/webadmin/webadmin-email-address-contact/src/test/java/com/linagora/tmail/webadmin/EmailAddressContactRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-email-address-contact/src/test/java/com/linagora/tmail/webadmin/EmailAddressContactRoutesTest.java
@@ -44,7 +44,7 @@ import reactor.core.publisher.Mono;
 
 class EmailAddressContactRoutesTest {
     private static final String DOMAINS_CONTACTS_PATH = "/domains/%s/contacts";
-    private static final String ALL_DOMAINS_PATH = "/domains/contacts";
+    private static final String ALL_DOMAINS_PATH = "/domains/contacts/all";
     private static final Domain CONTACT_DOMAIN = Domain.of("contact.com");
 
     private static final String mailAddressA = "john@" + CONTACT_DOMAIN.asString();


### PR DESCRIPTION
GET ALL contact route's path is duplicated with a James domain route's path.

GET https://james-admin.upn.integration-open-paas.org/domains/contacts
```json
{
    "statusCode": 404,
    "type": "InvalidArgument",
    "message": "The domain list does not contain: contacts",
    "details": null
}
```

Test if a domain exists route's path: GET http://ip:port/domains/{domainName}