### PR TITLE
ISSUE-624 New tag for Linagora apisix image

### DIFF
--- a/demo/apisix/README.md
+++ b/demo/apisix/README.md
@@ -5,4 +5,4 @@ Runs Apisix with the TeamMail plugin for OIDC single logout
 In order to build the image:
 
 0. Build the plugin for Apisix: `cd tmail-apisix-plugin-runner && mvn clean package`
-1. Build the image: `docker build -t linagora/apisix:3.2.0-debian-javaplugin .`
+1. Build the image: `docker build -t linagora/apisix:3.2.0-debian-javaplugin-0.2 .`

--- a/demo/apisix/tmail-apisix-plugin-runner/README.md
+++ b/demo/apisix/tmail-apisix-plugin-runner/README.md
@@ -13,7 +13,7 @@ mvn clean package
 ```
 
 ## How to use it
-- Build Apisix docker image that support Java plugin runner : `docker build -t linagora/apisix:3.2.0-debian-javaplugin .`
+- Build Apisix docker image that support Java plugin runner : `docker build -t linagora/apisix:3.2.0-debian-javaplugin-0.2 .`
 - Configuration the plugin in `/usr/local/apisix/conf/config.yaml` of apisix container
     - Append: 
 ```yaml

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 
   apisix:
     container_name: apisix.example.com
-    image: linagora/apisix:3.2.0-debian-javaplugin
+    image: linagora/apisix:3.2.0-debian-javaplugin-0.2
     volumes:
       - ./apisix/conf/apisix.yaml:/usr/local/apisix/conf/apisix.yaml
       - ./apisix/conf/config.yaml:/usr/local/apisix/conf/config.yaml


### PR DESCRIPTION
Pushed `linagora/apisix:3.2.0-debian-sentinel-javaplugin` to the linagora docker repo already