### PR TITLE
ISSUE-1192 Apisix: enable ticket route

### DIFF
--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -12,18 +12,6 @@ routes:
       proxy-rewrite:
         uri: /jmap
   -
-    id: jmap_websocket
-    uri: /oidc/jmap/ws
-    service_id: jmap_service_oidc
-    enable_websocket: true
-    methods:
-      - GET
-      - OPTIONS
-    plugin_config_id: jmap-plugin
-    plugins:
-      proxy-rewrite:
-        uri: /jmap/ws
-  -
     id: jmap_websocket_ticket
     uri: /oidc/jmap/ws/ticket
     service_id: jmap_service_oidc
@@ -196,13 +184,18 @@ routes:
       - OPTIONS
     plugin_config_id: jmap-plugin
   - id: jmap_websocket_basic_auth
-    uri: /jmap/ws
+    uris:
+      - /oidc/jmap/ws
+      - /jmap/ws
     service_id: jmap_service_basic_auth
     enable_websocket: true
     methods:
       - GET
       - OPTIONS
     plugin_config_id: jmap-plugin
+    plugins:
+      proxy-rewrite:
+        uri: /jmap/ws
   - id: jmap_websocket_ticket_basic_auth
     uri: /jmap/ws/ticket
     service_id: jmap_service_basic_auth

--- a/demo/apisix/conf/apisix.yaml
+++ b/demo/apisix/conf/apisix.yaml
@@ -24,6 +24,17 @@ routes:
       proxy-rewrite:
         uri: /jmap/ws
   -
+    id: jmap_websocket_ticket
+    uri: /oidc/jmap/ws/ticket
+    service_id: jmap_service_oidc
+    methods:
+      - POST
+      - OPTIONS
+    plugin_config_id: jmap-plugin
+    plugins:
+      proxy-rewrite:
+        uri: /jmap/ws/ticket
+  -
     id: jmap_session_oidc
     uri: /oidc/jmap/session
     service_id: jmap_service_oidc
@@ -190,6 +201,13 @@ routes:
     enable_websocket: true
     methods:
       - GET
+      - OPTIONS
+    plugin_config_id: jmap-plugin
+  - id: jmap_websocket_ticket_basic_auth
+    uri: /jmap/ws/ticket
+    service_id: jmap_service_basic_auth
+    methods:
+      - POST
       - OPTIONS
     plugin_config_id: jmap-plugin
 

--- a/demo/tmail/jmap.properties
+++ b/demo/tmail/jmap.properties
@@ -13,7 +13,7 @@ tls.secret=james72laBalle
 #
 jwt.publickeypem.url=file://conf/jwt_publickey
 
-authentication.strategy.rfc8621=BasicAuthenticationStrategy,XUserAuthenticationStrategy
+authentication.strategy.rfc8621=BasicAuthenticationStrategy,XUserAuthenticationStrategy,com.linagora.tmail.james.jmap.ticket.TicketAuthenticationStrategy
 
 # Should simple Email/query be resolved against a Cassandra projection, or should we resolve them against OpenSearch?
 # This enables a higher resilience, but the projection needs to be correctly populated. False by default.

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/ticketAuthentication.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/ticketAuthentication.adoc
@@ -24,10 +24,11 @@ Will return :
 
 ----
 {
-    "ticket":"WHATEVER",
+    "value":"WHATEVER",
     "clientAddress": "1.234.458.56",
     "generatedOn": "UTCDate",
-    "validUntil": "UTCDate"
+    "validUntil": "UTCDate",
+    "username": "james-user@tmail.com"
 }
 
 ----
@@ -44,7 +45,7 @@ curl -XDELETE https://james/jmap/websocket/ticket/WHATEVER
 During the next 60s this ticket can be used a single time via query parameters as an authentication mechanism. Thus web-browser clients can use it to open a secure connection:
 
 ----
-wss://james/jmap/js?ticket=UUID
+wss://james/jmap/ws?ticket=WHATEVER
 
 ----
 

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/json/TicketSerializer.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/json/TicketSerializer.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.{JsString, JsValue, Json, Writes}
 
 object TicketSerializer {
   implicit val ticketValueWrites: Writes[TicketValue] = ticketValue => JsString(ticketValue.value.toString)
-  implicit val addressWrites: Writes[InetAddress] = address => JsString(address.toString)
+  implicit val addressWrites: Writes[InetAddress] = address => JsString(address.getHostAddress)
   implicit val usernameWrites: Writes[Username] = username => JsString(username.asString())
   implicit val ticketWrites: Writes[Ticket] = Json.writes[Ticket]
 


### PR DESCRIPTION
Frontend team start to integrate WebSocket.

Browser does not support sending Authorization header upon HTTP handshake request => solution: https://github.com/linagora/tmail-backend/blob/master/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/ticketAuthentication.adoc

We need to expose the route via APISIX.