### PR TITLE
ISSUE-951 Add method=REPLY parameter in the header content-type of th…

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventReplyPerformer.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventReplyPerformer.scala
@@ -183,7 +183,7 @@ class CalendarEventMailReplyGenerator(val bodyPartContentGenerator: CalendarRepl
       .map(calendarReply => calendarReply.toString.getBytes(StandardCharsets.UTF_8))
       .map(calendarAsByte => Seq(MimeMessageBuilder.bodyPartBuilder
         .data(calendarAsByte)
-        .addHeader("Content-Type", "text/calendar; charset=UTF-8"),
+        .addHeader("Content-Type", "text/calendar; charset=UTF-8; method=REPLY"),
         MimeMessageBuilder.bodyPartBuilder
           .data(calendarAsByte)
           .filename(ICS_FILE_NAME)


### PR DESCRIPTION
…e ics generated reply

Some mail providers like Outlook need it to recognize it as a calendar event and update their calendar with it automatically