### PR TITLE
Update James SHA1

### DIFF
--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventReplyWithAMQPWorkflowTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventReplyWithAMQPWorkflowTest.java
@@ -20,13 +20,14 @@ import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.common.LinagoraCalendarEventReplyWithAMQPWorkflowContract;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+import com.rabbitmq.client.BuiltinExchangeType;
 
 public class MemoryCalendarEventReplyWithAMQPWorkflowTest implements LinagoraCalendarEventReplyWithAMQPWorkflowContract {
     static final String AMQP_EXCHANGE_NAME = "james:events";
     static final String AMQP_ROUTING_KEY = "icalendar_routing_key2";
 
     @RegisterExtension
-    public static AmqpExtension amqpExtension = new AmqpExtension(AMQP_EXCHANGE_NAME, AMQP_ROUTING_KEY);
+    public static AmqpExtension amqpExtension = new AmqpExtension(AMQP_EXCHANGE_NAME, AMQP_ROUTING_KEY, BuiltinExchangeType.FANOUT);
 
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/resources/mailetcontainer_with_amqpforward_openpass.xml
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/resources/mailetcontainer_with_amqpforward_openpass.xml
@@ -59,6 +59,7 @@
             <mailet match="SenderIsLocal" class="AmqpForwardAttribute">
                 <uri>{{AmqpForwardAttribute_uri}}</uri>
                 <exchange>james:events</exchange>
+                <exchange_type>fanout</exchange_type>
                 <attribute>icalendarAsJson2</attribute>
                 <routing_key>icalendar_routing_key2</routing_key>
                 <onMailetException>ignore</onMailetException>


### PR DESCRIPTION
Error when deploying prod:
{"timestamp":"2024-09-19T02:00:09.101Z","level":"ERROR","thread":"main","logger":"org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor","message":"Caused by nested exception: ","context":"default","exception":"com.rabbitmq.client.ShutdownSignalException: channel error; protocol method: #method<channel.close>(reply-code=406, reply-text=PRECONDITION_FAILED - inequivalent arg 'type' for exchange 'collector:email' in vhost '/': received 'direct' but current is 'fanout', class-id=40, method-id=10)

Need to include the AMQP hotfix: https://github.com/apache/james-project/pull/2412