### PR TITLE
Fixup Guice install POP3ServerModule 2 times

### DIFF
--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -246,7 +246,6 @@ public class DistributedServer {
         new IMAPServerModule(),
         JMAP,
         new ManageSieveServerModule(),
-        new POP3ServerModule(),
         new ProtocolHandlerModule(),
         new SMTPServerModule(),
         WEBADMIN);


### PR DESCRIPTION
- It should be installed single time by `choosePop3ServerModule` method

// Fix miss code of pr https://github.com/linagora/tmail-backend/pull/1180/files