### PR TITLE
Avoid Google jib create draft images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,11 @@ pipeline {
 
               echo "Docker tag: ${env.DOCKER_TAG}"
 
+              // Load docker from tar file
+              sh "docker load -i tmail-backend/apps/distributed/target/jib-image.tar"
+              sh "docker load -i tmail-backend/apps/distributed-es6-backport/target/jib-image.tar"
+              sh "docker load -i tmail-backend/apps/memory/target/jib-image.tar"
+
               // Temporary retag image names
               sh "docker tag linagora/tmail-backend-memory linagora/tmail-backend:memory-${env.DOCKER_TAG}"
               sh "docker tag linagora/tmail-backend-distributed linagora/tmail-backend:distributed-${env.DOCKER_TAG}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,11 +27,6 @@ pipeline {
                     sh 'mvn -B surefire:test'
                 }
             }
-            post {
-                always {
-                    deleteDir() /* clean up our workspace */
-                }
-            }
         }
         stage('Deliver Docker images') {
           when {
@@ -50,9 +45,9 @@ pipeline {
               echo "Docker tag: ${env.DOCKER_TAG}"
 
               // Load docker from tar file
-              sh "docker load -i tmail-backend/apps/distributed/target/jib-image.tar"
-              sh "docker load -i tmail-backend/apps/distributed-es6-backport/target/jib-image.tar"
-              sh "docker load -i tmail-backend/apps/memory/target/jib-image.tar"
+              sh "docker load -i apps/distributed/target/jib-image.tar"
+              sh "docker load -i apps/distributed-es6-backport/target/jib-image.tar"
+              sh "docker load -i apps/memory/target/jib-image.tar"
 
               // Temporary retag image names
               sh "docker tag linagora/tmail-backend-memory linagora/tmail-backend:memory-${env.DOCKER_TAG}"
@@ -71,6 +66,7 @@ pipeline {
           }
           post {
               always {
+                  deleteDir() /* clean up our workspace */
                   script {
                       if (env.BRANCH_NAME == "master") {
                           emailext(

--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -397,7 +397,7 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>dockerBuild</goal>
+                            <goal>buildTar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -397,7 +397,7 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>dockerBuild</goal>
+                            <goal>buildTar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -217,7 +217,7 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>dockerBuild</goal>
+                            <goal>buildTar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/tmail-backend/deployment-tests/distributed-es6-backport/src/test/java/com/linagora/tmail/deployment/TmailDistributedEs6Extension.java
+++ b/tmail-backend/deployment-tests/distributed-es6-backport/src/test/java/com/linagora/tmail/deployment/TmailDistributedEs6Extension.java
@@ -6,6 +6,10 @@ import static com.linagora.tmail.deployment.ThirdPartyContainers.createElasticse
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
@@ -51,7 +55,11 @@ public class TmailDistributedEs6Extension implements BeforeEachCallback, AfterEa
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed-es6-backport").toString(),
+            Paths.get("tmail-backend", "apps", "distributed-es6-backport", "target", "jib-image.tar").toString());
+        james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
+
         Runnables.runParallel(
             cassandra::start,
             elasticsearch::start,

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
@@ -6,6 +6,10 @@ import static com.linagora.tmail.deployment.ThirdPartyContainers.createElasticse
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
@@ -69,7 +73,11 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed").toString(),
+            Paths.get("tmail-backend", "apps", "distributed", "target", "jib-image.tar").toString());
+        james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
+
         Runnables.runParallel(
             cassandra::start,
             elasticsearch::start,

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
@@ -74,7 +74,7 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws IOException {
-        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed").toString(),
+        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed-ldap").toString(),
             Paths.get("tmail-backend", "apps", "distributed", "target", "jib-image.tar").toString());
         james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
 

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
@@ -6,6 +6,10 @@ import static com.linagora.tmail.deployment.ThirdPartyContainers.createElasticse
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
@@ -50,7 +54,11 @@ public class TmailDistributedExtension implements BeforeEachCallback, AfterEachC
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed").toString(),
+            Paths.get("tmail-backend", "apps", "distributed", "target", "jib-image.tar").toString());
+        james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
+
         Runnables.runParallel(
             cassandra::start,
             elasticsearch::start,

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
@@ -1,5 +1,9 @@
 package com.linagora.tmail.deployment;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
@@ -21,7 +25,10 @@ public class TmailMemoryExtension implements BeforeEachCallback, AfterEachCallba
         .withExposedPorts(25, 143, 80);
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+        String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "memory").toString(),
+            Paths.get("tmail-backend", "apps", "memory", "target", "jib-image.tar").toString());
+        container.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
         container.start();
     }
 


### PR DESCRIPTION
When JIB dockerBuild, it created two images: one in it is a draft, and never be removed. (`none` image, no any tag)
By buildTar mode, the image will be saved as a tar file, then we can lazy load it.

Draft images example: 
![image](https://user-images.githubusercontent.com/81145350/176154543-e49b2131-435f-4194-ba41-aece4634932e.png)
