### PR TITLE
ISSUE-755 EnforceRateLimitingPlan - Fix mistake at commit #7fae36a60d…

### DIFF
--- a/tmail-backend/mailets/src/main/scala/com/linagora/tmail/mailets/EnforceRateLimitingPlan.scala
+++ b/tmail-backend/mailets/src/main/scala/com/linagora/tmail/mailets/EnforceRateLimitingPlan.scala
@@ -57,7 +57,7 @@ class EnforceRateLimitingPlan @Inject()(planRepository: RateLimitingPlanReposito
     planRateLimiterResolver = PlanRateLimiterResolver(
       rateLimiterFactory = rateLimiterFactory,
       keyPrefix = Option(getInitParameter("keyPrefix")).map(KeyPrefix),
-      precision = getMailetConfig.getDuration("duration"))
+      precision = getMailetConfig.getDuration("precision"))
   }
 
   @VisibleForTesting


### PR DESCRIPTION
…b954bbb80d56a0d446a31fed33a8a8

- precision value must parse from `precision` config (not `duration`)