### PR TITLE
[REFACTORING] Remove the binding on the Rspamd listener

### DIFF
--- a/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/rspamd/RspamdModule.java
+++ b/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/rspamd/RspamdModule.java
@@ -7,11 +7,9 @@ import java.time.Clock;
 import java.util.Optional;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.events.EventListener;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.rspamd.RspamdListener;
 import org.apache.james.rspamd.client.RspamdClientConfiguration;
 import org.apache.james.rspamd.client.RspamdHttpClient;
 import org.apache.james.rspamd.route.FeedMessageRoute;
@@ -44,10 +42,6 @@ public class RspamdModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
-            .addBinding()
-            .to(RspamdListener.class);
-
         Multibinder.newSetBinder(binder(), Routes.class)
             .addBinding()
             .to(FeedMessageRoute.class);

--- a/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/resources/listeners.xml
+++ b/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/resources/listeners.xml
@@ -6,4 +6,8 @@
     <class>org.apache.james.jmap.event.PopulateEmailQueryViewListener</class>
     <async>true</async>
   </listener>
+  <listener>
+    <class>org.apache.james.rspamd.RspamdListener</class>
+    <async>true</async>
+  </listener>
 </listeners>

--- a/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/resources/mailetcontainer.xml
+++ b/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/resources/mailetcontainer.xml
@@ -64,4 +64,10 @@
             </mailet>
         </processor>
     </processors>
+
+    <processor state="virus" enableJmx="false">
+        <mailet match="All" class="ToRepository">
+            <repositoryPath>cassandra://var/mail/virus/</repositoryPath>
+        </mailet>
+    </processor>
 </mailetcontainer>


### PR DESCRIPTION
In case we are deploying TMail without rspamd, the listener will keep trying to connect to Rspamd for any mail activity which results in a lot of errors messages in logs.

It's still possible to add the listener via listeners.xml file