### PR TITLE
Postgres-app: unset JAVA_TOOL_OPTIONS env variable when running james-cli

### DIFF
--- a/tmail-backend/apps/postgres/src/main/scripts/james-cli
+++ b/tmail-backend/apps/postgres/src/main/scripts/james-cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+unset JAVA_TOOL_OPTIONS
 java -cp /root/resources:/root/classes:/root/libs/* org.apache.james.cli.ServerCmd "$@"


### PR DESCRIPTION
GIVEN I run james-cli in kubernetes
THEN the pod crashes and reboots

Because the james-cli runs JVM it catches the environment variables set by James. As such it always pretouch 3GB of RAM. When added to memory consumed by James it exceeds the limit and pod get's OOM-killed.