### PR TITLE
ISSUE-624 Apisix plugin runner - support redis sentinel

### DIFF
--- a/demo/apisix/tmail-apisix-plugin-runner/README.md
+++ b/demo/apisix/tmail-apisix-plugin-runner/README.md
@@ -39,28 +39,49 @@ ext-plugin:
 - Be default the plugin use in-memory for storage. 
 ### Redis
 - Provide the properties
-    - `redis.url` (or environment `REDIS_URL`): [String] the redis url. For several url, use `,` character for separate
+    - `redis.topology` (or environment `REDIS_TOPOLOGY`): [String] the redis topology. Default to `standalone`. Available values: `standalone`, `cluster`, `sentinel`, `master_replica`
+    - `redis.url` (or environment `REDIS_URL`): [String] the redis url. 
+        - For standalone topology, it is the format `host:port`. 
+        - For cluster topology, it is the format `host1:port1,host2:port2,...`. 
+        - For master-replica topology, it is the format `masterHost:masterPort,replicaHost1:replicaPort1,replicaHost2:replicaPort2,...`
+        - For sentinel topology, it is the format `redis-sentinel://secret1@sentinel-1:26379,sentinel-2:26379,sentinel-3:26379?sentinelMasterId=mymaster`. Ref: https://github.com/redis/lettuce/wiki/Redis-URI-and-connection-details#uri-syntax
     - `redis.password` (or environment `REDIS_PASSWORD`): [String] the redis password (Optional).
-    - `redis.cluster.enabled` (or environment `REDIS_CLUSTER_ENABLE`): [Boolean]. `true` for redis master-replicas topology, 
-    `false` for standalone topology
     - `redis.timeout` (or environment `REDIS_TIMEOUT`): [Integer] the timeout for redis command when client send to Redis server. Default to 5000 (5 seconds)
     - `redis.ignoreErrors` (or environment `REDIS_IGNORE_ERRORS`): [Boolean]. This configuration determines whether errors from Redis should be ignored or not. If set to `true`, when the application is unable to connect to Redis, the revoked token will not be checked. Default to true
 
-Eg: 
+Eg:
+- For standalone redis
 ```yaml
 redis:
   url: redis.example.com:6379
   password: secret1
-  cluster.enable: false 
+  topology: standalone 
   timeout: 5000
   ignoreErrors: true
 ```
-or
+- For cluster redis
 ```yaml
 redis:
   url: redis-master.example.com:6379,redis-replica1.example.com:6379
   password: secret1
-  cluster.enable: true
+  topology: cluster
+  timeout: 5000
+  ignoreErrors: true
+```
+- For master-replica redis
+```yaml
+redis:
+  url: redis-master.example.com:6379,redis-replica1.example.com:6379
+  password: secret1
+  topology: master_replica
+  timeout: 5000
+  ignoreErrors: true
+```
+- For sentinel redis
+```yaml
+redis:
+  url: redis-sentinel://secret1@sentinel-1:26379,sentinel-2:26379,sentinel-3:26379?sentinelMasterId=mymaster
+  topology: sentinel
   timeout: 5000
   ignoreErrors: true
 ```

--- a/demo/apisix/tmail-apisix-plugin-runner/src/main/resources/application.yaml
+++ b/demo/apisix/tmail-apisix-plugin-runner/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ socket:
 redis:
   url: ${REDIS_URL:localhost:6379}
   password: ${REDIS_PASSWORD:}
-  cluster.enable: ${REDIS_CLUSTER_ENABLE:false}
+  topology: ${REDIS_TOPOLOGY:standalone}
   ignoreErrors: ${REDIS_IGNORE_ERRORS:true}
   timeout: ${REDIS_TIMEOUT:5000}
 

--- a/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/ClusterRedisRevokedTokenRepositoryTest.java
+++ b/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/ClusterRedisRevokedTokenRepositoryTest.java
@@ -75,10 +75,10 @@ class ClusterRedisRevokedTokenRepositoryTest implements RevokedTokenRepositoryCo
 
     @BeforeEach
     void setup() {
-        RedisStringCommands<String, String> stringStringRedisStringCommands = AppConfiguration.initRedisCommand(
+        RedisStringCommands<String, String> stringStringRedisStringCommands = AppConfiguration.initRedisCommandCluster(
             String.format("localhost:%d,localhost:%d",
                 REDIS_MASTER.getMappedPort(6379), REDIS_REPLICA.getMappedPort(6379)),
-            REDIS_PASSWORD, true, Duration.ofSeconds(3));
+            REDIS_PASSWORD,  Duration.ofSeconds(3));
 
         revokedTokenRepository = new RedisRevokedTokenRepository(stringStringRedisStringCommands, IGNORE_REDIS_ERRORS);
     }
@@ -121,10 +121,10 @@ class ClusterRedisRevokedTokenRepositoryTest implements RevokedTokenRepositoryCo
     @Test
     void existsShouldThrowWhenIgnoreWasNotConfiguredAndRedisError() throws InterruptedException {
         boolean ignoreRedisErrors = false;
-        RedisRevokedTokenRepository testee = new RedisRevokedTokenRepository(AppConfiguration.initRedisCommand(
+        RedisRevokedTokenRepository testee = new RedisRevokedTokenRepository(AppConfiguration.initRedisCommandCluster(
             String.format("localhost:%d,localhost:%d",
                 REDIS_MASTER.getMappedPort(6379), REDIS_REPLICA.getMappedPort(6379)),
-            REDIS_PASSWORD, true, Duration.ofSeconds(3)), ignoreRedisErrors);
+            REDIS_PASSWORD,  Duration.ofSeconds(3)), ignoreRedisErrors);
 
         ContainerHelper.pause(REDIS_MASTER);
         TimeUnit.SECONDS.sleep(1);

--- a/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisMasterReplicaRevokedTokenRepositoryTest.java
+++ b/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisMasterReplicaRevokedTokenRepositoryTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.sync.RedisStringCommands;
 
-class ClusterRedisRevokedTokenRepositoryTest implements RevokedTokenRepositoryContract {
+class RedisMasterReplicaRevokedTokenRepositoryTest implements RevokedTokenRepositoryContract {
     private static final String REDIS_PASSWORD = "my_password";
 
     static Network dockernetwork = Network.newNetwork();

--- a/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisMasterReplicaRevokedTokenRepositoryTest.java
+++ b/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisMasterReplicaRevokedTokenRepositoryTest.java
@@ -75,7 +75,7 @@ class RedisMasterReplicaRevokedTokenRepositoryTest implements RevokedTokenReposi
 
     @BeforeEach
     void setup() {
-        RedisStringCommands<String, String> stringStringRedisStringCommands = AppConfiguration.initRedisCommandCluster(
+        RedisStringCommands<String, String> stringStringRedisStringCommands = AppConfiguration.initRedisCommandMasterReplica(
             String.format("localhost:%d,localhost:%d",
                 REDIS_MASTER.getMappedPort(6379), REDIS_REPLICA.getMappedPort(6379)),
             REDIS_PASSWORD,  Duration.ofSeconds(3));
@@ -121,7 +121,7 @@ class RedisMasterReplicaRevokedTokenRepositoryTest implements RevokedTokenReposi
     @Test
     void existsShouldThrowWhenIgnoreWasNotConfiguredAndRedisError() throws InterruptedException {
         boolean ignoreRedisErrors = false;
-        RedisRevokedTokenRepository testee = new RedisRevokedTokenRepository(AppConfiguration.initRedisCommandCluster(
+        RedisRevokedTokenRepository testee = new RedisRevokedTokenRepository(AppConfiguration.initRedisCommandMasterReplica(
             String.format("localhost:%d,localhost:%d",
                 REDIS_MASTER.getMappedPort(6379), REDIS_REPLICA.getMappedPort(6379)),
             REDIS_PASSWORD,  Duration.ofSeconds(3)), ignoreRedisErrors);

--- a/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisSentinelRevokedTokenRepositoryTest.java
+++ b/demo/apisix/tmail-apisix-plugin-runner/src/test/java/com/linagora/apisix/plugin/RedisSentinelRevokedTokenRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.linagora.apisix.plugin;
+
+import static com.linagora.apisix.plugin.RedisRevokedTokenRepository.IGNORE_REDIS_ERRORS;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.api.sync.RedisStringCommands;
+
+@Disabled("This test is disabled because it requires a Redis Sentinel cluster to be running, for manual testing only, " +
+    "can run Redis Sentinel cluster by using docker-compose sample at https://github.com/apache/james-project/blob/149595da247dfb915ecb60d239edf627616916ae/server/mailet/rate-limiter-redis/docker-compose-sample/docker-compose-with-redis-sentinel.yml")
+public class RedisSentinelRevokedTokenRepositoryTest implements RevokedTokenRepositoryContract {
+
+    static final String REDIS_SENTINEL_URL = "redis-sentinel://secret1@localhost:26379,localhost:26380,localhost:26381?sentinelMasterId=mymaster";
+
+    RedisRevokedTokenRepository revokedTokenRepository;
+
+    RedisStringCommands<String, String> stringStringRedisStringCommands;
+
+    @BeforeEach
+    void setup() {
+        stringStringRedisStringCommands = AppConfiguration.initRedisCommandSentinel(
+            REDIS_SENTINEL_URL, Duration.ofSeconds(3));
+        revokedTokenRepository = new RedisRevokedTokenRepository(stringStringRedisStringCommands, IGNORE_REDIS_ERRORS);
+    }
+
+    @AfterEach
+    void afterEach() {
+        RedisClient redisClient = RedisClient.create(REDIS_SENTINEL_URL);
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+        RedisCommands<String, String> syncCommands = connection.sync();
+        syncCommands.flushall();
+    }
+
+    @Override
+    public IRevokedTokenRepository testee() {
+        return revokedTokenRepository;
+    }
+}


### PR DESCRIPTION
## Why?
For [MU] deployment, SSO, Apisix, and Redis Sentinel are required.
 The current `tmail-apisix-plugin-runner` does not support configuration parsing for Sentinel.

## Some note for this change of this pr
- Rename `ClusterRedisRevokedTokenRepositoryTest` -> `RedisMasterReplicaRevokedTokenRepositoryTest`
 to reflect the master-replica topology of the test container, reducing potential confusion.
- `RedisSentinelRevokedTokenRepositoryTest`: Placeholder for a manual test (I performed it, and it works).
- :white_check_mark: Rebuild the image `linagora/apisix:3.2.0-debian-javaplugin` and successfully start it with Redis Sentinel.
![Screenshot_20240726_181630](https://github.com/user-attachments/assets/bbee57de-19c5-4211-8ce5-b79a3ed55d68)

