### PR TITLE
[FIX] Missing JMAP listeners module in Distributed ES6

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed-es6-backport/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -15,6 +15,7 @@ import org.apache.james.SearchModuleChooser;
 import org.apache.james.events.RabbitMQEventBus;
 import org.apache.james.eventsourcing.eventstore.cassandra.EventNestedTypes;
 import org.apache.james.jmap.InjectionKeys;
+import org.apache.james.jmap.draft.JMAPListenerModule;
 import org.apache.james.json.DTO;
 import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.MailboxManager;
@@ -270,7 +271,16 @@ public class DistributedServer {
             .combineWith(UsersRepositoryModuleChooser.chooseModules(configuration.usersRepositoryImplementation()))
             .combineWith(chooseFirebase(configuration.firebaseModuleChooserConfiguration()))
             .combineWith(chooserLinagoraServicesDiscovery(configuration.linagoraServicesDiscoveryModuleChooserConfiguration()))
-            .overrideWith(chooseMailbox(configuration.mailboxConfiguration()));
+            .overrideWith(chooseMailbox(configuration.mailboxConfiguration()))
+            .overrideWith(chooseJmapModule(configuration));
+    }
+
+    private static Module chooseJmapModule(DistributedJamesConfiguration configuration) {
+        if (configuration.jmapEnabled()) {
+            return new JMAPListenerModule();
+        }
+        return binder -> {
+        };
     }
 
     private static class EncryptedMailboxModule extends AbstractModule {


### PR DESCRIPTION
Otherwise, `tmail.linagora.com` would not function normally without JMAP listeners, in the next release.