### PR TITLE
[FIX] FCM: do not flag background update (`content-available=1`) for EmailDelivery notifications

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebasePushClient.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebasePushClient.java
@@ -115,7 +115,6 @@ public class FirebasePushClient {
                     .setTitle("Twake Mail")
                     .setBody("You have new message")
                     .build())
-                .setContentAvailable(true)
                 .setMutableContent(true)
                 .build();
         }


### PR DESCRIPTION
cf: https://github.com/linagora/tmail-backend/commit/43c49615a06edb850fdd7d4b35fbd05873dfc6af#r141977107

cc @tddang-linagora I deployed this fix on staging.