### PR TITLE
ISSUE-1198 Add docs for disable S3 metrics

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
@@ -135,3 +135,10 @@ Specified to TMail backend, we can configure the following configurations in the
 | objectstorage.s3.secondary.secretKey
 | https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[S3 access key secret]
 |===
+
+Besides that, we need to disable S3 metrics to have the secondary blob store working, as we are having S3 metrics key conflicts between two blob stores.
+
+In `jvm.properties` add:
+```
+james.s3.metrics.enabled=false
+```


### PR DESCRIPTION
Otherwise, we have metric keys conflict between 2 blob stores: 

```java
09:00:22.679 [INFO ] o.a.j.CONFIGURATION - Load configuration file /root/conf/blob.properties 
09:00:22.899 [ERROR] o.a.j.GuiceJamesServer - Fatal error while starting James java.lang.IllegalArgumentException: A metric named s3_httpClient_availableConcurrency already exists
	at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:168)
	at org.apache.james.metrics.dropwizard.DropWizardGaugeRegistry.settableGauge(DropWizardGaugeRegistry.java:53)
	at org.apache.james.blob.objectstorage.aws.JamesS3MetricPublisher.<init>(JamesS3MetricPublisher.java:45)
	at org.apache.james.blob.objectstorage.aws.S3ClientFactory.lambda$new$0(S3ClientFactory.java:92)
```

cc @hungphan227 