### PR TITLE
Fix error in the test related to Ldap container - java.lang.IllegalSt…

### DIFF
--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -31,6 +31,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>combined-identity</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>encrypted-mailbox-guice</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed-es6-backport/src/test/java/com/linagora/tmail/james/app/CombinedIdentityJamesServerTest.java
+++ b/tmail-backend/apps/distributed-es6-backport/src/test/java/com/linagora/tmail/james/app/CombinedIdentityJamesServerTest.java
@@ -1,34 +1,22 @@
 package com.linagora.tmail.james.app;
 
-import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
-import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
-import org.apache.commons.configuration2.HierarchicalConfiguration;
-import org.apache.commons.configuration2.plist.PropertyListConfiguration;
-import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
-import org.apache.james.server.core.configuration.ConfigurationProvider;
-import org.apache.james.user.ldap.DockerLdapSingleton;
-import org.apache.james.user.ldap.LdapGenericContainer;
 import org.apache.james.utils.GuiceProbe;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.combined.identity.CombinedUsersRepository;
+import com.linagora.tmail.combined.identity.LdapExtension;
 import com.linagora.tmail.combined.identity.UsersRepositoryClassProbe;
 import com.linagora.tmail.combined.identity.UsersRepositoryModuleChooser;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
-
 public class CombinedIdentityJamesServerTest {
-    static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
 
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
@@ -40,44 +28,13 @@ public class CombinedIdentityJamesServerTest {
             .build())
         .server(configuration -> DistributedServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule())
-            .overrideWith(binder -> binder.bind(ConfigurationProvider.class).toInstance((s, l) -> new BaseHierarchicalConfiguration(baseConfiguration())))
             .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class).addBinding().to(UsersRepositoryClassProbe.class)))
         .extension(new DockerElasticSearchExtension())
         .extension(new CassandraExtension())
         .extension(new RabbitMQExtension())
+        .extension(new LdapExtension())
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
-
-
-    @BeforeAll
-    static void setUpAll() {
-        ldapContainer.start();
-    }
-
-    @AfterAll
-    static void afterAll() {
-        ldapContainer.stop();
-    }
-
-    private static HierarchicalConfiguration<ImmutableNode> baseConfiguration() {
-        PropertyListConfiguration configuration = new PropertyListConfiguration();
-        configuration.addProperty("[@ldapHost]", DockerLdapSingleton.ldapContainer.getLdapHost());
-        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
-        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
-        configuration.addProperty("[@userBase]", "ou=People,dc=james,dc=org");
-        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
-        configuration.addProperty("[@maxRetries]", "1");
-        configuration.addProperty("[@retryStartInterval]", "0");
-        configuration.addProperty("[@retryMaxInterval]", "2");
-        configuration.addProperty("[@retryIntervalScale]", "1000");
-        configuration.addProperty("[@connectionTimeout]", "1000");
-        configuration.addProperty("[@readTimeout]", "1000");
-
-        configuration.addProperty("[@userIdAttribute]", "mail");
-        configuration.addProperty("supportsVirtualHosting", true);
-        configuration.addProperty("[@administratorId]", ADMIN.asString());
-        return configuration;
-    }
 
     @Test
     void shouldUseCombinedUsersRepositoryWhenSpecified(GuiceJamesServer server) {

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -29,6 +29,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>combined-identity</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>encrypted-mailbox-guice</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/CombinedIdentityJamesServerTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/CombinedIdentityJamesServerTest.java
@@ -1,36 +1,25 @@
 package com.linagora.tmail.james.app;
 
-import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
-import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
-import org.apache.commons.configuration2.HierarchicalConfiguration;
-import org.apache.commons.configuration2.plist.PropertyListConfiguration;
-import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
-import org.apache.james.server.core.configuration.ConfigurationProvider;
-import org.apache.james.user.ldap.DockerLdapSingleton;
-import org.apache.james.user.ldap.LdapGenericContainer;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.GuiceProbe;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.combined.identity.CombinedUsersRepository;
+import com.linagora.tmail.combined.identity.LdapExtension;
 import com.linagora.tmail.combined.identity.UsersRepositoryClassProbe;
 import com.linagora.tmail.combined.identity.UsersRepositoryModuleChooser;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
 public class CombinedIdentityJamesServerTest {
-    static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
 
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
@@ -42,44 +31,13 @@ public class CombinedIdentityJamesServerTest {
             .build())
         .server(configuration -> DistributedServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule())
-            .overrideWith(binder -> binder.bind(ConfigurationProvider.class).toInstance((s, l) -> new BaseHierarchicalConfiguration(baseConfiguration())))
             .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class).addBinding().to(UsersRepositoryClassProbe.class)))
         .extension(new DockerOpenSearchExtension())
         .extension(new CassandraExtension())
         .extension(new RabbitMQExtension())
+        .extension(new LdapExtension())
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
-
-
-    @BeforeAll
-    static void setUpAll() {
-        ldapContainer.start();
-    }
-
-    @AfterAll
-    static void afterAll() {
-        ldapContainer.stop();
-    }
-
-    private static HierarchicalConfiguration<ImmutableNode> baseConfiguration() {
-        PropertyListConfiguration configuration = new PropertyListConfiguration();
-        configuration.addProperty("[@ldapHost]", DockerLdapSingleton.ldapContainer.getLdapHost());
-        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
-        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
-        configuration.addProperty("[@userBase]", "ou=People,dc=james,dc=org");
-        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
-        configuration.addProperty("[@maxRetries]", "1");
-        configuration.addProperty("[@retryStartInterval]", "0");
-        configuration.addProperty("[@retryMaxInterval]", "2");
-        configuration.addProperty("[@retryIntervalScale]", "1000");
-        configuration.addProperty("[@connectionTimeout]", "1000");
-        configuration.addProperty("[@readTimeout]", "1000");
-
-        configuration.addProperty("[@userIdAttribute]", "mail");
-        configuration.addProperty("[@administratorId]", ADMIN.asString());
-        configuration.addProperty("enableVirtualHosting", true);
-        return configuration;
-    }
 
     @Test
     void shouldUseCombinedUsersRepositoryWhenSpecified(GuiceJamesServer server) {

--- a/tmail-backend/apps/memory/src/test/java/com/linagora/tmail/james/app/JamesServerConcreteContract.java
+++ b/tmail-backend/apps/memory/src/test/java/com/linagora/tmail/james/app/JamesServerConcreteContract.java
@@ -15,7 +15,7 @@ interface JamesServerConcreteContract extends JamesServerContract {
 
     @Override
     default int imapsPort(GuiceJamesServer server) {
-        return server.getProbe(ImapGuiceProbe.class).getImapsPort();
+        return server.getProbe(ImapGuiceProbe.class).getImapStartTLSPort();
     }
 
     @Override

--- a/tmail-backend/combined-identity/src/test/java/com/linagora/tmail/combined/identity/LdapExtension.java
+++ b/tmail-backend/combined-identity/src/test/java/com/linagora/tmail/combined/identity/LdapExtension.java
@@ -1,0 +1,68 @@
+package com.linagora.tmail.combined.identity;
+
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
+
+import java.util.function.Function;
+
+import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.plist.PropertyListConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.GuiceModuleTestExtension;
+import org.apache.james.server.core.configuration.ConfigurationProvider;
+import org.apache.james.user.ldap.DockerLdapSingleton;
+import org.apache.james.user.ldap.LdapGenericContainer;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.inject.Module;
+
+public class LdapExtension implements GuiceModuleTestExtension {
+    private final LdapGenericContainer ldapGenericContainer = DockerLdapSingleton.ldapContainer;
+
+    private final Function<String, HierarchicalConfiguration<ImmutableNode>> configurationFunction;
+
+    public LdapExtension(Function<String, HierarchicalConfiguration<ImmutableNode>> configurationFunction) {
+        this.configurationFunction = configurationFunction;
+    }
+
+    public LdapExtension() {
+        this.configurationFunction = LdapExtension::baseConfiguration;
+    }
+    @Override
+    public Module getModule() {
+        return binder -> binder.bind(ConfigurationProvider.class)
+            .toInstance((s, l) -> new BaseHierarchicalConfiguration(configurationFunction.apply(ldapGenericContainer.getLdapHost())));
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        ldapGenericContainer.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        ldapGenericContainer.stop();
+    }
+
+    private static HierarchicalConfiguration<ImmutableNode> baseConfiguration(String ldapHost) {
+        PropertyListConfiguration configuration = new PropertyListConfiguration();
+        configuration.addProperty("[@ldapHost]", ldapHost);
+        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
+        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
+        configuration.addProperty("[@userBase]", "ou=People,dc=james,dc=org");
+        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
+        configuration.addProperty("[@maxRetries]", "1");
+        configuration.addProperty("[@retryStartInterval]", "0");
+        configuration.addProperty("[@retryMaxInterval]", "2");
+        configuration.addProperty("[@retryIntervalScale]", "1000");
+        configuration.addProperty("[@connectionTimeout]", "1000");
+        configuration.addProperty("[@readTimeout]", "1000");
+
+        configuration.addProperty("[@userIdAttribute]", "mail");
+        configuration.addProperty("[@administratorId]", ADMIN.asString());
+        configuration.addProperty("enableVirtualHosting", true);
+        return configuration;
+    }
+
+}

--- a/tmail-backend/combined-identity/src/test/resources/ldif-files/Dockerfile
+++ b/tmail-backend/combined-identity/src/test/resources/ldif-files/Dockerfile
@@ -1,3 +1,0 @@
-FROM dinkel/openldap:latest
-
-COPY populate.ldif /etc/ldap/prepopulate/prepop.ldif

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
 
@@ -55,7 +58,10 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
             .withEnv("LDAP_DOMAIN", "james.org")
             .withEnv("LDAP_ADMIN_PASSWORD", "secret")
             .withCommand("--copy-service --loglevel debug")
-            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("team-mail-openldap-testing" + UUID.randomUUID()));
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("team-mail-openldap-testing" + UUID.randomUUID()))
+            .waitingFor(new LogMessageWaitStrategy().withRegEx(".*slapd starting\\n").withTimes(1)
+                .withStartupTimeout(Duration.ofMinutes(3)))
+            .withStartupCheckStrategy(new MinimumDurationRunningStartupCheckStrategy(Duration.ofSeconds(10)));
     }
 
     @SuppressWarnings("resource")

--- a/tmail-backend/mailbox/encrypted/api/src/main/scala/com/linagora/tmail/encrypted/EncryptedMailboxManager.scala
+++ b/tmail-backend/mailbox/encrypted/api/src/main/scala/com/linagora/tmail/encrypted/EncryptedMailboxManager.scala
@@ -170,4 +170,10 @@ class EncryptedMailboxManager @Inject()(mailboxManager: MailboxManager,
 
   override def applyRightsCommandReactive(mailboxPath: MailboxPath, mailboxACLCommand: MailboxACL.ACLCommand, session: MailboxSession): Publisher[Void] =
     mailboxManager.applyRightsCommandReactive(mailboxPath, mailboxACLCommand, session)
+
+  override def listRightsReactive(mailboxPath: MailboxPath, session: MailboxSession): Publisher[MailboxACL] =
+    mailboxManager.listRightsReactive(mailboxPath, session)
+
+  override def listRightsReactive(mailboxId: MailboxId, session: MailboxSession): Publisher[MailboxACL] =
+    mailboxManager.listRightsReactive(mailboxId, session)
 }

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -104,6 +104,12 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>combined-identity</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>distributed</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
…ateException: Mapped port can only be obtained after the container is started

- Reason: Tmail-backend server extension tries to get LdapHost before Ldap already start