### PR TITLE
FCM subscriptions deletion

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -602,6 +602,7 @@ Implemented extra steps for TMail are:
 
 - `ContactUserDeletionTaskStep`: deletes contacts belonging to the user.
 - `PGPKeysUserDeletionTaskStep`: remove PGP public keys belonging to the user.
+- `FirebaseSubscriptionUserDeletionTaskStep`: deletes firebase subscriptions belonging to the user.
 
 Response codes:
 

--- a/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/firebase/CassandraFirebaseSubscriptionRepository.scala
+++ b/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/firebase/CassandraFirebaseSubscriptionRepository.scala
@@ -74,6 +74,10 @@ class CassandraFirebaseSubscriptionRepository @Inject()(dao: CassandraFirebaseSu
       .flatMap(subscription => dao.deleteOne(username, subscription.deviceClientId.value))
       .`then`()
 
+  override def revoke(username: Username): Publisher[Void] =
+    SMono.fromPublisher(dao.deleteAllSubscriptions(username))
+      .`then`()
+
   override def get(username: Username, ids: util.Set[FirebaseSubscriptionId]): Publisher[FirebaseSubscription] =
     dao.selectAll(username)
       .filter(subscription => ids.contains(subscription.id))

--- a/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/firebase/CassandraFirebaseSubscriptionRepository.scala
+++ b/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/firebase/CassandraFirebaseSubscriptionRepository.scala
@@ -12,6 +12,7 @@ import javax.inject.Inject
 import org.apache.james.backends.cassandra.components.CassandraModule
 import org.apache.james.core.Username
 import org.apache.james.jmap.api.model.TypeName
+import org.apache.james.user.api.DeleteUserDataTaskStep
 import org.reactivestreams.Publisher
 import reactor.core.publisher.SynchronousSink
 import reactor.core.scala.publisher.SMono
@@ -27,6 +28,10 @@ case class CassandraFirebaseSubscriptionRepositoryModule() extends AbstractModul
       .addBinding().toInstance(CassandraFirebaseSubscriptionTable.MODULE)
 
     bind(classOf[CassandraFirebaseSubscriptionDAO]).in(Scopes.SINGLETON)
+
+    Multibinder.newSetBinder(binder, classOf[DeleteUserDataTaskStep])
+      .addBinding()
+      .to(classOf[FirebaseSubscriptionUserDeletionTaskStep])
   }
 }
 

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionRepository.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionRepository.java
@@ -21,6 +21,8 @@ public interface FirebaseSubscriptionRepository {
 
     Publisher<Void> revoke(Username username, FirebaseSubscriptionId id);
 
+    Publisher<Void> revoke(Username username);
+
     Publisher<FirebaseSubscription> get(Username username, Set<FirebaseSubscriptionId> ids);
 
     Publisher<FirebaseSubscription> list(Username username);

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionUserDeletionTaskStep.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionUserDeletionTaskStep.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package com.linagora.tmail.james.jmap.firebase;
+
+import javax.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.user.api.DeleteUserDataTaskStep;
+import org.reactivestreams.Publisher;
+
+public class FirebaseSubscriptionUserDeletionTaskStep implements DeleteUserDataTaskStep {
+    private final FirebaseSubscriptionRepository firebaseSubscriptionRepository;
+
+    @Inject
+    public FirebaseSubscriptionUserDeletionTaskStep(FirebaseSubscriptionRepository firebaseSubscriptionRepository) {
+        this.firebaseSubscriptionRepository = firebaseSubscriptionRepository;
+    }
+
+    @Override
+    public StepName name() {
+        return new StepName("FirebaseSubscriptionUserDeletionTaskStep");
+    }
+
+    @Override
+    public int priority() {
+        return 8;
+    }
+
+    @Override
+    public Publisher<Void> deleteUserData(Username username) {
+        return firebaseSubscriptionRepository.revoke(username);
+    }
+}

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/MemoryFirebaseSubscriptionRepository.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/MemoryFirebaseSubscriptionRepository.java
@@ -14,12 +14,14 @@ import javax.inject.Inject;
 
 import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.TypeName;
+import org.apache.james.user.api.DeleteUserDataTaskStep;
 import org.reactivestreams.Publisher;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.james.jmap.model.DeviceClientIdInvalidException;
 import com.linagora.tmail.james.jmap.model.ExpireTimeInvalidException;
 import com.linagora.tmail.james.jmap.model.FirebaseSubscription;
@@ -41,6 +43,10 @@ public class MemoryFirebaseSubscriptionRepository implements FirebaseSubscriptio
         protected void configure() {
             bind(MemoryFirebaseSubscriptionRepository.class).in(Scopes.SINGLETON);
             bind(FirebaseSubscriptionRepository.class).to(MemoryFirebaseSubscriptionRepository.class);
+
+            Multibinder.newSetBinder(binder(), DeleteUserDataTaskStep.class)
+                .addBinding()
+                .to(FirebaseSubscriptionUserDeletionTaskStep.class);
         }
     }
 

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/MemoryFirebaseSubscriptionRepository.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/MemoryFirebaseSubscriptionRepository.java
@@ -108,6 +108,12 @@ public class MemoryFirebaseSubscriptionRepository implements FirebaseSubscriptio
     }
 
     @Override
+    public Publisher<Void> revoke(Username username) {
+        return Mono.fromRunnable(() -> table.row(username).clear())
+            .then();
+    }
+
+    @Override
     public Publisher<FirebaseSubscription> get(Username username, Set<FirebaseSubscriptionId> ids) {
         return Flux.fromIterable(table.row(username).entrySet())
             .filter(entry -> ids.contains(entry.getKey()))

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionRepositoryContract.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionRepositoryContract.scala
@@ -2,8 +2,8 @@ package com.linagora.tmail.james.jmap.firebase
 
 import java.time.{Clock, Instant, ZoneId, ZonedDateTime}
 
-import com.linagora.tmail.james.jmap.firebase.FirebaseSubscriptionRepositoryContract.{ALICE, INVALID_EXPIRE, MAX_EXPIRE, SAMPLE_DEVICE_TOKEN_1, SAMPLE_DEVICE_TOKEN_2, VALID_EXPIRE}
-import com.linagora.tmail.james.jmap.model.{DeviceClientId, DeviceClientIdInvalidException, TokenInvalidException, ExpireTimeInvalidException, FirebaseToken, FirebaseSubscription, FirebaseSubscriptionCreationRequest, FirebaseSubscriptionExpiredTime, FirebaseSubscriptionId, FirebaseSubscriptionNotFoundException}
+import com.linagora.tmail.james.jmap.firebase.FirebaseSubscriptionRepositoryContract.{ALICE, BOB, INVALID_EXPIRE, MAX_EXPIRE, SAMPLE_DEVICE_TOKEN_1, SAMPLE_DEVICE_TOKEN_2, VALID_EXPIRE}
+import com.linagora.tmail.james.jmap.model.{DeviceClientId, DeviceClientIdInvalidException, ExpireTimeInvalidException, FirebaseSubscription, FirebaseSubscriptionCreationRequest, FirebaseSubscriptionExpiredTime, FirebaseSubscriptionId, FirebaseSubscriptionNotFoundException, FirebaseToken, TokenInvalidException}
 import org.apache.james.core.Username
 import org.apache.james.jmap.api.model.{State, TypeName}
 import org.apache.james.utils.UpdatableTickingClock
@@ -49,6 +49,7 @@ object FirebaseSubscriptionRepositoryContract {
   val VALID_EXPIRE: ZonedDateTime = ZonedDateTime.now(CLOCK).plusDays(2)
   val MAX_EXPIRE: ZonedDateTime = ZonedDateTime.now(CLOCK).plusDays(7)
   val ALICE: Username = Username.of("alice")
+  val BOB: Username = Username.of("bob")
   val SAMPLE_DEVICE_TOKEN_1 = FirebaseToken("dummy_device_token_1")
   val SAMPLE_DEVICE_TOKEN_2 = FirebaseToken("dummy_device_token_2")
 }
@@ -233,6 +234,44 @@ trait FirebaseSubscriptionRepositoryContract {
     val remainingSubscriptions = SFlux.fromPublisher(testee.get(ALICE, Set(firebaseSubscriptionId).asJava)).collectSeq().block().asJava
 
     assertThat(remainingSubscriptions).isEmpty()
+  }
+
+  @Test
+  def revokeSubscriptionsOfAnUserShouldSucceed(): Unit = {
+    val validRequest1 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("1"),
+      token = SAMPLE_DEVICE_TOKEN_1,
+      types = Seq(CustomTypeName1))
+    val validRequest2 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("2"),
+      token = SAMPLE_DEVICE_TOKEN_2,
+      types = Seq(CustomTypeName1))
+    SMono.fromPublisher(testee.save(ALICE, validRequest1)).block()
+    SMono.fromPublisher(testee.save(ALICE, validRequest2)).block()
+
+    SMono.fromPublisher(testee.revoke(ALICE)).block()
+
+    val remainingSubscriptions = SFlux.fromPublisher(testee.list(ALICE)).collectSeq().block().asJava
+    assertThat(remainingSubscriptions).isEmpty()
+  }
+
+  @Test
+  def revokeSubscriptionsShouldNotRemoveOtherUserSubscriptions(): Unit = {
+    val validRequest1 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("1"),
+      token = SAMPLE_DEVICE_TOKEN_1,
+      types = Seq(CustomTypeName1))
+    val validRequest2 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("2"),
+      token = SAMPLE_DEVICE_TOKEN_2,
+      types = Seq(CustomTypeName1))
+    SMono.fromPublisher(testee.save(ALICE, validRequest1)).block()
+    SMono.fromPublisher(testee.save(BOB, validRequest2)).block()
+
+    SMono.fromPublisher(testee.revoke(ALICE)).block()
+
+    val remainingSubscriptions = SFlux.fromPublisher(testee.list(BOB)).collectSeq().block().asJava
+    assertThat(remainingSubscriptions).hasSize(1)
   }
 
   @Test

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionUserDeletionTaskStepTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebaseSubscriptionUserDeletionTaskStepTest.scala
@@ -1,0 +1,71 @@
+package com.linagora.tmail.james.jmap.firebase
+
+import com.linagora.tmail.james.jmap.contact.ContactUsernameChangeTaskStepTest.ALICE
+import com.linagora.tmail.james.jmap.firebase.FirebaseSubscriptionRepositoryContract.{BOB, SAMPLE_DEVICE_TOKEN_1, SAMPLE_DEVICE_TOKEN_2}
+import com.linagora.tmail.james.jmap.model.{DeviceClientId, FirebaseSubscriptionCreationRequest}
+import org.apache.james.utils.UpdatableTickingClock
+import org.assertj.core.api.Assertions.{assertThat, assertThatCode}
+import org.junit.jupiter.api.{BeforeEach, Test}
+import reactor.core.scala.publisher.{SFlux, SMono}
+
+import scala.jdk.CollectionConverters._
+
+class FirebaseSubscriptionUserDeletionTaskStepTest {
+  var firebaseSubscriptionRepository: FirebaseSubscriptionRepository = _
+  var testee: FirebaseSubscriptionUserDeletionTaskStep = _
+
+  @BeforeEach
+  def beforeEach(): Unit = {
+    firebaseSubscriptionRepository = new MemoryFirebaseSubscriptionRepository(new UpdatableTickingClock(FirebaseSubscriptionRepositoryContract.NOW))
+    testee = new FirebaseSubscriptionUserDeletionTaskStep(firebaseSubscriptionRepository)
+  }
+
+  @Test
+  def shouldRemoveSubscriptions(): Unit = {
+    val validRequest1 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("1"),
+      token = SAMPLE_DEVICE_TOKEN_1,
+      types = Seq(CustomTypeName1))
+    val validRequest2 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("2"),
+      token = SAMPLE_DEVICE_TOKEN_2,
+      types = Seq(CustomTypeName1))
+    SMono.fromPublisher(firebaseSubscriptionRepository.save(ALICE, validRequest1)).block()
+    SMono.fromPublisher(firebaseSubscriptionRepository.save(ALICE, validRequest2)).block()
+
+    SMono.fromPublisher(testee.deleteUserData(ALICE)).block()
+
+    assertThat(SFlux.fromPublisher(firebaseSubscriptionRepository.list(ALICE))
+      .collectSeq().block().asJava)
+      .isEmpty()
+  }
+
+  @Test
+  def shouldNotRemoveSubscriptionsOfOtherUsers(): Unit = {
+    val validRequest1 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("1"),
+      token = SAMPLE_DEVICE_TOKEN_1,
+      types = Seq(CustomTypeName1))
+    val validRequest2 = FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("2"),
+      token = SAMPLE_DEVICE_TOKEN_2,
+      types = Seq(CustomTypeName1))
+    SMono.fromPublisher(firebaseSubscriptionRepository.save(ALICE, validRequest1)).block()
+    val bobSubscription = SMono.fromPublisher(firebaseSubscriptionRepository.save(BOB, validRequest2)).block()
+
+    SMono.fromPublisher(testee.deleteUserData(ALICE)).block()
+
+    assertThat(SFlux.fromPublisher(firebaseSubscriptionRepository.list(BOB))
+      .collectSeq().block().asJava)
+      .containsOnly(bobSubscription)
+  }
+
+  @Test
+  def shouldBeIdempotent(): Unit = {
+    SMono.fromPublisher(testee.deleteUserData(ALICE)).block()
+
+    assertThatCode(() => SMono.fromPublisher(testee.deleteUserData(ALICE)).block())
+      .doesNotThrowAnyException()
+  }
+
+}


### PR DESCRIPTION
resolve https://github.com/linagora/tmail-backend/issues/668

IT part: required setup of real FCM credentials, I would rather skip it.
For deleting the FCM token on FCM, I do not see the Firebase admin SDK supporting any API like that.