### PR TITLE
CORS for APISIX

### DIFF
--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -12,6 +12,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - POST
+      - OPTIONS
     plugins:
       proxy-rewrite:
         uri: /jmap
@@ -21,6 +22,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - GET
+      - OPTIONS
     plugins:
       proxy-rewrite:
         uri: /jmap/session
@@ -30,6 +32,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - GET
+      - OPTIONS
     plugins:
       proxy-rewrite:
         regex_uri:
@@ -41,6 +44,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - POST
+      - OPTIONS
     plugins:
       proxy-rewrite:
         regex_uri:
@@ -52,6 +56,7 @@ routes:
     service_id: jmap_no_auth_service
     methods:
       - GET
+      - OPTIONS
     plugins:
       proxy-rewrite:
         uri: /.well-known/webfinger
@@ -61,6 +66,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - GET
+      - OPTIONS
     plugins:
       proxy-rewrite:
         uri: /.well-known/linagora-ecosystem
@@ -70,6 +76,7 @@ routes:
     service_id: jmap_service_oidc
     methods:
       - GET
+      - OPTIONS
     plugins:
       proxy-rewrite:
         uri: /.well-known/jmap

--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -91,13 +91,13 @@ services:
             - - request_method
               - "~="
               - OPTIONS
-        client_id: "james_apisix"
-        client_secret: "james_apisix"
+        client_id: "james"
+        client_secret: "james"
         discovery: "http://sso.example.com/.well-known/openid-configuration"
         scope: "openid profile"
         bearer_only: true
-        introspection_endpoint_auth_method: "client_secret_post"
         redirect_uri: "http://test.sso.example.com:8080/login-callback.html"
+        use_jwks: true
   -
     id: jmap_no_auth_service
     upstream_id: jmap_upstream

--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -18,7 +18,9 @@ routes:
         uri: /jmap
   -
     id: jmap_session
-    uri: /oidc/jmap/session
+    uris:
+      - /oidc/jmap/session
+      - /jmap/session
     service_id: jmap_service_oidc
     methods:
       - GET

--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -86,6 +86,11 @@ services:
     upstream_id: jmap_upstream
     plugins:
       openid-connect:
+        _meta:
+          filter:
+            - - request_method
+              - "~="
+              - OPTIONS
         client_id: "james_apisix"
         client_secret: "james_apisix"
         discovery: "http://sso.example.com/.well-known/openid-configuration"

--- a/demo/tmail/.env
+++ b/demo/tmail/.env
@@ -1,4 +1,4 @@
-SERVER_URL=http://test.sso.example.com:8090
-WEB_OIDC_CLIENT_ID=james
+SERVER_URL=http://apisix.example.com:9080/oidc
+WEB_OIDC_CLIENT_ID=james_apisix
 DOMAIN_REDIRECT_URL=http://test.sso.example.com:8080
 APP_GRID_AVAILABLE=supported

--- a/demo/tmail/.env
+++ b/demo/tmail/.env
@@ -1,4 +1,4 @@
 SERVER_URL=http://apisix.example.com:9080/oidc
-WEB_OIDC_CLIENT_ID=james_apisix
+WEB_OIDC_CLIENT_ID=james
 DOMAIN_REDIRECT_URL=http://test.sso.example.com:8080
 APP_GRID_AVAILABLE=supported

--- a/demo/tmail/jmap.properties
+++ b/demo/tmail/jmap.properties
@@ -26,4 +26,4 @@ jwt.privatekeypem.url=file://conf/jwt_privatekey
 # CF https://openid.net/specs/openid-connect-discovery-1_0.html
 oidc.provider.url=http://sso.example.com
 
-url.prefix=http://test.sso.example.com:8090
+url.prefix=http://apisix.example.com:9080/oidc


### PR DESCRIPTION
Outside of the CORS setup scope, but I am trying to set up a smooth SSO flow for TMail FE + APISIX.

Currently, I can log in to TMail, however, can not do anything more with it because the wrong endpoint was called by TMail FE
![image](https://user-images.githubusercontent.com/55171818/234261962-22b6a0e6-8919-4ed5-9fbe-5cf745a016dd.png)

TODO: check configuration regarding oidc endpoint, jmap prefix.. 