### PR TITLE
Add a module chooser for deleted message vault on distributed server

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
@@ -62,3 +62,13 @@ Default to 20MB. Supported units are B (bytes) K (KB) M (MB) G (GB).
 
 Example: `public.asset.total.size=20MB`.
 |===
+
+== Deleted message vault configuration
+
+By default on Tmail backend, the deleted message vault is enabled (contrary to James server where it is disabled).
+
+It is still possible to disable it by modifying the following property on `deletedMessageVault.properties`:
+
+....
+enabled=false
+....

--- a/tmail-backend/apps/distributed/src/main/conf/deletedMessageVault.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/deletedMessageVault.properties
@@ -1,4 +1,15 @@
 # ============================================= Deleted Messages Vault Configuration ==================================
+
+enabled=true
+
+# Enable work queue to be used with deleted message vault
+# Default to false
+# workQueueEnabled=false
+
 # Retention period for your deleted messages into the vault, after which they expire and can be potentially cleaned up
 # Optional, default 1y
 # retentionPeriod=1y
+
+# Messages restored from the Deleted Messages Vault are placed in a mailbox with this name (default: ``Restored-Messages``).
+# The mailbox will be created if it does not exist yet.
+# restoreLocation=Restored-Messages

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
@@ -229,7 +229,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                 try {
                     return VaultConfiguration.from(propertiesProvider.getConfiguration("deletedMessageVault"));
                 } catch (FileNotFoundException e) {
-                    return VaultConfiguration.DEFAULT;
+                    return VaultConfiguration.ENABLED_DEFAULT;
                 } catch (ConfigurationException e) {
                     throw new RuntimeException(e);
                 }

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
@@ -16,6 +16,7 @@ import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.server.core.configuration.FileConfigurationProvider;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.apache.james.utils.PropertiesProvider;
+import org.apache.james.vault.VaultConfiguration;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.blob.blobid.list.BlobStoreConfiguration;
@@ -36,7 +37,8 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                                             PropertiesProvider propertiesProvider,
                                             boolean quotaCompatibilityMode,
                                             EventBusKeysChoice eventBusKeysChoice,
-                                            boolean dropListEnabled) implements Configuration {
+                                            boolean dropListEnabled,
+                                            VaultConfiguration vaultConfiguration) implements Configuration {
     public static class Builder {
         private Optional<MailboxConfiguration> mailboxConfiguration;
         private Optional<SearchConfiguration> searchConfiguration;
@@ -51,6 +53,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
         private Optional<EventBusKeysChoice> eventBusKeysChoice;
         private Optional<Boolean> quotaCompatibilityMode;
         private Optional<Boolean> dropListsEnabled;
+        private Optional<VaultConfiguration> vaultConfiguration;
 
         private Builder() {
             searchConfiguration = Optional.empty();
@@ -66,6 +69,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
             quotaCompatibilityMode = Optional.empty();
             eventBusKeysChoice = Optional.empty();
             dropListsEnabled = Optional.empty();
+            vaultConfiguration = Optional.empty();
         }
 
         public Builder workingDirectory(String path) {
@@ -151,6 +155,11 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
             return this;
         }
 
+        public Builder vaultConfiguration(VaultConfiguration vaultConfiguration) {
+            this.vaultConfiguration = Optional.of(vaultConfiguration);
+            return this;
+        }
+
         public DistributedJamesConfiguration build() {
             ConfigurationPath configurationPath = this.configurationPath.orElse(new ConfigurationPath(FileSystem.FILE_PROTOCOL_AND_CONF));
             JamesServerResourceLoader directories = new JamesServerResourceLoader(rootDirectory
@@ -216,6 +225,16 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                 }
             });
 
+            VaultConfiguration vaultConfiguration = this.vaultConfiguration.orElseGet(() -> {
+                try {
+                    return VaultConfiguration.from(propertiesProvider.getConfiguration("deletedMessageVault"));
+                } catch (FileNotFoundException e) {
+                    return VaultConfiguration.DEFAULT;
+                } catch (ConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
             return new DistributedJamesConfiguration(
                 configurationPath,
                 directories,
@@ -230,7 +249,8 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                 propertiesProvider,
                 quotaCompatibilityMode,
                 eventBusKeysChoice,
-                dropListsEnabled);
+                dropListsEnabled,
+                vaultConfiguration);
         }
     }
 

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -235,7 +235,6 @@ public class DistributedServer {
         new KeystoreSetMethodModule(),
         new TicketRoutesModule(),
         new WebFingerModule(),
-        new EmailRecoveryActionMethodModule(),
         new LabelMethodModule(),
         new JmapSettingsMethodModule())
         .with(new CassandraTicketStoreModule(), new TeamMailboxJmapModule());
@@ -485,12 +484,14 @@ public class DistributedServer {
         if (vaultConfiguration.isEnabled() && vaultConfiguration.isWorkQueueEnabled()) {
             return Modules.combine(
                 new DistributedDeletedMessageVaultModule(),
-                new DeletedMessageVaultRoutesModule());
+                new DeletedMessageVaultRoutesModule(),
+                new EmailRecoveryActionMethodModule());
         }
         if (vaultConfiguration.isEnabled()) {
             return Modules.combine(
                 new CassandraDeletedMessageVaultModule(),
-                new DeletedMessageVaultRoutesModule());
+                new DeletedMessageVaultRoutesModule(),
+                new EmailRecoveryActionMethodModule());
         }
         return binder -> {
 

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -53,6 +53,7 @@ import org.apache.james.modules.mailbox.CassandraMailboxQuotaLegacyModule;
 import org.apache.james.modules.mailbox.CassandraMailboxQuotaModule;
 import org.apache.james.modules.mailbox.CassandraQuotaMailingModule;
 import org.apache.james.modules.mailbox.CassandraSessionModule;
+import org.apache.james.modules.mailbox.DistributedDeletedMessageVaultModule;
 import org.apache.james.modules.mailbox.OpenSearchClientModule;
 import org.apache.james.modules.mailbox.OpenSearchDisabledModule;
 import org.apache.james.modules.mailbox.OpenSearchMailboxModule;
@@ -96,6 +97,7 @@ import org.apache.james.quota.search.scanning.ScanningQuotaSearcher;
 import org.apache.james.rate.limiter.redis.RedisRateLimiterModule;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
+import org.apache.james.vault.VaultConfiguration;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -189,7 +191,6 @@ public class DistributedServer {
     public static final Module WEBADMIN = Modules.combine(
         new CassandraRoutesModule(),
         new DataRoutesModules(),
-        new DeletedMessageVaultRoutesModule(),
         new DLPRoutesModule(),
         new InconsistencyQuotasSolvingRoutesModule(),
         new InconsistencySolvingRoutesModule(),
@@ -272,7 +273,6 @@ public class DistributedServer {
     public static final Module CASSANDRA_MAILBOX_MODULE = Modules.combine(
         new CassandraConsistencyTaskSerializationModule(),
         new CassandraMailboxModule(),
-        new CassandraDeletedMessageVaultModule(),
         new MailboxModule(),
         new TikaMailboxModule());
 
@@ -338,6 +338,7 @@ public class DistributedServer {
             .combineWith(chooseRedisRateLimiterModule(configuration))
             .combineWith(chooseRspamdModule(configuration))
             .combineWith(chooseQuotaModule(configuration))
+            .combineWith(chooseDeletedMessageVault(configuration.vaultConfiguration()))
             .overrideWith(chooseModules(searchConfiguration))
             .overrideWith(chooseMailbox(configuration.mailboxConfiguration()))
             .overrideWith(chooseJmapModule(configuration))
@@ -474,6 +475,22 @@ public class DistributedServer {
     private static Module chooseDropListsModule(DistributedJamesConfiguration configuration) {
         if (configuration.dropListEnabled()) {
             return Modules.combine(new CassandraDropListsModule(), new DropListsRoutesModule());
+        }
+        return binder -> {
+
+        };
+    }
+
+    private static Module chooseDeletedMessageVault(VaultConfiguration vaultConfiguration) {
+        if (vaultConfiguration.isEnabled() && vaultConfiguration.isWorkQueueEnabled()) {
+            return Modules.combine(
+                new DistributedDeletedMessageVaultModule(),
+                new DeletedMessageVaultRoutesModule());
+        }
+        if (vaultConfiguration.isEnabled()) {
+            return Modules.combine(
+                new CassandraDeletedMessageVaultModule(),
+                new DeletedMessageVaultRoutesModule());
         }
         return binder -> {
 

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/AwsS3BlobStoreExtension.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/AwsS3BlobStoreExtension.java
@@ -1,0 +1,31 @@
+package com.linagora.tmail.james.app;
+
+import org.apache.james.GuiceModuleTestExtension;
+import org.apache.james.blob.objectstorage.aws.DockerAwsS3Singleton;
+import org.apache.james.modules.objectstorage.aws.s3.DockerAwsS3TestRule;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.inject.Module;
+
+public class AwsS3BlobStoreExtension implements GuiceModuleTestExtension {
+
+    private final DockerAwsS3TestRule awsS3TestRule;
+
+    public AwsS3BlobStoreExtension() {
+        this.awsS3TestRule = new DockerAwsS3TestRule();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        ensureAwsS3started();
+    }
+
+    private void ensureAwsS3started() {
+        DockerAwsS3Singleton.singleton.dockerAwsS3();
+    }
+
+    @Override
+    public Module getModule() {
+        return awsS3TestRule.getModule();
+    }
+}

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedServerWithoutDeletedMessageVaultTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedServerWithoutDeletedMessageVaultTest.java
@@ -1,45 +1,116 @@
 package com.linagora.tmail.james.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.core.Domain;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.util.Port;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.apache.james.utils.TestIMAPClient;
 import org.apache.james.vault.VaultConfiguration;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linagora.tmail.blob.blobid.list.BlobStoreConfiguration;
+import com.google.common.io.Resources;
+import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.encrypted.MailboxConfiguration;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
+import reactor.core.publisher.Flux;
+
 public class DistributedServerWithoutDeletedMessageVaultTest {
+    private static final String JAMES_SERVER_HOST = "127.0.0.1";
+    private static final String DOMAIN = "tmail.org";
+    private static final String BOB = "bob@" + DOMAIN;
+    private static final String SENDER = "sender@" + DOMAIN;
+    private static final String PASSWORD = "secret";
+    private static final ConditionFactory CALMLY_AWAIT = Awaitility
+        .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
+        .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
+        .await();
+
     @RegisterExtension
     static JamesServerExtension testExtension =  new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
             .configurationFromClasspath()
-            .blobStore(BlobStoreConfiguration.builder()
-                .disableCache()
-                .deduplication()
-                .noCryptoConfig()
-                .enableSingleSave())
             .searchConfiguration(SearchConfiguration.openSearch())
             .mailbox(new MailboxConfiguration(false))
             .eventBusKeysChoice(EventBusKeysChoice.RABBITMQ)
             .vaultConfiguration(VaultConfiguration.DEFAULT)
             .build())
         .server(configuration -> DistributedServer.createServer(configuration)
-            .overrideWith(new LinagoraTestJMAPServerModule()))
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class).addBinding().to(EncryptedDistributedServerTest.BlobStoreDaoClassProbe.class)))
         .extension(new DockerOpenSearchExtension())
         .extension(new CassandraExtension())
         .extension(new RabbitMQExtension())
+        .extension(new AwsS3BlobStoreExtension())
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
 
     @Test
     void distributedJamesServerShouldStartWithoutDeletedMessageVault(GuiceJamesServer server) {
         assertThat(server.isStarted()).isTrue();
+    }
+
+    @Test
+    void deletedMessageVaultBucketShouldNotBeCreatedWhenDeleteMessage(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(BOB, PASSWORD)
+            .addUser(SENDER, PASSWORD);
+
+        MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
+        mailboxProbe.createMailbox("#private", BOB, DefaultMailboxes.INBOX);
+
+        Port smtpPort = Port.of(server.getProbe(SmtpGuiceProbe.class).getSmtpPort().getValue());
+        String message = Resources.toString(Resources.getResource("eml/htmlMail.eml"), StandardCharsets.UTF_8);
+
+        try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
+            sender.connect(JAMES_SERVER_HOST, smtpPort).authenticate(SENDER, PASSWORD);
+            sendUniqueMessage(sender, message);
+        }
+
+        CALMLY_AWAIT.until(() -> server.getProbe(SpoolerProbe.class).processingFinished());
+
+        try (TestIMAPClient reader = new TestIMAPClient()) {
+            reader.connect(JAMES_SERVER_HOST, server.getProbe(ImapGuiceProbe.class).getImapPort())
+                .login(BOB, PASSWORD)
+                .select(TestIMAPClient.INBOX)
+                .awaitMessageCount(CALMLY_AWAIT, 1);
+
+            reader.setFlagsForAllMessagesInMailbox("\\Deleted");
+            reader.expunge();
+            reader.awaitMessageCount(CALMLY_AWAIT, 0);
+        }
+
+        BlobStoreDAO blobStoreDAO = server.getProbe(EncryptedDistributedServerTest.BlobStoreDaoClassProbe.class).getBlobStoreDAO();
+        assertThat(Flux.from(blobStoreDAO.listBuckets()).collectList().block().stream().map(BucketName::asString).filter(bucket -> bucket.contains("deleted-messages")))
+            .hasSize(0);
+    }
+
+    private void sendUniqueMessage(SMTPMessageSender sender, String message) throws IOException {
+        String uniqueMessage = message.replace("banana", "UUID " + UUID.randomUUID());
+        sender.sendMessageWithHeaders(SENDER, BOB, uniqueMessage);
     }
 }

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedServerWithoutDeletedMessageVaultTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedServerWithoutDeletedMessageVaultTest.java
@@ -1,0 +1,45 @@
+package com.linagora.tmail.james.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.vault.VaultConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.blob.blobid.list.BlobStoreConfiguration;
+import com.linagora.tmail.encrypted.MailboxConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+public class DistributedServerWithoutDeletedMessageVaultTest {
+    @RegisterExtension
+    static JamesServerExtension testExtension =  new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
+        DistributedJamesConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .blobStore(BlobStoreConfiguration.builder()
+                .disableCache()
+                .deduplication()
+                .noCryptoConfig()
+                .enableSingleSave())
+            .searchConfiguration(SearchConfiguration.openSearch())
+            .mailbox(new MailboxConfiguration(false))
+            .eventBusKeysChoice(EventBusKeysChoice.RABBITMQ)
+            .vaultConfiguration(VaultConfiguration.DEFAULT)
+            .build())
+        .server(configuration -> DistributedServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule()))
+        .extension(new DockerOpenSearchExtension())
+        .extension(new CassandraExtension())
+        .extension(new RabbitMQExtension())
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+
+    @Test
+    void distributedJamesServerShouldStartWithoutDeletedMessageVault(GuiceJamesServer server) {
+        assertThat(server.isStarted()).isTrue();
+    }
+}

--- a/tmail-backend/apps/distributed/src/test/resources/eml/htmlMail.eml
+++ b/tmail-backend/apps/distributed/src/test/resources/eml/htmlMail.eml
@@ -1,0 +1,81 @@
+Delivered-To: mister@james.org
+Received: by 10.28.170.202 with SMTP id t193csp327634wme;
+        Thu, 4 Jun 2015 00:36:15 -0700 (PDT)
+X-Received: by 10.180.77.195 with SMTP id u3mr5042880wiw.30.1433403375307;
+        Thu, 04 Jun 2015 00:36:15 -0700 (PDT)
+Return-Path: <bounces+1453977-062b-mister=james.org@email.airbnb.com>
+Received: from o7.email.airbnb.com (o7.email.airbnb.com. [167.89.32.249])
+        by mx.google.com with ESMTPS id i2si5691730wjz.123.2015.06.04.00.36.13
+        for <mister@james.org>
+        (version=TLSv1.2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);
+        Thu, 04 Jun 2015 00:36:15 -0700 (PDT)
+Received-SPF: pass (google.com: domain of bounces+1453977-062b-mister=james.org@email.airbnb.com designates 167.89.32.249 as permitted sender) client-ip=167.89.32.249;
+Authentication-Results: mx.google.com;
+       spf=pass (google.com: domain of bounces+1453977-062b-mister=james.org@email.airbnb.com designates 167.89.32.249 as permitted sender) smtp.mail=bounces+1453977-062b-mister=james.org@email.airbnb.com;
+       dkim=pass header.i=@email.airbnb.com;
+       dmarc=pass (p=REJECT dis=NONE) header.from=airbnb.com
+DKIM-Signature: v=1; a=rsa-sha1; c=relaxed; d=email.airbnb.com;
+	h=from:to:subject:mime-version:content-type:content-transfer-encoding;
+	s=s20150428; bh=2mhWUwzjtQTC0KljgpaEsuvrqok=; b=EhC2QHKb5+63egDD
+	qDCAepUELCeUZXCkw8+31kGT+O1va3iAKvQSAvzXJ3qJlIL9FgdeFk8sR78Vszn/
+	A73vp6NGjAW60M4gUZjxEOIPzGKIS95KfmHxg10fXUOFW0uePojNEg4ZPCcuitrZ
+	HuWvzHK5I2siGnqupiivwxDgs5c=
+DKIM-Signature: v=1; a=rsa-sha1; c=relaxed; d=sendgrid.info;
+	h=from:to:subject:mime-version:content-type:content-transfer-encoding:x-feedback-id;
+	s=smtpapi; bh=2mhWUwzjtQTC0KljgpaEsuvrqok=; b=FPiYMmNJLCrL2e8v/0
+	DQC4voofe8nuuE7rhXZ25oqNAhAQja4oKIysJ1qAME2aEaqh+N5aJlCEuHrSG/7+
+	NAQ0OY8KaJ2zlnxAbmgJETOjnf4oGdAa+nU/nVVEPfN2NRcBCNLGQZ80U4T5k8Xi
+	PakIuZvKDTRq7PiosSCSHT/FQ=
+Received: by filter0490p1mdw1.sendgrid.net with SMTP id filter0490p1mdw1.13271.556FFFE7B
+        2015-06-04 07:36:09.249601779 +0000 UTC
+Received: from i-dee0850e.inst.aws.airbnb.com (ec2-54-90-154-187.compute-1.amazonaws.com [54.90.154.187])
+	by ismtpd-017 (SG) with ESMTP id 14dbd7fa6b4.779a.254b43
+	for <mister@james.org>; Thu, 04 Jun 2015 07:36:09 +0000 (UTC)
+Received: by i-dee0850e.inst.aws.airbnb.com (Postfix, from userid 1041)
+	id 19CBA24C60; Thu,  4 Jun 2015 07:36:09 +0000 (UTC)
+Date: Thu, 04 Jun 2015 07:36:08 +0000
+From: Airbnb <discover@airbnb.com>
+To: mister@james.org
+Message-ID: <556fffe8cac78_7ed0e0fe204457be@i-dee0850e.mail>
+Subject: Text and Html not similar
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="--==_mimepart_556fffe8c7e84_7ed0e0fe20445637";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+X-User-ID: 32692788
+X-Locale: fr
+X-Category: engagement
+X-Template: low_intent_top_destinations
+recipients:
+sent-on:
+X-SG-EID: mgVKhb3i1xMIKbRk82EYOUTMOPmiNk6g5BaWGQQKDTQchtClhw7VcIxig2BMwy1QMCr7h56hNVush8
+ 4aRV0ieMn+WZ1XVnpY0OcmMYNZnuuvlOoNkBaiuiqeWuKVZO9c9S5OyxPy7WQeI0mccenq35NpLqjI
+ nQt7IAl2sIUksUD4lM8Ai0u2C88YW13cL+Lo
+X-SG-ID: pQ7zy0fBcyQB3Gm22dZtqT6AR3zbAquH5ABZFkQfSKaxWRhz0YhtD36Li5uybRUjnPsuB21NpreKvG
+ t8iQBUn2ygs6hx6sMcgyI7L7bAY28p14Qj47KqA3JXbtMa0Xa3wdZaUUjZpemCg078XxMM5VaSHdDO
+ ChUhSV+z9RAJ38wAdUfXkpbO+m97vpU+mtWzVBoOrSiWCVYoNxPhvE4yIQ==
+X-Feedback-ID: 1453977:N5+DXWRfRBXSDDbqVYXPNg8MjWYWwZibliGo1i/oSqY=:Ibl/atjs+SOcHCINmWWv/YvIGzDUihUrks9jdHsNF1+pafkc987UhcxmuyggxNgdCkEmMZDb9gJcndcUJy5KOw==:SG
+
+----==_mimepart_556fffe8c7e84_7ed0e0fe20445637
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+The text/plain part is not matching the html one.
+
+----==_mimepart_556fffe8c7e84_7ed0e0fe20445637
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  </head>
+  <body bgcolor="#FFFFFF" text="#000000">
+    <i>This is a mail with <b>beautifull</b> html content which contains a banana.</i><br>
+  </body>
+</html>
+
+----==_mimepart_556fffe8c7e84_7ed0e0fe20445637--

--- a/tmail-backend/apps/distributed/src/test/resources/eml/htmlMail.eml
+++ b/tmail-backend/apps/distributed/src/test/resources/eml/htmlMail.eml
@@ -1,38 +1,4 @@
 Delivered-To: mister@james.org
-Received: by 10.28.170.202 with SMTP id t193csp327634wme;
-        Thu, 4 Jun 2015 00:36:15 -0700 (PDT)
-X-Received: by 10.180.77.195 with SMTP id u3mr5042880wiw.30.1433403375307;
-        Thu, 04 Jun 2015 00:36:15 -0700 (PDT)
-Return-Path: <bounces+1453977-062b-mister=james.org@email.airbnb.com>
-Received: from o7.email.airbnb.com (o7.email.airbnb.com. [167.89.32.249])
-        by mx.google.com with ESMTPS id i2si5691730wjz.123.2015.06.04.00.36.13
-        for <mister@james.org>
-        (version=TLSv1.2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);
-        Thu, 04 Jun 2015 00:36:15 -0700 (PDT)
-Received-SPF: pass (google.com: domain of bounces+1453977-062b-mister=james.org@email.airbnb.com designates 167.89.32.249 as permitted sender) client-ip=167.89.32.249;
-Authentication-Results: mx.google.com;
-       spf=pass (google.com: domain of bounces+1453977-062b-mister=james.org@email.airbnb.com designates 167.89.32.249 as permitted sender) smtp.mail=bounces+1453977-062b-mister=james.org@email.airbnb.com;
-       dkim=pass header.i=@email.airbnb.com;
-       dmarc=pass (p=REJECT dis=NONE) header.from=airbnb.com
-DKIM-Signature: v=1; a=rsa-sha1; c=relaxed; d=email.airbnb.com;
-	h=from:to:subject:mime-version:content-type:content-transfer-encoding;
-	s=s20150428; bh=2mhWUwzjtQTC0KljgpaEsuvrqok=; b=EhC2QHKb5+63egDD
-	qDCAepUELCeUZXCkw8+31kGT+O1va3iAKvQSAvzXJ3qJlIL9FgdeFk8sR78Vszn/
-	A73vp6NGjAW60M4gUZjxEOIPzGKIS95KfmHxg10fXUOFW0uePojNEg4ZPCcuitrZ
-	HuWvzHK5I2siGnqupiivwxDgs5c=
-DKIM-Signature: v=1; a=rsa-sha1; c=relaxed; d=sendgrid.info;
-	h=from:to:subject:mime-version:content-type:content-transfer-encoding:x-feedback-id;
-	s=smtpapi; bh=2mhWUwzjtQTC0KljgpaEsuvrqok=; b=FPiYMmNJLCrL2e8v/0
-	DQC4voofe8nuuE7rhXZ25oqNAhAQja4oKIysJ1qAME2aEaqh+N5aJlCEuHrSG/7+
-	NAQ0OY8KaJ2zlnxAbmgJETOjnf4oGdAa+nU/nVVEPfN2NRcBCNLGQZ80U4T5k8Xi
-	PakIuZvKDTRq7PiosSCSHT/FQ=
-Received: by filter0490p1mdw1.sendgrid.net with SMTP id filter0490p1mdw1.13271.556FFFE7B
-        2015-06-04 07:36:09.249601779 +0000 UTC
-Received: from i-dee0850e.inst.aws.airbnb.com (ec2-54-90-154-187.compute-1.amazonaws.com [54.90.154.187])
-	by ismtpd-017 (SG) with ESMTP id 14dbd7fa6b4.779a.254b43
-	for <mister@james.org>; Thu, 04 Jun 2015 07:36:09 +0000 (UTC)
-Received: by i-dee0850e.inst.aws.airbnb.com (Postfix, from userid 1041)
-	id 19CBA24C60; Thu,  4 Jun 2015 07:36:09 +0000 (UTC)
 Date: Thu, 04 Jun 2015 07:36:08 +0000
 From: Airbnb <discover@airbnb.com>
 To: mister@james.org
@@ -43,19 +9,6 @@ Content-Type: multipart/alternative;
  boundary="--==_mimepart_556fffe8c7e84_7ed0e0fe20445637";
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-X-User-ID: 32692788
-X-Locale: fr
-X-Category: engagement
-X-Template: low_intent_top_destinations
-recipients:
-sent-on:
-X-SG-EID: mgVKhb3i1xMIKbRk82EYOUTMOPmiNk6g5BaWGQQKDTQchtClhw7VcIxig2BMwy1QMCr7h56hNVush8
- 4aRV0ieMn+WZ1XVnpY0OcmMYNZnuuvlOoNkBaiuiqeWuKVZO9c9S5OyxPy7WQeI0mccenq35NpLqjI
- nQt7IAl2sIUksUD4lM8Ai0u2C88YW13cL+Lo
-X-SG-ID: pQ7zy0fBcyQB3Gm22dZtqT6AR3zbAquH5ABZFkQfSKaxWRhz0YhtD36Li5uybRUjnPsuB21NpreKvG
- t8iQBUn2ygs6hx6sMcgyI7L7bAY28p14Qj47KqA3JXbtMa0Xa3wdZaUUjZpemCg078XxMM5VaSHdDO
- ChUhSV+z9RAJ38wAdUfXkpbO+m97vpU+mtWzVBoOrSiWCVYoNxPhvE4yIQ==
-X-Feedback-ID: 1453977:N5+DXWRfRBXSDDbqVYXPNg8MjWYWwZibliGo1i/oSqY=:Ibl/atjs+SOcHCINmWWv/YvIGzDUihUrks9jdHsNF1+pafkc987UhcxmuyggxNgdCkEmMZDb9gJcndcUJy5KOw==:SG
 
 ----==_mimepart_556fffe8c7e84_7ed0e0fe20445637
 Content-Type: text/plain;


### PR DESCRIPTION
If the vault is disabled, it should not bind related classes and not create a bucket on s3 either.