### PR TITLE
[CI] Jenkinsfile - Recording Test Results and Archiving Artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,16 @@ pipeline {
                     sh 'mvn -B surefire:test'
                 }
             }
+            post {
+                always {
+                    junit(testResults: '**/surefire-reports/*.xml', allowEmptyResults: false)
+                    junit(testResults: '**/failsafe-reports/*.xml', allowEmptyResults: true)
+                }
+                failure {
+                    archiveArtifacts artifacts: '**/target/test-run.log' , fingerprint: true
+                    archiveArtifacts artifacts: '**/surefire-reports/*' , fingerprint: true
+                }
+            }
         }
         stage('Deliver Docker images') {
           when {


### PR DESCRIPTION
When the ci test fails, We can click on "Tests" on the Jenkin board to quickly get the names of test cases that failed. (it will be easier than reading the noise logs)
