### PR TITLE
ISSUE-919 Integration tests for TMail JMAP - Remove "@Disabled" test in PostgresEmailQueryMethod

### DIFF
--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailQueryMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailQueryMethodTest.java
@@ -61,21 +61,4 @@ public class PostgresEmailQueryMethodTest implements EmailQueryMethodContract {
         .extension(new ClockExtension())
         .build();
 
-    @Override
-    @Test
-    @Disabled("Flaky test. TODO stabilize it.")
-    public void listMailsShouldBeSortedWhenUsingTo(GuiceJamesServer server) {
-    }
-
-    @Override
-    @Test
-    @Disabled("Flaky test. TODO stabilize it.")
-    public void listMailsShouldBeSortedWhenUsingFrom(GuiceJamesServer server) {
-    }
-
-    @Override
-    @Test
-    @Disabled("Flaky test. TODO stabilize it.")
-    public void inMailboxOtherThanShouldBeRejectedWhenInOperator(GuiceJamesServer server) {
-    }
 }


### PR DESCRIPTION
after https://github.com/apache/james-project/pull/2183