### PR TITLE
[POC] JIB avoid using root as user

### DIFF
--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -234,24 +234,43 @@
                     <container>
                         <mainClass>com.linagora.tmail.james.app.MemoryServer</mainClass>
                         <ports>
-                            <port>80</port> <!-- JMAP -->
-                            <port>143</port> <!-- IMAP -->
-                            <port>993</port> <!-- IMAPS -->
-                            <port>25</port> <!-- SMTP -->
-                            <port>465</port> <!-- SMTP + STARTTLS -->
-                            <port>587</port> <!-- SMTPS -->
+                            <port>8080</port> <!-- JMAP -->
+                            <port>30143</port> <!-- IMAP -->
+                            <port>30993</port> <!-- IMAPS -->
+                            <port>3025</port> <!-- SMTP -->
+                            <port>30465</port> <!-- SMTP + STARTTLS -->
+                            <port>30587</port> <!-- SMTPS -->
                             <port>4000</port> <!-- GLOWROOT, if activated -->
                             <port>4190</port> <!-- ManageSieve, if activated -->
                             <port>8000</port> <!-- WEBADMIN -->
                         </ports>
-                        <appRoot>/root</appRoot>
+                        <appRoot>/home/nobody</appRoot>
+                        <jvmFlags>
+                            <jvmFlag>-Dlogback.configurationFile=/home/nobody/conf/logback.xml</jvmFlag>
+                            <jvmFlag>-Dworking.directory=/home/nobody/</jvmFlag>
+                            <!-- Prevents Logjam (CVE-2015-4000) -->
+                            <jvmFlag>-Djdk.tls.ephemeralDHKeySize=2048</jvmFlag>
+                        </jvmFlags>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                        <volumes>
+                            <volume>/home/nobody/logs</volume>
+                            <volume>/home/nobody/conf</volume>
+                            <volume>/home/nobody/sieve</volume>
+                            <volume>/home/nobody/glowroot/plugins</volume>
+                            <volume>/home/nobody/glowroot/data</volume>
+                            <volume>/home/nobody/extensions-jars</volume>
+                        </volumes>
+                        <user>nobody</user>
                     </container>
                     <extraDirectories>
                         <paths>
                             <path>
                                 <from>src/main/conf</from>
-                                <into>/root/conf</into>
+                                <into>/home/nobody/conf</into>
+                            </path>
+                            <path>
+                                <from>src/main/logs</from>
+                                <into>/home/nobody/logs</into>
                             </path>
                             <path>
                                 <from>src/main/scripts</from>
@@ -259,19 +278,19 @@
                             </path>
                             <path>
                                 <from>target/glowroot</from>
-                                <into>/root/glowroot</into>
+                                <into>/home/nobody/glowroot</into>
                             </path>
                             <path>
                                 <from>target/async-profiler-2.7-linux-x64</from>
-                                <into>/root/async-profiler</into>
+                                <into>/home/nobody/async-profiler</into>
                             </path>
                             <path>
                                 <from>src/main/extensions-jars</from>
-                                <into>/root/extensions-jars</into>
+                                <into>/home/nobody/extensions-jars</into>
                             </path>
                             <path>
                                 <from>src/main/provisioning</from>
-                                <into>/root/provisioning</into>
+                                <into>/home/nobody/provisioning</into>
                             </path>
                         </paths>
                         <permissions>
@@ -280,19 +299,23 @@
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                             <permission>
-                                <file>/root/async-profiler/profiler.sh</file>
+                                <file>/home/nobody/logs/james.log</file>
+                                <mode>777</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                            </permission>
+                            <permission>
+                                <file>/home/nobody/async-profiler/profiler.sh</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                             <permission>
-                                <file>/root/async-profiler/build/libasyncProfiler.so</file>
+                                <file>/home/nobody/async-profiler/build/libasyncProfiler.so</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                             <permission>
-                                <file>/root/async-profiler/build/jattach</file>
+                                <file>/home/nobody/async-profiler/build/jattach</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                             <permission>
-                                <file>/root/provisioning/provisioning.sh</file>
+                                <file>/home/nobody/provisioning/provisioning.sh</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                         </permissions>

--- a/tmail-backend/apps/memory/src/main/conf/imapserver.xml
+++ b/tmail-backend/apps/memory/src/main/conf/imapserver.xml
@@ -23,7 +23,7 @@ under the License.
 <imapservers>
     <imapserver enabled="true">
         <jmxName>imapserver</jmxName>
-        <bind>0.0.0.0:143</bind>
+        <bind>0.0.0.0:30143</bind>
         <connectionBacklog>200</connectionBacklog>
         <tls socketTLS="false" startTLS="true">
             <!-- To create a new keystore execute:
@@ -42,7 +42,7 @@ under the License.
     </imapserver>
     <imapserver enabled="true">
         <jmxName>imapserver-ssl</jmxName>
-        <bind>0.0.0.0:993</bind>
+        <bind>0.0.0.0:30993</bind>
         <connectionBacklog>200</connectionBacklog>
         <tls socketTLS="true" startTLS="false">
             <!-- To create a new keystore execute:

--- a/tmail-backend/apps/memory/src/main/conf/jmap.properties
+++ b/tmail-backend/apps/memory/src/main/conf/jmap.properties
@@ -3,6 +3,8 @@
 
 enabled=true
 
+jmap.port=8080
+
 tls.keystoreURL=file://conf/keystore
 tls.secret=james72laBalle
 

--- a/tmail-backend/apps/memory/src/main/conf/logback.xml
+++ b/tmail-backend/apps/memory/src/main/conf/logback.xml
@@ -31,9 +31,9 @@
         </appender>
 
         <appender name="LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                <file>/logs/james.log</file>
+                <file>/home/nobody/logs/james.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-                    <fileNamePattern>/logs/james.%i.log.tar.gz</fileNamePattern>
+                    <fileNamePattern>/home/nobody/logs/james.%i.log.tar.gz</fileNamePattern>
                     <minIndex>1</minIndex>
                     <maxIndex>3</maxIndex>
                 </rollingPolicy>

--- a/tmail-backend/apps/memory/src/main/conf/smtpserver.xml
+++ b/tmail-backend/apps/memory/src/main/conf/smtpserver.xml
@@ -23,7 +23,7 @@
 <smtpservers>
     <smtpserver enabled="true">
         <jmxName>smtpserver-global</jmxName>
-        <bind>0.0.0.0:25</bind>
+        <bind>0.0.0.0:3025</bind>
         <connectionBacklog>200</connectionBacklog>
         <tls socketTLS="false" startTLS="false">
             <keystore>file://conf/keystore</keystore>
@@ -47,7 +47,7 @@
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-TLS</jmxName>
-        <bind>0.0.0.0:465</bind>
+        <bind>0.0.0.0:30465</bind>
         <connectionBacklog>200</connectionBacklog>
         <tls socketTLS="true" startTLS="false">
             <keystore>file://conf/keystore</keystore>
@@ -75,7 +75,7 @@
     </smtpserver>
     <smtpserver enabled="true">
         <jmxName>smtpserver-authenticated</jmxName>
-        <bind>0.0.0.0:587</bind>
+        <bind>0.0.0.0:30587</bind>
         <connectionBacklog>200</connectionBacklog>
         <tls socketTLS="false" startTLS="true">
             <keystore>file://conf/keystore</keystore>


### PR DESCRIPTION
Just a POC to try with JIB running as  a non root user...

A bit of a pain IMO, JIB is not really thought for that obviously. They seem to want to push mainly the responsibility to the base docker image that should create that non root user, assign it to a group and assign his working directory to it.

This it TMail memory with a `nobody` user... It runs... but I had to:

- change most ports (non root user can't use privileged ports like 25, 143, 80, ...)
- mount a bs empty file for logs and then put a 777 permission on it (because all the folders and files still belong to root user... so no choice if you want to write. Note that it is an issue for log rotation saves though)
- as said above no folder belongs to that nobody user...