### PR TITLE
Upgrade apisix base image to 3.9.1-debian

### DIFF
--- a/demo/apisix/Dockerfile
+++ b/demo/apisix/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/apisix:3.2.0-debian
+FROM apache/apisix:3.9.1-debian
 USER root
 RUN apt-get update && apt -y install openjdk-11-jre-headless
 ADD apache-apisix-java-plugin-runner-0.4.0-bin.tar.gz /usr/local/

--- a/demo/apisix/README.md
+++ b/demo/apisix/README.md
@@ -5,4 +5,4 @@ Runs Apisix with the TeamMail plugin for OIDC single logout
 In order to build the image:
 
 0. Build the plugin for Apisix: `cd tmail-apisix-plugin-runner && mvn clean package`
-1. Build the image: `docker build -t linagora/apisix:3.2.0-debian-javaplugin-0.2 .`
+1. Build the image: `docker build -t linagora/apisix:3.9.1-debian-javaplugin .`

--- a/demo/apisix/tmail-apisix-plugin-runner/README.md
+++ b/demo/apisix/tmail-apisix-plugin-runner/README.md
@@ -13,7 +13,7 @@ mvn clean package
 ```
 
 ## How to use it
-- Build Apisix docker image that support Java plugin runner : `docker build -t linagora/apisix:3.2.0-debian-javaplugin-0.2 .`
+- Build Apisix docker image that support Java plugin runner : `docker build -t linagora/apisix:3.9.1-debian-javaplugin .`
 - Configuration the plugin in `/usr/local/apisix/conf/config.yaml` of apisix container
     - Append: 
 ```yaml

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 
   apisix:
     container_name: apisix.example.com
-    image: linagora/apisix:3.2.0-debian-javaplugin-0.2
+    image: linagora/apisix:3.9.1-debian-javaplugin
     volumes:
       - ./apisix/conf/apisix.yaml:/usr/local/apisix/conf/apisix.yaml
       - ./apisix/conf/config.yaml:/usr/local/apisix/conf/config.yaml


### PR DESCRIPTION
From the local docker compose test I could check quickly it seems to still work. But let's test it first on a staging environment before moving to it