### PR TITLE
ISSUE-1204 Autocomplete prefix search for names

### DIFF
--- a/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OpenSearchContactConfiguration.java
+++ b/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OpenSearchContactConfiguration.java
@@ -104,7 +104,7 @@ public class OpenSearchContactConfiguration {
     public static final WriteAliasName DEFAULT_ALIAS_WRITE_DOMAIN_CONTACT_NAME = new WriteAliasName("domain_contact_write_alias");
     public static final ReadAliasName DEFAULT_ALIAS_READ_DOMAIN_CONTACT_NAME = new ReadAliasName("domain_contact_read_alias");
     public static final Integer DEFAULT_MAX_NGRAM_DIFF = 27;
-    public static final Integer DEFAULT_MIN_NGRAM = 3;
+    public static final Integer DEFAULT_MIN_NGRAM = 1;
 
     public static final OpenSearchContactConfiguration DEFAULT_CONFIGURATION = builder().build();
 

--- a/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OpenSearchContactConfiguration.java
+++ b/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OpenSearchContactConfiguration.java
@@ -104,7 +104,7 @@ public class OpenSearchContactConfiguration {
     public static final WriteAliasName DEFAULT_ALIAS_WRITE_DOMAIN_CONTACT_NAME = new WriteAliasName("domain_contact_write_alias");
     public static final ReadAliasName DEFAULT_ALIAS_READ_DOMAIN_CONTACT_NAME = new ReadAliasName("domain_contact_read_alias");
     public static final Integer DEFAULT_MAX_NGRAM_DIFF = 27;
-    public static final Integer DEFAULT_MIN_NGRAM = 1;
+    public static final Integer DEFAULT_MIN_NGRAM = 2;
 
     public static final OpenSearchContactConfiguration DEFAULT_CONFIGURATION = builder().build();
 

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/EmailAddressContactSearchEngineContract.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/EmailAddressContactSearchEngineContract.scala
@@ -8,6 +8,8 @@ import org.apache.james.jmap.api.model.AccountId
 import org.assertj.core.api.Assertions.{assertThat, assertThatCode, assertThatThrownBy}
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import reactor.core.scala.publisher.{SFlux, SMono}
 
 import scala.jdk.CollectionConverters._
@@ -51,6 +53,28 @@ trait EmailAddressContactSearchEngineContract {
   def testee(): EmailAddressContactSearchEngine
 
   def awaitDocumentsIndexed(query: QueryType, documentCount: Long): Unit
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("d", "di", "dia", "dian", "diana"))
+  def prefixSearchForFirstnameShouldWork(searchInput: String): Unit = {
+    SMono(testee().index(accountId, ContactFields(new MailAddress("dpot@linagora.com"), firstname = "Diana", surname = "Pivot"))).block()
+
+    awaitDocumentsIndexed(MatchAllQuery(), 1)
+
+    assertThat(SFlux.fromPublisher(testee().autoComplete(accountId, searchInput)).asJava().map(_.fields.address).collectList().block())
+      .containsExactlyInAnyOrder(new MailAddress("dpot@linagora.com"))
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("p", "pi", "piv", "pivo", "pivot"))
+  def prefixSearchForSurnameShouldWork(searchInput: String): Unit = {
+    SMono(testee().index(accountId, ContactFields(new MailAddress("dpot@linagora.com"), firstname = "Diana", surname = "Pivot"))).block()
+
+    awaitDocumentsIndexed(MatchAllQuery(), 1)
+
+    assertThat(SFlux.fromPublisher(testee().autoComplete(accountId, searchInput)).asJava().map(_.fields.address).collectList().block())
+      .containsExactlyInAnyOrder(new MailAddress("dpot@linagora.com"))
+  }
 
   @Test
   def shouldNotReturnDuplicatedContactAtReadTime(): Unit = {

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/EmailAddressContactSearchEngineContract.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/EmailAddressContactSearchEngineContract.scala
@@ -55,7 +55,7 @@ trait EmailAddressContactSearchEngineContract {
   def awaitDocumentsIndexed(query: QueryType, documentCount: Long): Unit
 
   @ParameterizedTest
-  @ValueSource(strings = Array("d", "di", "dia", "dian", "diana"))
+  @ValueSource(strings = Array("di", "dia", "dian", "diana"))
   def prefixSearchForFirstnameShouldWork(searchInput: String): Unit = {
     SMono(testee().index(accountId, ContactFields(new MailAddress("dpot@linagora.com"), firstname = "Diana", surname = "Pivot"))).block()
 
@@ -66,7 +66,7 @@ trait EmailAddressContactSearchEngineContract {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("p", "pi", "piv", "pivo", "pivot"))
+  @ValueSource(strings = Array("pi", "piv", "pivo", "pivot"))
   def prefixSearchForSurnameShouldWork(searchInput: String): Unit = {
     SMono(testee().index(accountId, ContactFields(new MailAddress("dpot@linagora.com"), firstname = "Diana", surname = "Pivot"))).block()
 


### PR DESCRIPTION
Previously, prefix search for first name/surname works but only with at least 3 chars. Reason: to not return too noise suggestions, and save indexing space.

However, Diana seems to have requested this to be able to search with fewer characters. Verified with GMail that supports autocomplete addresses from 1 char though.

TODO: testing and document index (settings) migration steps.