### PR TITLE
ISSUE-638 Add APISIX in the demo OIDC docker compose on TMail

### DIFF
--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -1,0 +1,18 @@
+routes:
+  -
+    id: httpbin    #For test, TODO remove
+    uri: /ping
+    upstream:
+      nodes:
+      type: roundrobin
+    plugin_config_id: 1
+
+plugin_configs:
+  -
+    id: 1
+    plugins:
+      response-rewrite:
+        status_code: 200
+        body: "APISIX already up!\n"  #For test, TODO remove
+    desc: "response-rewrite"
+#END

--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -1,6 +1,6 @@
 routes:
   -
-    id: httpbin    #For test, TODO remove
+    id: test    #For test, TODO remove
     uri: /ping
     upstream:
       nodes:

--- a/demo/apisix/conf/config.yaml
+++ b/demo/apisix/conf/config.yaml
@@ -1,0 +1,4 @@
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml

--- a/demo/apisix/test.sh
+++ b/demo/apisix/test.sh
@@ -1,0 +1,5 @@
+APISIX_URL="127.0.0.1:9080"
+curl http://$APISIX_URL/ping
+
+# Expected response: APISIX already up!
+

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -101,5 +101,20 @@ services:
     networks:
       - tmail
 
+  apisix:
+    command: >
+      bash -c "cat /apisix-config/config.yaml > /usr/local/apisix/conf/config.yaml
+      && ln -s /apisix-config/apisix.yaml /usr/local/apisix/conf/apisix.yaml 
+      && /docker-entrypoint.sh docker-start"
+
+    image: apache/apisix:3.2.0-debian
+    volumes:
+      - ./apisix/conf/apisix.yaml:/apisix-config/apisix.yaml
+      - ./apisix/conf/config.yaml:/apisix-config/config.yaml
+    networks:
+      - tmail
+    ports:
+      - "9080:9080/tcp"
+
 networks:
   tmail:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -102,15 +102,10 @@ services:
       - tmail
 
   apisix:
-    command: >
-      bash -c "cat /apisix-config/config.yaml > /usr/local/apisix/conf/config.yaml
-      && ln -s /apisix-config/apisix.yaml /usr/local/apisix/conf/apisix.yaml 
-      && /docker-entrypoint.sh docker-start"
-
     image: apache/apisix:3.2.0-debian
     volumes:
-      - ./apisix/conf/apisix.yaml:/apisix-config/apisix.yaml
-      - ./apisix/conf/config.yaml:/apisix-config/config.yaml
+      - ./apisix/conf/apisix.yaml:/usr/local/apisix/conf/apisix.yaml
+      - ./apisix/conf/config.yaml:/usr/local/apisix/conf/config.yaml
     networks:
       - tmail
     ports:


### PR DESCRIPTION
resolve https://github.com/linagora/tmail-backend/issues/638

Ref: 
- How to configure run with standalone mode: https://github.com/apache/apisix-docker/blob/821b4744a003cdff5eff75c2a1896ec0eaa1089a/debian/docker-entrypoint.sh#L24
