### PR TITLE
[IMPROVEMENT] Set default `-Dextra.props=/root/conf/jvm.properties` for TMail apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
                                 <jvmFlag>-XX:+ExitOnOutOfMemoryError</jvmFlag>
                                 <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
                                 <jvmFlag>-Dworking.directory=/root/</jvmFlag>
+                                <jvmFlag>-Dextra.props=/root/conf/jvm.properties</jvmFlag>
                             </jvmFlags>
                         </container>
                     </configuration>

--- a/tmail-backend/apps/distributed/src/main/conf/jvm.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/jvm.properties
@@ -5,7 +5,7 @@
 # my.property=whatever
 
 # Required to locate Cassandra driver configuration
-config.file=conf/cassandra-driver.conf
+config.file=/root/conf/cassandra-driver.conf
 
 # (Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB.
 # This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk.


### PR DESCRIPTION

- Better convenient as this is our common path to use too.
- Match default behavior with James apps