### PR TITLE
ISSUE-666 Contacts deletion: should remove the contact in domain contact

### DIFF
--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStepTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStepTest.scala
@@ -19,6 +19,8 @@ object ContactUsernameChangeTaskStepTest {
   val ANDRE_CONTACT: ContactFields = ContactFields(ANDRE_MAIL_ADDRESS, "Andre", "Dupont")
   val MARIE_MAIL_ADDRESS: MailAddress = new MailAddress("marie@linagora.com")
   val MARIE_CONTACT: ContactFields = ContactFields(MARIE_MAIL_ADDRESS, "Marie", "Bourdier")
+  val ALICE_MAIL_ADDRESS: MailAddress = new MailAddress("alice@linagora.com")
+  val ALICE_CONTACT: ContactFields = ContactFields(ALICE_MAIL_ADDRESS, "Alice", "Gwen")
 }
 
 class ContactUsernameChangeTaskStepTest {


### PR DESCRIPTION
IMO there should be no reason that other users still be suggested a deleted user contact. Some deployments may not depend on LSC/LDAP to sync the deletion for domain contact.