### PR TITLE
Update docker-compose sample file: modify the healthcheck to prevent the creation of a temporary file by wget

### DIFF
--- a/tmail-backend/apps/distributed/docker-compose.yml
+++ b/tmail-backend/apps/distributed/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       # openssl rsa -in jwt_privatekey -pubout > jwt_publickey
     restart: on-failure
     healthcheck:
-      test: [ "CMD-SHELL", "wget --server-response 'http://localhost:8000/healthcheck?check=IMAPHealthCheck&check=Cassandra%20backend&strict' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1" ]
+      test: [ "CMD-SHELL", "wget -q -O /dev/null --server-response 'http://localhost:8000/healthcheck?check=IMAPHealthCheck&check=Cassandra%20backend&strict' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1" ]
       interval: 60s
       timeout: 30s
       retries: 2


### PR DESCRIPTION
The current Healthcheck generate a lot of temporay file
![image](https://github.com/user-attachments/assets/0650b29f-aa5d-4e1c-a4e0-c0cc50999984)

With argument `-q -O /dev/null` it will be resolved


