### PR TITLE
ISSUE-579 Deployment issue with distributed-esv6 version

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -26,6 +26,7 @@ import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
+import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
 import org.apache.james.modules.data.CassandraJmapModule;
 import org.apache.james.modules.data.CassandraRecipientRewriteTableModule;
@@ -210,7 +211,8 @@ public class DistributedServer {
         new CassandraSessionModule(),
         new CassandraSieveRepositoryModule(),
         BLOB_MODULE,
-        CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE);
+        CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE,
+        new CassandraDelegationStoreModule());
 
     public static final Module CASSANDRA_MAILBOX_MODULE = Modules.combine(
         new CassandraConsistencyTaskSerializationModule(),

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -26,6 +26,7 @@ import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.MailboxModule;
 import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.data.CassandraDLPConfigurationStoreModule;
+import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraDomainListModule;
 import org.apache.james.modules.data.CassandraJmapModule;
 import org.apache.james.modules.data.CassandraRecipientRewriteTableModule;
@@ -210,7 +211,8 @@ public class DistributedServer {
         new CassandraSessionModule(),
         new CassandraSieveRepositoryModule(),
         BLOB_MODULE,
-        CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE);
+        CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE,
+        new CassandraDelegationStoreModule());
 
     public static final Module CASSANDRA_MAILBOX_MODULE = Modules.combine(
         new CassandraConsistencyTaskSerializationModule(),

--- a/tmail-backend/combined-identity/src/main/java/com/linagora/tmail/combined/identity/CombinedUsersRepositoryModule.java
+++ b/tmail-backend/combined-identity/src/main/java/com/linagora/tmail/combined/identity/CombinedUsersRepositoryModule.java
@@ -1,16 +1,8 @@
 package com.linagora.tmail.combined.identity;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.adapter.mailbox.DelegationStoreAuthorizator;
-import org.apache.james.backends.cassandra.components.CassandraModule;
-import org.apache.james.mailbox.Authorizator;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
-import org.apache.james.user.api.DelegationStore;
 import org.apache.james.user.api.UsersRepository;
-import org.apache.james.user.cassandra.CassandraDelegationStore;
-import org.apache.james.user.cassandra.CassandraRepositoryConfiguration;
-import org.apache.james.user.cassandra.CassandraUsersDAO;
-import org.apache.james.user.cassandra.CassandraUsersRepositoryModule;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
 import org.apache.james.user.ldap.ReadOnlyLDAPUsersDAO;
 import org.apache.james.user.ldap.ReadOnlyUsersLDAPRepository;
@@ -22,24 +14,17 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 
 public class CombinedUsersRepositoryModule extends AbstractModule {
     @Override
     public void configure() {
-        Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
-        cassandraDataDefinitions.addBinding().toInstance(CassandraUsersRepositoryModule.MODULE);
-
-        bind(CassandraUsersDAO.class).in(Scopes.SINGLETON);
         bind(ReadOnlyLDAPUsersDAO.class).in(Scopes.SINGLETON);
         bind(CombinedUserDAO.class).in(Scopes.SINGLETON);
         bind(CombinedUsersRepository.class).in(Scopes.SINGLETON);
 
         bind(UsersDAO.class).to(CombinedUserDAO.class);
         bind(UsersRepository.class).to(CombinedUsersRepository.class);
-        bind(DelegationStore.class).to(CassandraDelegationStore.class);
-        bind(Authorizator.class).to(DelegationStoreAuthorizator.class);
     }
 
     @Provides
@@ -47,12 +32,6 @@ public class CombinedUsersRepositoryModule extends AbstractModule {
     public LdapRepositoryConfiguration provideConfiguration(ConfigurationProvider configurationProvider) throws ConfigurationException {
         return LdapRepositoryConfiguration.from(
             configurationProvider.getConfiguration("usersrepository"));
-    }
-
-    @Provides
-    @Singleton
-    public CassandraRepositoryConfiguration provideCassandraRepositoryConfiguration() {
-        return CassandraRepositoryConfiguration.DEFAULT;
     }
 
     @ProvidesIntoSet

--- a/tmail-backend/combined-identity/src/main/java/com/linagora/tmail/combined/identity/UsersRepositoryModuleChooser.java
+++ b/tmail-backend/combined-identity/src/main/java/com/linagora/tmail/combined/identity/UsersRepositoryModuleChooser.java
@@ -30,7 +30,6 @@ import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.james.data.LdapUsersRepositoryModule;
-import org.apache.james.modules.data.CassandraDelegationStoreModule;
 import org.apache.james.modules.data.CassandraUsersRepositoryModule;
 import org.apache.james.server.core.configuration.FileConfigurationProvider;
 import org.slf4j.Logger;
@@ -45,9 +44,9 @@ public class UsersRepositoryModuleChooser {
 
     public static List<Module> chooseModules(Implementation implementation) {
         return switch (implementation) {
-            case LDAP -> ImmutableList.of(new LdapUsersRepositoryModule(), new CassandraDelegationStoreModule());
+            case LDAP -> ImmutableList.of(new LdapUsersRepositoryModule());
             case COMBINED -> ImmutableList.of(new CombinedUsersRepositoryModule());
-            case DEFAULT -> ImmutableList.of(new CassandraUsersRepositoryModule(), new CassandraDelegationStoreModule());
+            case DEFAULT -> ImmutableList.of(new CassandraUsersRepositoryModule());
         };
     }
 

--- a/tmail-backend/deployment-tests/common/src/main/java/com/linagora/tmail/deployment/JmapContract.java
+++ b/tmail-backend/deployment-tests/common/src/main/java/com/linagora/tmail/deployment/JmapContract.java
@@ -1,14 +1,20 @@
 package com.linagora.tmail.deployment;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.jmap.JMAPTestingConstants.jmapRequestSpecBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.DefaultMailboxes;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -16,13 +22,19 @@ import org.testcontainers.containers.GenericContainer;
 import com.google.common.collect.ImmutableList;
 
 import io.restassured.RestAssured;
+import io.restassured.authentication.NoAuthScheme;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
 
 public interface JmapContract {
     String ARGUMENTS = "methodResponses[0][1]";
     Username BOB = Username.of("bob@domain.tld");
+    Username ALICE = Username.of("alice@domain.tld");
+    String ALICE_ACCOUNT_ID = "3d537c9fe934639a6a2f33b8357827bfab186b178c0b4d8424173b0e6472b44e";
     String BOB_PASSWORD = "bobpassword";
+    String ALICE_PASSWORD = "alicepassword";
 
     GenericContainer<?> jmapContainer();
 
@@ -30,6 +42,7 @@ public interface JmapContract {
     default void setUp() throws Exception {
         jmapContainer().execInContainer("james-cli", "AddDomain", "domain.tld");
         jmapContainer().execInContainer("james-cli", "AddUser", BOB.asString(), BOB_PASSWORD);
+        jmapContainer().execInContainer("james-cli", "AddUser", ALICE.asString(), ALICE_PASSWORD);
 
         PreemptiveBasicAuthScheme authScheme = new PreemptiveBasicAuthScheme();
         authScheme.setUserName(BOB.asString());
@@ -66,6 +79,59 @@ public interface JmapContract {
            .statusCode(200)
            .body(ARGUMENTS + ".list", hasSize(6))
            .body(ARGUMENTS + ".list.name", hasItems(expectedMailboxes.toArray()));
+   }
+
+   @Test
+   default void sessionRouteAndUploadRouteAndDownloadRouteShouldWork() {
+       RequestSpecification webadminRequestSpec = new RequestSpecBuilder()
+           .setContentType(ContentType.JSON)
+           .setAccept(ContentType.JSON)
+           .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+           .setBaseUri("http://" + jmapContainer().getContainerIpAddress())
+           .setPort(jmapContainer().getMappedPort(8000))
+           .setAuth(new NoAuthScheme())
+           .build();
+
+       // ALICE delegates BOB
+       given(webadminRequestSpec)
+       .when()
+           .put(String.format("/users/%s/authorizedUsers/%s", ALICE.asString(), BOB.asString()))
+       .then()
+           .statusCode(200);
+
+       // BOB's JMAP session should return BOB and ALICE accounts
+       String response = given()
+       .when()
+           .get("/jmap/session")
+       .then()
+           .statusCode(200)
+           .extract()
+           .body()
+           .asString();
+
+       assertThat(response).contains(BOB.asString(), ALICE.asString());
+
+       // BOB upload as ALICE
+       String blobId = given()
+           .body("whatever")
+       .when()
+           .post(String.format("/upload/%s", ALICE_ACCOUNT_ID))
+       .then()
+           .statusCode(201)
+           .body("blobId", Matchers.notNullValue())
+           .body("accountId", is(ALICE_ACCOUNT_ID))
+           .extract()
+           .body()
+           .jsonPath()
+           .getString("blobId");
+
+       // BOB download as ALICE
+       given()
+       .when()
+           .get(String.format("/download/%s/%s", ALICE_ACCOUNT_ID, blobId))
+       .then()
+           .statusCode(200)
+           .body(is("whatever"));
    }
 
 }

--- a/tmail-backend/deployment-tests/distributed-es6-backport/src/test/java/com/linagora/tmail/deployment/TmailDistributedEs6Extension.java
+++ b/tmail-backend/deployment-tests/distributed-es6-backport/src/test/java/com/linagora/tmail/deployment/TmailDistributedEs6Extension.java
@@ -3,9 +3,9 @@ package com.linagora.tmail.deployment;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.ES6_IMAGE_NAME;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.ES6_NETWORK_ALIAS;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createCassandra;
-import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
+import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,7 +52,7 @@ public class TmailDistributedEs6Extension implements BeforeEachCallback, AfterEa
             .withCopyFileToContainer(MountableFile.forClasspathResource("james-conf/jwt_publickey"), "/root/conf/")
             .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("team-mail-distributed-esv6-testing" + UUID.randomUUID()))
             .waitingFor(TestContainerWaitStrategy.WAIT_STRATEGY)
-            .withExposedPorts(25, 143, 80);
+            .withExposedPorts(25, 143, 80, 8000);
     }
 
     @Override

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
@@ -3,9 +3,9 @@ package com.linagora.tmail.deployment;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.OS_IMAGE_NAME;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.OS_NETWORK_ALIAS;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createCassandra;
-import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
+import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +70,7 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
             .withCopyFileToContainer(MountableFile.forClasspathResource("james-conf/jwt_publickey"), "/root/conf/")
             .withCreateContainerCmdModifier(cmder -> cmder.withName("team-mail-distributed-ldap-testing" + UUID.randomUUID()))
             .waitingFor(TestContainerWaitStrategy.WAIT_STRATEGY)
-            .withExposedPorts(25, 143, 80);
+            .withExposedPorts(25, 143, 80, 8000);
     }
 
     @Override

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/resources/prepopulated-ldap/populate.ldif
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/resources/prepopulated-ldap/populate.ldif
@@ -24,6 +24,15 @@ mail: bob@domain.tld
 userPassword: bobpassword
 description: bob
 
+dn: uid=alice, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: alice
+cn: alice
+sn: alice
+mail: alice@domain.tld
+userPassword: alicepassword
+description: alice
+
 dn: uid=imapuser, ou=people, dc=james,dc=org
 objectClass: inetOrgPerson
 uid: imapuser

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
@@ -3,9 +3,9 @@ package com.linagora.tmail.deployment;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.OS_IMAGE_NAME;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.OS_NETWORK_ALIAS;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createCassandra;
-import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createRabbitMQ;
 import static com.linagora.tmail.deployment.ThirdPartyContainers.createS3;
+import static com.linagora.tmail.deployment.ThirdPartyContainers.createSearchContainer;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class TmailDistributedExtension implements BeforeEachCallback, AfterEachC
             .withCopyFileToContainer(MountableFile.forClasspathResource("james-conf/jwt_publickey"), "/root/conf/")
             .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("team-mail-distributed-testing" + UUID.randomUUID()))
             .waitingFor(TestContainerWaitStrategy.WAIT_STRATEGY)
-            .withExposedPorts(25, 143, 80);
+            .withExposedPorts(25, 143, 80, 8000);
     }
 
     @Override

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
@@ -22,7 +22,7 @@ public class TmailMemoryExtension implements BeforeEachCallback, AfterEachCallba
         .withCopyFileToContainer(MountableFile.forClasspathResource("james-conf/jwt_publickey"), "/root/conf/")
         .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("tmail-memory-testing" + UUID.randomUUID()))
         .waitingFor(TestContainerWaitStrategy.WAIT_STRATEGY)
-        .withExposedPorts(25, 143, 80);
+        .withExposedPorts(25, 143, 80, 8000);
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws IOException {


### PR DESCRIPTION
So distributed-es6 is ok now, but not ok especially for LDAP user repository mode which requires a fix on James side: https://github.com/apache/james-project/pull/1473

I expect `DistributedLdapJmapTest.sessionRouteShouldReturnDelegatedAccounts` to fail for now.