### PR TITLE
[BUILD] Build multi-platform (amd64/arm64) for docker image by JIB

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,25 +52,8 @@ pipeline {
               }
 
               echo "Docker tag: ${env.DOCKER_TAG}"
-
-              // Load docker from tar file
-              sh "docker load -i tmail-backend/apps/distributed/target/jib-image.tar"
-              sh "docker load -i tmail-backend/apps/distributed-es6-backport/target/jib-image.tar"
-              sh "docker load -i tmail-backend/apps/memory/target/jib-image.tar"
-
-              // Temporary retag image names
-              sh "docker tag linagora/tmail-backend-memory linagora/tmail-backend:memory-${env.DOCKER_TAG}"
-              sh "docker tag linagora/tmail-backend-distributed linagora/tmail-backend:distributed-${env.DOCKER_TAG}"
-              sh "docker tag linagora/tmail-backend-distributed-esv6 linagora/tmail-backend:distributed-esv6-${env.DOCKER_TAG}"
-
-              def memoryImage = docker.image "linagora/tmail-backend:memory-${env.DOCKER_TAG}"
-              def distributedImage = docker.image "linagora/tmail-backend:distributed-${env.DOCKER_TAG}"
-              def distributedEs6Image = docker.image "linagora/tmail-backend:distributed-esv6-${env.DOCKER_TAG}"
-              docker.withRegistry('', 'dockerHub') {
-                memoryImage.push()
-                distributedImage.push()
-                distributedEs6Image.push()
-              }
+              // build and push docker images
+              sh "mvn -Pci jib:build -pl apps/distributed,apps/distributed-es6-backport,apps/memory -X"
             }
           }
           post {

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <target.jdk>17</target.jdk>
+        <jib.base.image>eclipse-temurin:20-jre-jammy</jib.base.image>
     </properties>
 
     <modules>

--- a/tmail-backend/apps/distributed-es6-backport/pom.xml
+++ b/tmail-backend/apps/distributed-es6-backport/pom.xml
@@ -487,4 +487,111 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <from>
+                                <image>${jib.base.image}</image>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                            <to>
+                                <image>linagora/tmail-backend</image>
+                                <tags>
+                                    <tag>distributed-esv6-${env.DOCKER_TAG}</tag>
+                                </tags>
+                                <auth>
+                                    <username>${env.DOCKER_HUB_USER}</username>
+                                    <password>${env.DOCKER_HUB_TOKEN}</password>
+                                </auth>
+                            </to>
+                            <container>
+                                <mainClass>com.linagora.tmail.james.app.DistributedServer</mainClass>
+                                <ports>
+                                    <port>80</port> <!-- JMAP -->
+                                    <port>143</port> <!-- IMAP -->
+                                    <port>993</port> <!-- IMAPS -->
+                                    <port>25</port> <!-- SMTP -->
+                                    <port>465</port> <!-- SMTP + STARTTLS -->
+                                    <port>587</port> <!-- SMTPS -->
+                                    <port>4000</port> <!-- GLOWROOT, if activated -->
+                                    <port>8000</port> <!-- WEBADMIN -->
+                                </ports>
+                                <appRoot>/root</appRoot>
+                                <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                            </container>
+                            <extraDirectories>
+                                <paths>
+                                    <path>
+                                        <from>src/main/conf</from>
+                                        <into>/root/conf</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/scripts</from>
+                                        <into>/usr/bin</into>
+                                    </path>
+                                    <path>
+                                        <from>target/glowroot</from>
+                                        <into>/root/glowroot</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/extensions-jars</from>
+                                        <into>/root/extensions-jars</into>
+                                    </path>
+                                    <path>
+                                        <from>target/async-profiler-2.9-linux-x64</from>
+                                        <into>/root/async-profiler</into>
+                                    </path>
+                                </paths>
+                                <permissions>
+                                    <permission>
+                                        <file>/usr/bin/james-cli</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/profiler.sh</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/libasyncProfiler.so</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/jattach</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                </permissions>
+                            </extraDirectories>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -482,4 +482,112 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <from>
+                                <image>${jib.base.image}</image>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                            <to>
+                                <image>linagora/tmail-backend</image>
+                                <tags>
+                                    <tag>distributed-${env.DOCKER_TAG}</tag>
+                                </tags>
+                                <auth>
+                                    <username>${env.DOCKER_HUB_USER}</username>
+                                    <password>${env.DOCKER_HUB_TOKEN}</password>
+                                </auth>
+                            </to>
+                            <container>
+                                <mainClass>com.linagora.tmail.james.app.DistributedServer</mainClass>
+                                <ports>
+                                    <port>80</port> <!-- JMAP -->
+                                    <port>143</port> <!-- IMAP -->
+                                    <port>993</port> <!-- IMAPS -->
+                                    <port>25</port> <!-- SMTP -->
+                                    <port>465</port> <!-- SMTP + STARTTLS -->
+                                    <port>587</port> <!-- SMTPS -->
+                                    <port>4000</port> <!-- GLOWROOT, if activated -->
+                                    <port>4190</port> <!-- ManageSieve, if activated -->
+                                    <port>8000</port> <!-- WEBADMIN -->
+                                </ports>
+                                <appRoot>/root</appRoot>
+                                <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                            </container>
+                            <extraDirectories>
+                                <paths>
+                                    <path>
+                                        <from>src/main/conf</from>
+                                        <into>/root/conf</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/scripts</from>
+                                        <into>/usr/bin</into>
+                                    </path>
+                                    <path>
+                                        <from>target/glowroot</from>
+                                        <into>/root/glowroot</into>
+                                    </path>
+                                    <path>
+                                        <from>target/async-profiler-2.9-linux-x64</from>
+                                        <into>/root/async-profiler</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/extensions-jars</from>
+                                        <into>/root/extensions-jars</into>
+                                    </path>
+                                </paths>
+                                <permissions>
+                                    <permission>
+                                        <file>/usr/bin/james-cli</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/profiler.sh</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/libasyncProfiler.so</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/jattach</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                </permissions>
+                            </extraDirectories>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -305,4 +305,120 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <from>
+                                <image>${jib.base.image}</image>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                            <to>
+                                <image>linagora/tmail-backend</image>
+                                <tags>
+                                    <tag>memory-${env.DOCKER_TAG}</tag>
+                                </tags>
+                                <auth>
+                                    <username>${env.DOCKER_HUB_USER}</username>
+                                    <password>${env.DOCKER_HUB_TOKEN}</password>
+                                </auth>
+                            </to>
+                            <container>
+                                <mainClass>com.linagora.tmail.james.app.MemoryServer</mainClass>
+                                <ports>
+                                    <port>80</port> <!-- JMAP -->
+                                    <port>143</port> <!-- IMAP -->
+                                    <port>993</port> <!-- IMAPS -->
+                                    <port>25</port> <!-- SMTP -->
+                                    <port>465</port> <!-- SMTP + STARTTLS -->
+                                    <port>587</port> <!-- SMTPS -->
+                                    <port>4000</port> <!-- GLOWROOT, if activated -->
+                                    <port>4190</port> <!-- ManageSieve, if activated -->
+                                    <port>8000</port> <!-- WEBADMIN -->
+                                </ports>
+                                <appRoot>/root</appRoot>
+                                <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                            </container>
+                            <extraDirectories>
+                                <paths>
+                                    <path>
+                                        <from>src/main/conf</from>
+                                        <into>/root/conf</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/scripts</from>
+                                        <into>/usr/bin</into>
+                                    </path>
+                                    <path>
+                                        <from>target/glowroot</from>
+                                        <into>/root/glowroot</into>
+                                    </path>
+                                    <path>
+                                        <from>target/async-profiler-2.9-linux-x64</from>
+                                        <into>/root/async-profiler</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/extensions-jars</from>
+                                        <into>/root/extensions-jars</into>
+                                    </path>
+                                    <path>
+                                        <from>src/main/provisioning</from>
+                                        <into>/root/provisioning</into>
+                                    </path>
+                                </paths>
+                                <permissions>
+                                    <permission>
+                                        <file>/usr/bin/james-cli</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/profiler.sh</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/libasyncProfiler.so</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/async-profiler/build/jattach</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/root/provisioning/provisioning.sh</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                </permissions>
+                            </extraDirectories>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Why

Developers who use computers based on ARM CPU (e.g.: mobile team with MacBook, and me sometimes), will get poor performance. 

## How
- JIB supports it (only `jib:build` goal) https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image
- Create a new maven profile ("ci") for the configuration of multi-platform
- Jenkinsfile will use "CI" profile for the Delivery image

## Result 
- The Docker hub looks like this:
![image](https://github.com/linagora/tmail-backend/assets/81145350/3d7b758e-342a-4ee2-8556-b46e73491bc0)

- When running the `tmail-backend-memory` image on the arm CPU, it automatically fetches exactly os/arch by manifest
### Before
![image](https://github.com/linagora/tmail-backend/assets/81145350/a4feb6b3-eff7-4017-a745-0aa575e32749)

### After
![image](https://github.com/linagora/tmail-backend/assets/81145350/3b33d00a-6409-41b2-b5be-8e7ecab1367d)


