### PR TITLE
[APISIX] Avoid call TokenRevokedFilter plugin upon OPTIONS request

### DIFF
--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -228,6 +228,11 @@ plugin_configs:
         healthy:
           successes: 1
       ext-plugin-pre-req:
+        _meta:
+          filter:
+            - - request_method
+              - "~="
+              - OPTIONS
         conf:
           - name: TokenRevokedFilter
             value: '{"enable":"feature"}'


### PR DESCRIPTION
[demo fix avoid token revoked when OPTIONS request.webm](https://github.com/linagora/tmail-backend/assets/55171818/7d345397-a8af-48e8-a46b-41220373493d)
