### PR TITLE
ISSUE-1124 Implement liveness-like for tmail-backend container

### DIFF
--- a/tmail-backend/apps/distributed/docker-compose.yml
+++ b/tmail-backend/apps/distributed/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '3'
+version: '3.8'
 
 networks:
   emaily:
     driver: bridge
 
 services:
-  james:
+  tmail-backend:
     depends_on:
       cassandra:
         condition: service_healthy
@@ -20,8 +20,8 @@ services:
       s3:
         condition: service_started
     image: linagora/tmail-backend-distributed
-    container_name: james
-    hostname: james.local
+    container_name: tmail-backend
+    hostname: tmail-backend.local
     ports:
       - "80:80"
       - "25:25"
@@ -40,6 +40,22 @@ services:
       # openssl genrsa -out jwt_privatekey 4096
       # openssl rsa -in jwt_privatekey -pubout > jwt_publickey
     restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "wget -O- -S http://localhost:8000/healthcheck/checks/Cassandra%20backend | grep -q 'healthy' || exit 1"]
+      interval: 60s
+      timeout: 30s
+      retries: 2
+      start_period: 60s # require upper Docker v25
+
+  monitor-tmail-backend:
+    image: docker:27-cli
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./monitor_health.sh:/monitor_health.sh
+    depends_on:
+      tmail-backend:
+        condition: service_healthy
+    entrypoint: [ "sh", "/monitor_health.sh", "tmail-backend"]
 
   opensearch:
     image: opensearchproject/opensearch:2.1.0

--- a/tmail-backend/apps/distributed/monitor_health.sh
+++ b/tmail-backend/apps/distributed/monitor_health.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script monitors the health of a container (the container needs to be configured with a healthcheck).
+# If the container is unhealthy, the script restarts the container.
+
+# Function to get the current timestamp
+timestamp() {
+  date +"%Y-%m-%d %H:%M:%S %Z"
+}
+
+# Check if CONTAINER_NAME argument is provided
+if [ -z "$1" ]; then
+  echo "Error: Please provide the CONTAINER_NAME as an argument."
+  exit 1
+fi
+
+CONTAINER_NAME="$1"
+INTERVAL_IN_SECOND=30
+
+echo "[$(timestamp)]: Start monitoring container $CONTAINER_NAME health."
+
+while true; do
+  CONTAINER_HEALTH_STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER_NAME")
+
+  if [ "$CONTAINER_HEALTH_STATUS" == "unhealthy" ]; then
+    echo "[$(timestamp)]: Container $CONTAINER_NAME is unhealthy! Restarting the container..."
+
+    if docker restart "$CONTAINER_NAME"; then
+      echo "[$(timestamp)]: Container $CONTAINER_NAME restarted."
+    else
+      echo "[$(timestamp)]: Failed to restart container $CONTAINER_NAME."
+    fi
+  fi
+
+  sleep "$INTERVAL_IN_SECOND"
+done


### PR DESCRIPTION
- tmail-backend container would be marked as `healthy` after it fully started.
- tmail-backend container would be restarted upon the container being `unhealthy`, until it is `healthy` again.

https://github.com/user-attachments/assets/c7b83427-e7f7-483d-804b-0326f97d56a2

