### PR TITLE
Force vhost parameter for RabbitMQ on address contact queues

### DIFF
--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/TestRabbitMQModule.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/TestRabbitMQModule.java
@@ -73,7 +73,8 @@ public class TestRabbitMQModule extends AbstractModule {
     public RabbitMQEmailAddressContactConfiguration rabbitMQEmailAddressContactConfiguration(RabbitMQConfiguration rabbitMQConfiguration) {
         return new RabbitMQEmailAddressContactConfiguration(ADDRESS_CONTACT_QUEUE,
             rabbitMQConfiguration.getUri(),
-            rabbitMQConfiguration.getManagementCredentials());
+            rabbitMQConfiguration.getManagementCredentials(),
+            rabbitMQConfiguration.getVhost());
     }
 
     @Provides

--- a/tmail-backend/jmap/extensions-rabbitmq/src/test/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactConfigurationTest.java
+++ b/tmail-backend/jmap/extensions-rabbitmq/src/test/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactConfigurationTest.java
@@ -13,12 +13,25 @@ import org.junit.jupiter.api.Test;
 class RabbitMQEmailAddressContactConfigurationTest {
 
     @Test
-    void amqpURIShouldSupportVhost() {
+    void amqpURIShouldSupportVhostInURI() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("address.contact.uri", "amqp://james:james@rabbitmqhost:5672/vhost1");
         configuration.addProperty("address.contact.user", "DEFAULT_USER");
         configuration.addProperty("address.contact.password", "DEFAULT_PASSWORD");
         configuration.addProperty("address.contact.queue", "DEFAULT_QUEUE");
+
+        assertThat(RabbitMQEmailAddressContactConfiguration.from(configuration).vhost())
+            .isEqualTo(Optional.of("vhost1"));
+    }
+
+    @Test
+    void amqpURIShouldSupportDefaultVhost() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("address.contact.uri", "amqp://james:james@rabbitmqhost:5672");
+        configuration.addProperty("address.contact.user", "DEFAULT_USER");
+        configuration.addProperty("address.contact.password", "DEFAULT_PASSWORD");
+        configuration.addProperty("address.contact.queue", "DEFAULT_QUEUE");
+        configuration.addProperty("vhost", "vhost1");
 
         assertThat(RabbitMQEmailAddressContactConfiguration.from(configuration).vhost())
             .isEqualTo(Optional.of("vhost1"));

--- a/tmail-backend/jmap/extensions-rabbitmq/src/test/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactSubscriberTest.java
+++ b/tmail-backend/jmap/extensions-rabbitmq/src/test/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactSubscriberTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -55,7 +56,8 @@ class RabbitMQEmailAddressContactSubscriberTest {
         rabbitMQEmailAddressContactConfiguration = new RabbitMQEmailAddressContactConfiguration(
             aqmpContactQueue,
             URI.create("amqp://james:james@rabbitmqhost:5672"),
-            mock(RabbitMQConfiguration.ManagementCredentials.class));
+            mock(RabbitMQConfiguration.ManagementCredentials.class),
+            Optional.empty());
 
         searchEngine = new InMemoryEmailAddressContactSearchEngine();
         subscriber = new RabbitMQEmailAddressContactSubscriber(rabbitMQExtension.getReceiverProvider(),


### PR DESCRIPTION
Getting the vhost from the uri should be a fallback in case it's not present, like for other queues definition

Note: The fact that we don't have those queues in the vhost in most of our deployments is because we don't add it in the `address.contact.uri` parameter.