### PR TITLE
Install curl to docker image, then using curl for healthcheck

### DIFF
--- a/tmail-backend/apps/distributed/docker-compose.yml
+++ b/tmail-backend/apps/distributed/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       # openssl rsa -in jwt_privatekey -pubout > jwt_publickey
     restart: on-failure
     healthcheck:
-      test: [ "CMD-SHELL", "wget --server-response 'http://localhost:8000/healthcheck?check=IMAPHealthCheck&check=Cassandra%20backend&strict' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1" ]
+      test: [ "CMD-SHELL", "curl -f -s -o /dev/null 'http://localhost:8000/healthcheck?check=IMAPHealthCheck&check=Cassandra%20backend&strict'" ]
       interval: 60s
       timeout: 30s
       retries: 2

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -393,6 +393,19 @@
                             <md5>29127cee36b7acf069d31603b4558361</md5>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>curl-for-healthcheck</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/stunnel/static-curl/releases/download/8.10.1/curl-linux-x86_64-8.10.1.tar.xz</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}/curl</outputDirectory>
+                            <md5>e421095b552dfdabde77fa2137b15515</md5>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -473,6 +486,10 @@
                                 <into>/root/async-profiler</into>
                             </path>
                             <path>
+                                <from>target/curl</from>
+                                <into>/usr/local/bin</into>
+                            </path>
+                            <path>
                                 <from>src/main/extensions-jars</from>
                                 <into>/root/extensions-jars</into>
                             </path>
@@ -496,6 +513,10 @@
                             </permission>
                             <permission>
                                 <file>/root/async-profiler/build/jattach</file>
+                                <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                            </permission>
+                            <permission>
+                                <file>/usr/local/bin/curl</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                         </permissions>
@@ -575,6 +596,10 @@
                                         <into>/root/glowroot</into>
                                     </path>
                                     <path>
+                                        <from>target/curl</from>
+                                        <into>/usr/local/bin</into>
+                                    </path>
+                                    <path>
                                         <from>target/async-profiler-2.9-linux-x64</from>
                                         <into>/root/async-profiler</into>
                                     </path>
@@ -602,6 +627,10 @@
                                     </permission>
                                     <permission>
                                         <file>/root/async-profiler/build/jattach</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/usr/local/bin/curl</file>
                                         <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                                     </permission>
                                 </permissions>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -192,6 +192,19 @@
                             <md5>29127cee36b7acf069d31603b4558361</md5>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>curl-for-healthcheck</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/stunnel/static-curl/releases/download/8.10.1/curl-linux-x86_64-8.10.1.tar.xz</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}/curl</outputDirectory>
+                            <md5>e421095b552dfdabde77fa2137b15515</md5>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -273,6 +286,10 @@
                                 <into>/root/async-profiler</into>
                             </path>
                             <path>
+                                <from>target/curl</from>
+                                <into>/usr/local/bin</into>
+                            </path>
+                            <path>
                                 <from>src/main/extensions-jars</from>
                                 <into>/root/extensions-jars</into>
                             </path>
@@ -304,6 +321,10 @@
                             </permission>
                             <permission>
                                 <file>/root/provisioning/provisioning.sh</file>
+                                <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                            </permission>
+                            <permission>
+                                <file>/usr/local/bin/curl</file>
                                 <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                             </permission>
                         </permissions>
@@ -387,6 +408,10 @@
                                         <into>/root/async-profiler</into>
                                     </path>
                                     <path>
+                                        <from>target/curl</from>
+                                        <into>/usr/local/bin</into>
+                                    </path>
+                                    <path>
                                         <from>src/main/extensions-jars</from>
                                         <into>/root/extensions-jars</into>
                                     </path>
@@ -418,6 +443,10 @@
                                     </permission>
                                     <permission>
                                         <file>/root/provisioning/provisioning.sh</file>
+                                        <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
+                                    </permission>
+                                    <permission>
+                                        <file>/usr/local/bin/curl</file>
                                         <mode>755</mode> <!-- Read/write/execute for owner, read/execute for group/other -->
                                     </permission>
                                 </permissions>


### PR DESCRIPTION
- Using curl to prevent the creation of a temporary file by wget


another solution of https://github.com/linagora/tmail-backend/pull/1210

We should choose one.
Now `wget` is still enough, but `curl` offers a more comprehensive response