### PR TITLE
[FIX] Remove module chooser for deleted message vault for TMail Postgres app

### DIFF
--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
@@ -18,7 +18,6 @@ import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.server.core.configuration.FileConfigurationProvider;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.apache.james.utils.PropertiesProvider;
-import org.apache.james.vault.VaultConfiguration;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.UsersRepositoryModuleChooser;
@@ -36,8 +35,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                                          LinagoraServicesDiscoveryModuleChooserConfiguration linagoraServicesDiscoveryModuleChooserConfiguration,
                                          boolean jmapEnabled,
                                          PropertiesProvider propertiesProvider,
-                                         PostgresJamesConfiguration.EventBusImpl eventBusImpl,
-                                         VaultConfiguration deletedMessageVaultConfiguration) implements Configuration {
+                                         PostgresJamesConfiguration.EventBusImpl eventBusImpl) implements Configuration {
     public static class Builder {
         private Optional<MailboxConfiguration> mailboxConfiguration;
         private Optional<SearchConfiguration> searchConfiguration;
@@ -49,9 +47,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
         private Optional<FirebaseModuleChooserConfiguration> firebaseModuleChooserConfiguration;
         private Optional<LinagoraServicesDiscoveryModuleChooserConfiguration> linagoraServicesDiscoveryModuleChooserConfiguration;
         private Optional<Boolean> jmapEnabled;
-
         private Optional<PostgresJamesConfiguration.EventBusImpl> eventBusImpl;
-        private Optional<VaultConfiguration> deletedMessageVaultConfiguration;
 
         private Builder() {
             searchConfiguration = Optional.empty();
@@ -65,7 +61,6 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             linagoraServicesDiscoveryModuleChooserConfiguration = Optional.empty();
             jmapEnabled = Optional.empty();
             eventBusImpl = Optional.empty();
-            deletedMessageVaultConfiguration = Optional.empty();
         }
 
         public Builder workingDirectory(String path) {
@@ -141,11 +136,6 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             return this;
         }
 
-        public Builder deletedMessageVaultConfiguration(VaultConfiguration deletedMessageVaultConfiguration) {
-            this.deletedMessageVaultConfiguration = Optional.of(deletedMessageVaultConfiguration);
-            return this;
-        }
-
         public PostgresTmailConfiguration build() {
             ConfigurationPath configurationPath = this.configurationPath.orElse(new ConfigurationPath(FileSystem.FILE_PROTOCOL_AND_CONF));
             JamesServerResourceLoader directories = new JamesServerResourceLoader(rootDirectory
@@ -191,16 +181,6 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
 
             PostgresJamesConfiguration.EventBusImpl eventBusImpl = this.eventBusImpl.orElseGet(() -> PostgresJamesConfiguration.EventBusImpl.from(propertiesProvider));
 
-            VaultConfiguration deletedMessageVaultConfiguration = this.deletedMessageVaultConfiguration.orElseGet(() -> {
-                try {
-                    return VaultConfiguration.from(propertiesProvider.getConfiguration("deletedMessageVault"));
-                } catch (FileNotFoundException e) {
-                    return VaultConfiguration.DEFAULT;
-                } catch (ConfigurationException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-
             return new PostgresTmailConfiguration(
                 configurationPath,
                 directories,
@@ -213,8 +193,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                 servicesDiscoveryModuleChooserConfiguration,
                 jmapEnabled,
                 propertiesProvider,
-                eventBusImpl,
-                deletedMessageVaultConfiguration);
+                eventBusImpl);
         }
     }
 

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -118,7 +118,6 @@ public class PostgresTmailServer {
             .combineWith(chooseUserRepositoryModule(configuration))
             .combineWith(chooseBlobStoreModules(configuration))
             .combineWith(chooseEventBusModules(configuration))
-            .combineWith(chooseDeletedMessageVaultModules(configuration))
             .combineWith(chooseRedisRateLimiterModule(configuration))
             .combineWith(chooseRspamdModule(configuration))
             .combineWith(chooseFirebase(configuration.firebaseModuleChooserConfiguration()))
@@ -128,6 +127,7 @@ public class PostgresTmailServer {
     private static final Module WEBADMIN = Modules.combine(
         new WebAdminServerModule(),
         new DataRoutesModules(),
+        new DeletedMessageVaultRoutesModule(),
         new InconsistencyQuotasSolvingRoutesModule(),
         new MailboxRoutesModule(),
         new MailQueueRoutesModule(),
@@ -182,7 +182,8 @@ public class PostgresTmailServer {
         new TaskManagerModule(),
         new PostgresEventStoreModule(),
         new TikaMailboxModule(),
-        new PostgresVacationModule());
+        new PostgresVacationModule(),
+        new PostgresDeletedMessageVaultModule());
 
     private static final Module POSTGRES_MODULE_AGGREGATE = Modules.override(Modules.combine(
         new MailetProcessingModule(), POSTGRES_SERVER_MODULE, PROTOCOLS, JMAP_LINAGORA))
@@ -214,10 +215,6 @@ public class PostgresTmailServer {
                 DatabaseCombinedUserRequireModule.of(PostgresUsersDAO.class),
                 new PostgresUsersRepositoryModule())
                 .chooseModule(configuration.usersRepositoryImplementation()));
-    }
-
-    private static Module chooseDeletedMessageVaultModules(PostgresTmailConfiguration configuration) {
-        return Modules.combine(new PostgresDeletedMessageVaultModule(), new DeletedMessageVaultRoutesModule());
     }
 
     private static Module chooseRedisRateLimiterModule(PostgresTmailConfiguration configuration) {


### PR DESCRIPTION
cf TMail Distributed app: deleted message vault was always loaded e.g. for JMAP EmailRecoveryAction method