### PR TITLE
ISSUE-1124 Apply docker restart policy: restart on failure

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ./tmail/usersrepository.xml:/root/conf/usersrepository.xml
     networks:
       - tmail
+    restart: on-failure
 
   sso.example.com:
     image: yadd/lemonldap-ng-full

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
                     <configuration>
                         <container>
                             <jvmFlags>
+                                <jvmFlag>-XX:+ExitOnOutOfMemoryError</jvmFlag>
                                 <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
                                 <jvmFlag>-Dworking.directory=/root/</jvmFlag>
                             </jvmFlags>

--- a/tmail-backend/apps/distributed/docker-compose.yml
+++ b/tmail-backend/apps/distributed/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       # Key generation:
       # openssl genrsa -out jwt_privatekey 4096
       # openssl rsa -in jwt_privatekey -pubout > jwt_publickey
+    restart: on-failure
 
   opensearch:
     image: opensearchproject/opensearch:2.1.0


### PR DESCRIPTION
When the container exits with an error code > 0 (except `docker stop`), the container will be restarted automatically by Docker daemon.

https://github.com/user-attachments/assets/605026fb-2683-4239-a152-1fc775c74bac


Docker health check is not related to this Docker restart policy.

But if we want to customize the restart condition, we can combine Docker health check + a script to monitor the container's health status.