### PR TITLE
[FIX] CombinedUsersRepository configuration sample should use `enableVirtualHosting` instead of `supportsVirtualHosting`

### DIFF
--- a/tmail-backend/apps/distributed/src/main/conf/usersrepository.xml
+++ b/tmail-backend/apps/distributed/src/main/conf/usersrepository.xml
@@ -36,5 +36,5 @@
                  userBase="ou=people,dc=james,dc=org"
                  userIdAttribute="mail"
                  userObjectClass="person">
-<supportsVirtualHosting>true</supportsVirtualHosting>
+    <enableVirtualHosting>true</enableVirtualHosting>
 </usersrepository>-->


### PR DESCRIPTION
supportsVirtualHosting is only for ReadOnlyUsersRepository.