### PR TITLE
ISSUE-1201 User limit for mail restoration

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/deletedMessagesVault.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/deletedMessagesVault.adoc
@@ -8,15 +8,16 @@ mailboxes.
 
 == Additions to the capability object
 
-Servers supporting the deleted message vaul extension need to advertise it through the session capabilities:
+Servers supporting the deleted message vault extension need to advertise it through the session capabilities:
 ....
-com:linagora:params:messages:vault
+com:linagora:params:jmap:messages:vault
 ....
 
 The associated object have the following fields:
 
- - `maxRestoredEmails`: *Number | null*, defaulting to 5. Maximum number of emails a given `EmailRecoveryAction` would
+- `maxEmailRecoveryPerRequest`: *Number | null*, defaulting to `5`. Maximum number of emails a given `EmailRecoveryAction` would
 allow to recover.
+- `restorationHorizon`: *String | null*, defaulting to `15 days`. Horizon past which users can no longer recover emails on their own, formatted into a plurialization correct String, like `1 day 12 hours`.
 
 == EmailRecoveryAction object
 
@@ -32,7 +33,7 @@ It has the following properties:
  - `hasAttachment`: *Boolean | null*. Immutable. If set this EmailRecoveryAction would restore only email whose `hasAttachment` property matches this field.
  - `subject`: *String | null*. Immutable. If set this EmailRecoveryAction would restore only email whose `subject` property contains this field.
  - `sender`: *String | null*. Immutable. If set this EmailRecoveryAction would restore only email whose `from` property matches this field. Needs to be a valid email address.
- - `recipients`: *String[] | null*. Immutable. If set this EmailRecoveryAction would restore only email whose `to`, `cc` or `bcc` properties matches all of the mentionned email addresses.
+ - `recipients`: *String[] | null*. Immutable. If set this EmailRecoveryAction would restore only email whose `to`, `cc` or `bcc` properties matches all of the mentioned email addresses.
  Needs to be a valid email addresses.
  - `successfulRestoreCount`: *UnsignedInt* (server-set). Number of successful restored messages.
  - `errorRestoreCount`: *UnsignedInt* (server-set). Number of failed restored messages.

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -154,6 +154,7 @@ import com.linagora.tmail.james.jmap.method.JmapSettingsMethodModule;
 import com.linagora.tmail.james.jmap.method.KeystoreGetMethodModule;
 import com.linagora.tmail.james.jmap.method.KeystoreSetMethodModule;
 import com.linagora.tmail.james.jmap.method.LabelMethodModule;
+import com.linagora.tmail.james.jmap.method.MessageVaultCapabilitiesModule;
 import com.linagora.tmail.james.jmap.module.OSContactAutoCompleteModule;
 import com.linagora.tmail.james.jmap.oidc.WebFingerModule;
 import com.linagora.tmail.james.jmap.publicAsset.CassandraPublicAssetRepositoryModule;
@@ -237,6 +238,7 @@ public class DistributedServer {
         new KeystoreGetMethodModule(),
         new KeystoreSetMethodModule(),
         new TicketRoutesModule(),
+        new MessageVaultCapabilitiesModule(),
         new WebFingerModule(),
         new LabelMethodModule(),
         new JmapSettingsMethodModule(),

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -75,6 +75,7 @@ import com.linagora.tmail.james.jmap.method.JmapSettingsMethodModule;
 import com.linagora.tmail.james.jmap.method.KeystoreGetMethodModule;
 import com.linagora.tmail.james.jmap.method.KeystoreSetMethodModule;
 import com.linagora.tmail.james.jmap.method.LabelMethodModule;
+import com.linagora.tmail.james.jmap.method.MessageVaultCapabilitiesModule;
 import com.linagora.tmail.james.jmap.oidc.WebFingerModule;
 import com.linagora.tmail.james.jmap.publicAsset.PublicAssetsMemoryModule;
 import com.linagora.tmail.james.jmap.publicAsset.PublicAssetsModule;
@@ -136,6 +137,7 @@ public class MemoryServer {
         new JmapSettingsMethodModule(),
         new PublicAssetsModule(),
         new PublicAssetsMemoryModule(),
+        new MessageVaultCapabilitiesModule(),
         new MailboxesCleanupModule(),
         new InboxArchivalTaskModule(),
         new ContactSupportCapabilitiesModule())

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/EmailRecoveryActionSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/EmailRecoveryActionSetMethodContract.scala
@@ -77,7 +77,7 @@ object EmailRecoveryActionSetMethodContract {
 
   val DELETED_MESSAGE_CONTENT: Array[Byte] = "header: value\r\n\r\ncontent".getBytes(StandardCharsets.UTF_8)
   val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX")
-  val RESTORATION_HORIZON_SPAN_IN_DAYS: Int = 15
+  val RESTORATION_HORIZON_SPAN_IN_DAYS: Int = 14
 
   def creationSetInvalidRequestList: Stream[Arguments] = {
     val template: String =

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/MemoryMessageVaultCapabilityContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/MemoryMessageVaultCapabilityContract.scala
@@ -1,0 +1,83 @@
+package com.linagora.tmail.james.common
+
+import io.netty.handler.codec.http.HttpHeaderNames.ACCEPT
+import io.restassured.RestAssured.{`given`, requestSpecification}
+import io.restassured.http.ContentType.JSON
+import org.apache.http.HttpStatus.SC_OK
+import org.apache.james.GuiceJamesServer
+import org.apache.james.jmap.http.UserCredential
+import org.apache.james.jmap.rfc8621.contract.Fixture.{ACCEPT_RFC8621_VERSION_HEADER, BOB, BOB_PASSWORD, DOMAIN, authScheme, baseRequestSpecBuilder}
+import org.apache.james.utils.DataProbeImpl
+import org.hamcrest.Matchers.{equalTo, hasKey}
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+object MemoryMessageVaultCapabilityContract {
+
+  trait EmailRecoveryConfigured {
+
+    @BeforeEach
+    def setUp(server: GuiceJamesServer): Unit = {
+      server.getProbe(classOf[DataProbeImpl])
+        .fluent()
+        .addDomain(DOMAIN.asString())
+        .addUser(BOB.asString(), BOB_PASSWORD)
+
+      requestSpecification = baseRequestSpecBuilder(server)
+        .setAuth(authScheme(UserCredential(BOB, BOB_PASSWORD)))
+        .build
+    }
+
+    @Test
+    def shouldReturnCorrectInfoInMessageVaultCapability(): Unit = {
+      val maxEmailRecoveryPerRequest = "6"
+      val restorationHorizon = "14 days"
+
+      `given`()
+      .when()
+        .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+        .get("/session")
+      .`then`
+        .statusCode(SC_OK)
+        .contentType(JSON)
+        .body("capabilities", hasKey("com:linagora:params:jmap:messages:vault"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'", hasKey("maxEmailRecoveryPerRequest"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'.maxEmailRecoveryPerRequest", equalTo(maxEmailRecoveryPerRequest))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'", hasKey("restorationHorizon"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'.restorationHorizon", equalTo(restorationHorizon))
+    }
+  }
+
+  trait EmailRecoveryNotConfigured {
+
+    @BeforeEach
+    def setUp(server: GuiceJamesServer): Unit = {
+      server.getProbe(classOf[DataProbeImpl])
+        .fluent()
+        .addDomain(DOMAIN.asString())
+        .addUser(BOB.asString(), BOB_PASSWORD)
+
+      requestSpecification = baseRequestSpecBuilder(server)
+        .setAuth(authScheme(UserCredential(BOB, BOB_PASSWORD)))
+        .build
+    }
+
+    @Test
+    def shouldReturnDefaultValuesWhenEmailRecoveryNotConfigured(): Unit = {
+      val defaultMaxEmailRecoveryPerRequest = "5"
+      val defaultRestorationHorizon = "15 days"
+
+      `given`()
+      .when()
+        .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+        .get("/session")
+      .`then`
+        .statusCode(SC_OK)
+        .contentType(JSON)
+        .body("capabilities", hasKey("com:linagora:params:jmap:messages:vault"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'", hasKey("maxEmailRecoveryPerRequest"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'.maxEmailRecoveryPerRequest", equalTo(defaultMaxEmailRecoveryPerRequest))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'", hasKey("restorationHorizon"))
+        .body("capabilities.'com:linagora:params:jmap:messages:vault'.restorationHorizon", equalTo(defaultRestorationHorizon))
+    }
+  }
+}

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryMessageVaultCapabilityTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryMessageVaultCapabilityTest.java
@@ -1,0 +1,53 @@
+package com.linagora.tmail.james;
+
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.james.app.MemoryConfiguration;
+import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.james.common.MemoryMessageVaultCapabilityContract;
+import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.james.jmap.method.EmailRecoveryActionConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+public class MemoryMessageVaultCapabilityTest {
+
+    @Nested
+    class EmailRecoveryConfiguredTest implements MemoryMessageVaultCapabilityContract.EmailRecoveryConfigured {
+        @RegisterExtension
+        static JamesServerExtension
+                jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+                MemoryConfiguration.builder()
+                        .workingDirectory(tmpDir)
+                        .configurationFromClasspath()
+                        .usersRepository(DEFAULT)
+                        .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+                        .build())
+                .server(configuration -> MemoryServer.createServer(configuration)
+                        .overrideWith(new LinagoraTestJMAPServerModule()))
+                .build();
+    }
+
+    @Nested
+    class EmailRecoveryNotConfiguredTest implements MemoryMessageVaultCapabilityContract.EmailRecoveryNotConfigured {
+        @RegisterExtension
+        static JamesServerExtension
+                jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+                MemoryConfiguration.builder()
+                        .workingDirectory(tmpDir)
+                        .configurationFromClasspath()
+                        .usersRepository(DEFAULT)
+                        .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+                        .build())
+                .server(configuration -> MemoryServer.createServer(configuration)
+                        .overrideWith(new LinagoraTestJMAPServerModule(),
+                                binder -> binder.bind(EmailRecoveryActionConfiguration.class)
+                                        .toInstance(new EmailRecoveryActionConfiguration())
+                        ))
+                .build();
+    }
+}

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/resources/jmap.properties
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/resources/jmap.properties
@@ -1,6 +1,6 @@
 enabled=true
 emailRecoveryAction.maxEmailRecoveryPerRequest=6
-emailRecoveryAction.restorationHorizon=15d
+emailRecoveryAction.restorationHorizon=14d
 calendarEvent.reply.mailTemplateLocation=classpath://eml/
 calendarEvent.reply.supportedLanguages=en,fr
 support.mail.address=support@linagora.com

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/MessageVaultCapability.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/MessageVaultCapability.scala
@@ -1,28 +1,41 @@
 package com.linagora.tmail.james.jmap.method
 
+import java.time.Duration
+
 import com.google.inject.AbstractModule
-import com.google.inject.multibindings.ProvidesIntoSet
+import com.google.inject.Inject
+import com.google.inject.multibindings.Multibinder
 import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_MESSAGE_VAULT
+import org.apache.commons.lang3.time.DurationFormatUtils
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.{Capability, CapabilityFactory, CapabilityProperties, UrlPrefixes}
 import play.api.libs.json.{JsObject, Json}
 
-case object MessageVaultCapabilityProperties extends CapabilityProperties {
-  override def jsonify(): JsObject = Json.obj()
+case class MessageVaultCapabilityProperties(maxEmailRecoveryPerRequest: Long, restorationHorizon: Duration) extends CapabilityProperties {
+  override def jsonify(): JsObject = Json.obj(
+    "maxEmailRecoveryPerRequest" -> maxEmailRecoveryPerRequest.toString,
+    "restorationHorizon" -> DurationFormatUtils.formatDurationWords(restorationHorizon.toMillis, true, true))
 }
 
-case object MessageVaultCapability extends Capability {
-  val properties: CapabilityProperties = MessageVaultCapabilityProperties
+case class MessageVaultCapability(messageVaultCapabilityProperties: MessageVaultCapabilityProperties) extends Capability {
   val identifier: CapabilityIdentifier = LINAGORA_MESSAGE_VAULT
+  val properties: MessageVaultCapabilityProperties = messageVaultCapabilityProperties
 }
 
-case object MessageVaultCapabilityFactory extends CapabilityFactory {
-  override def create(urlPrefixes: UrlPrefixes): Capability = MessageVaultCapability
-
+case class MessageVaultCapabilityFactory @Inject()(configuration: EmailRecoveryActionConfiguration) extends CapabilityFactory {
   override def id(): CapabilityIdentifier = LINAGORA_MESSAGE_VAULT
+
+  override def create(urlPrefixes: UrlPrefixes): Capability = {
+    MessageVaultCapability(MessageVaultCapabilityProperties(
+      maxEmailRecoveryPerRequest = configuration.maxEmailRecoveryPerRequest,
+      restorationHorizon = configuration.restorationHorizon))
+  }
 }
 
 class MessageVaultCapabilitiesModule extends AbstractModule {
-  @ProvidesIntoSet
-  private def capability(): CapabilityFactory = MessageVaultCapabilityFactory
+  override def configure(): Unit = {
+    Multibinder.newSetBinder(binder(), classOf[CapabilityFactory])
+      .addBinding()
+      .to(classOf[MessageVaultCapabilityFactory])
+  }
 }


### PR DESCRIPTION
the issue has been tackled in [this PR](https://github.com/linagora/tmail-backend/pull/1224) but after merging Benoit Tellier commented the following:


> As done for https://github.com/linagora/tmail-backend/blob/master/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/deletedMessagesVault.adoc we would need to advertize in the JMAP session the restoration horizon.
> 
> ```
> maxRestaurationHorizon: String | null, defaulting to 15 days. Horizon past which users can no longer recover emails alone.
> ```
> 
> Why? It enables the frontend to present the limits to the user and enforce it in user input.
> 
> Of course we shall read it from the configuration.

