### PR TITLE
Create OpenPaasAmqpForwardAttribute

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 *** xref:tmail-backend/features/teamMailboxes.adoc[]
 *** xref:tmail-backend/features/tmailRateLimiting.adoc[]
 *** xref:tmail-backend/features/ldapMailingLists.adoc[]
+*** xref:tmail-backend/features/openpaas-integration.adoc[]
 ** xref:tmail-backend/extra-components/index.adoc[]
 ** xref:tmail-backend/imap-extensions/index.adoc[]
 *** xref:tmail-backend/imap-extensions/imapLoginDelegationExtension.adoc[]

--- a/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
@@ -215,3 +215,49 @@ Specified to TMail backend, we can configure the following configurations in the
 | https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[S3 access key secret]
 |===
 
+== OpenPaas Integration Configurations
+
+Specified to TMail backend, we can configure the following configurations in the *openpaas.properties* file.
+
+For more information about the OpenPaas integration, see xref:tmail-backend/features/openpaas-integration.adoc[OpenPaas Integration].
+
+.openpaas.properties additional content
+|===
+| Property name | explanation
+| rabbitmq.uri
+| URI for RabbitMQ server to communicate with OpenPaas. Example: `rabbitmq.uri=amqp://guest:guest@localhost:5672/`
+| openpaas.api.uri
+| URI for OpenPaas API. Example: `openpaas.api.uri=http://localhost:8080`
+| openpaas.admin.user
+| Admin username for OpenPaas. Example: `openpaas.admin.user=admin`
+| openpaas.admin.password
+| Admin password for OpenPaas. Example: `openpaas.admin.password=admin`
+|===
+
+=== OpenPaasAmqpForwardAttribute
+
+This mailet forwards the specified mail attribute value to OpenPaas through the AMQP protocol.
+
+=== Parameters
+
+The mailet configuration requires the following parameters:
+
+* `attribute`: the name of the attribute which its value would be forwarded, the value is expected to be a Map<String, byte[]>.
+* `exchange`: name of the AMQP exchange.
+* `exchange_type`: type of the exchange. Can be "direct", "fanout", "topic", "headers". Optional, defaults to "direct".
+
+=== Example
+This configuration forwards contacts collected by the `ContactsCollection` mailet to OpenPaas through the AMQP protocol.
+
+[source,xml]
+----
+<mailet match="SenderIsLocal" class="com.linagora.tmail.mailets.ContactsCollection">
+    <attribute>extractedContacts</attribute>
+</mailet>
+
+<mailet match="All" class="com.linagora.tmail.mailet.OpenPaasAmqpForwardAttribute">
+  <attribute>extractedContacts</attribute>
+  <exchange>contacts:contact:add</exchange>
+  <exchange_type>FANOUT</exchange_type>
+</mailet>
+----

--- a/docs/modules/ROOT/pages/tmail-backend/features/contactAutocomplete.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/features/contactAutocomplete.adoc
@@ -134,6 +134,8 @@ For example:
 }
 ....
 
+We also provide an integration with openpaas to synchronize contacts from openpaas to TMail. xref:ROOT:tmail-backend/features/openpaas-integration.adoc[Read more]...
+
 == Autocomplete with JMAP
 
 The client can easily get an autocomplete over its domain and account contacts via a simple JMAP method.

--- a/docs/modules/ROOT/pages/tmail-backend/features/openpaas-integration.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/features/openpaas-integration.adoc
@@ -1,0 +1,42 @@
+= OpenPaaS Integration
+:navtitle: OpenPaaS Integration
+
+https://docs.open-paas.org/[OpenPaaS], developed by Linagora, is a collaborative platform offering features such as calendar management, contact storage, and more. TMail integrates with OpenPaaS to offer integrations with OpenPaaS Calendar and address book.
+
+This document describes the key integration points and functionality between TMail and OpenPaaS.
+
+== Features
+TMail provides the following functionalities:
+
+- Adds recipients used by local users to their OpenPaaS collected contacts address book.
+- Imports OpenPaaS contacts into the local auto-complete database.
+- Integrates new events received by email into the OpenPaaS calendar.
+- Updates attendance in the OpenPaaS calendar based on email event responses.
+
+== Architecture and Implementation
+=== Overview
+
+TMail interacts with OpenPaaS through two main channels:
+
+- RabbitMQ Messages.
+- REST API Calls to the https://docs.open-paas.org/apis/web/[OpenPaaS API].
+
+=== OpenPaas Contacts Consumption
+TMail integrates with OpenPaaS to fetch contacts and index them. The `OpenPaasContactsConsumer` class handles contacts consumption by fetching contacts from OpenPaaS and indexing using `EmailAddressContactSearchEngine`.
+
+This integration powers the auto-complete feature in TMail, allowing users to email their OpenPaaS contacts directly from TMail's compose screen.
+
+=== Mail Attribute Forwarding
+Another feature is the ability to forward mail attributes to a OpenPaas through an AMQP server. This is enabled by `OpenPaasAmqpForwardAttribute` mailet.
+
+The integration uses the AMQP server configured in the `openpaas.properties` file.
+
+=== Implementation Notes
+Deploying OpenPaaS alongside TMail is not required, making the integration with OpenPaaS optional.
+
+To create a TMail server with OpenPaaS integration, you need to enable the `OpenPaasModule`. This is achieved through the `OpenPaasModuleChooserConfiguration` class. The same approach can be used to disable OpenPaaS integration.
+
+You can find relevant code snippets in the following files:
+
+- https://github.com/linagora/tmail-backend/blob/d68c1337ed7334364e36007905bdd17b6947de13/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java[DistributedServer]
+- https://github.com/linagora/tmail-backend/blob/d68c1337ed7334364e36007905bdd17b6947de13/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java[MemoryServer]

--- a/tmail-backend/tmail-third-party/openpaas/pom.xml
+++ b/tmail-backend/tmail-third-party/openpaas/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mailets-integration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-testing</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/Exchange.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/Exchange.java
@@ -1,0 +1,18 @@
+package com.linagora.tmail;
+
+import com.google.common.base.Preconditions;
+
+public record Exchange(String name) {
+
+    public Exchange {
+        Preconditions.checkNotNull(name);
+    }
+
+    public static Exchange of(String name) {
+        return new Exchange(name);
+    }
+
+    public boolean isDefaultExchange() {
+        return name.isBlank();
+    }
+}

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttribute.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttribute.java
@@ -1,0 +1,131 @@
+package com.linagora.tmail.mailet;
+
+import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.mail.MessagingException;
+
+import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeValue;
+import org.apache.mailet.Mail;
+import org.apache.mailet.MailetConfig;
+import org.apache.mailet.MailetException;
+import org.apache.mailet.base.GenericMailet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.linagora.tmail.OpenPaasModule;
+import com.rabbitmq.client.AlreadyClosedException;
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.rabbitmq.ExchangeSpecification;
+import reactor.rabbitmq.OutboundMessage;
+
+
+/**
+ * This mailet forwards the attributes values to a OpenPaas through the AMQP protocol.
+ * <br />
+ * It takes 3 parameters:
+ * <ul>
+ * <li>attribute (mandatory): content to be forwarded, expected to be a Map&lt;String, byte[]&gt;
+ * where the byte[] content is issued from a MimeBodyPart.
+ * It is typically generated from the StripAttachment mailet.</li>
+ * <li>exchange (mandatory): name of the AMQP exchange.</li>
+ * <li>exchange_type (optional, default to "direct"): type of the exchange. Valid values are: direct, fanout, topic, headers.</li>
+ * <li>routing_key (optional, default to empty string): name of the routing key on this exchange.</li>
+ * </ul>
+ *
+ * This mailet will send the data attached to the mail as an attribute holding a map.
+ * <p>
+ * @see OpenPaasAmqpForwardAttributeConfig
+ */
+public class OpenPaasAmqpForwardAttribute extends GenericMailet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenPaasAmqpForwardAttribute.class);
+
+    private final ReactorRabbitMQChannelPool openPaasRabbitChannelPool;
+    private OpenPaasAmqpForwardAttributeConfig config;
+
+    @Inject
+    public OpenPaasAmqpForwardAttribute(@Named(OpenPaasModule.OPENPAAS_INJECTION_KEY) ReactorRabbitMQChannelPool openPaasRabbitChannelPool) {
+        this.openPaasRabbitChannelPool = openPaasRabbitChannelPool;
+        openPaasRabbitChannelPool.start();
+    }
+
+    @Override
+    public void init(MailetConfig newConfig) throws MessagingException {
+        super.init(newConfig);
+        config = OpenPaasAmqpForwardAttributeConfig.from(newConfig);
+
+        ExchangeSpecification exchangeSpecification =
+            ExchangeSpecification.exchange(config.exchange())
+                .durable(DURABLE)
+                .type(config.maybeExchangeType().orElse(BuiltinExchangeType.DIRECT).getType());
+
+        openPaasRabbitChannelPool.getSender().declareExchange(exchangeSpecification)
+            .onErrorResume(error -> error instanceof ShutdownSignalException && error.getMessage().contains("reply-code=406, reply-text=PRECONDITION_FAILED"),
+                error -> {
+                    LOGGER.warn("Exchange `{}` already exists but with different configuration. Ignoring this error. \nError message: {}", config.exchange(), error.getMessage());
+                    return Mono.empty();
+                })
+            .block();
+    }
+
+    @Override
+    public void service(Mail mail) throws MailetException {
+        mail.getAttribute(config.attribute())
+            .map(Throwing.function(this::getAttributeContent).sneakyThrow())
+            .ifPresent(this::sendContent);
+    }
+
+    private Stream<byte[]> getAttributeContent(Attribute attribute) throws MailetException {
+        return extractAttributeValueContent(attribute.getValue().value())
+            .orElseThrow(() -> new MailetException("Invalid attribute found into attribute "
+                                                   + config.attribute().asString() + "class Map or List or String expected but "
+                                                   + attribute + " found."));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Stream<byte[]>> extractAttributeValueContent(Object attributeContent) {
+        if (attributeContent instanceof Map) {
+            return Optional.of(((Map<String, AttributeValue<byte[]>>) attributeContent).values().stream()
+                .map(AttributeValue::getValue));
+        }
+        if (attributeContent instanceof List) {
+            return Optional.of(((List<AttributeValue<byte[]>>) attributeContent).stream().map(AttributeValue::value));
+        }
+        if (attributeContent instanceof String) {
+            return Optional.of(Stream.of(((String) attributeContent).getBytes(StandardCharsets.UTF_8)));
+        }
+        return Optional.empty();
+    }
+
+    private void sendContent(Stream<byte[]> content) {
+        try {
+            openPaasRabbitChannelPool.getSender()
+                .send(Flux.fromStream(content)
+                    .map(bytes -> new OutboundMessage(config.exchange(), config.routingKey(), bytes)))
+                .block();
+        } catch (AlreadyClosedException e) {
+            LOGGER.error("AlreadyClosedException while writing to AMQP: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            LOGGER.error("IOException while writing to AMQP: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return "OpenPaasAmqpForwardAttribute";
+    }
+}

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttributeConfig.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttributeConfig.java
@@ -1,0 +1,83 @@
+package com.linagora.tmail.mailet;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.MailetConfig;
+import org.apache.mailet.MailetException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.rabbitmq.client.BuiltinExchangeType;
+
+public record OpenPaasAmqpForwardAttributeConfig(
+    AttributeName attribute,
+    String exchange,
+    Optional<BuiltinExchangeType> maybeExchangeType,
+    String routingKey) {
+
+    public static final String EXCHANGE_PARAMETER_NAME = "exchange";
+    public static final String EXCHANGE_TYPE_PARAMETER_NAME = "exchange_type";
+    public static final String ROUTING_KEY_PARAMETER_NAME = "routing_key";
+    public static final String ATTRIBUTE_PARAMETER_NAME = "attribute";
+    public static final String ROUTING_KEY_DEFAULT_VALUE = "";
+    public static final List<String> VALIDATE_EXCHANGE_TYPES = List.of("direct", "fanout", "topic", "headers");
+
+    public OpenPaasAmqpForwardAttributeConfig {
+        Preconditions.checkNotNull(attribute);
+        Preconditions.checkNotNull(exchange);
+        Preconditions.checkNotNull(maybeExchangeType);
+        Preconditions.checkNotNull(routingKey);
+
+        Preconditions.checkArgument(!exchange.isBlank());
+    }
+
+    public static OpenPaasAmqpForwardAttributeConfig from(MailetConfig mailetConfig)
+        throws MailetException {
+        AttributeName attribute = getAttributeParameter(mailetConfig);
+        String exchange = getExchangeParameter(mailetConfig);
+        Optional<BuiltinExchangeType> maybeExchangeType = getExchangeTypeParameter(mailetConfig);
+        String routingKey = getRoutingKeyParameter(mailetConfig);
+
+        return new OpenPaasAmqpForwardAttributeConfig(
+            attribute,
+            exchange,
+            maybeExchangeType,
+            routingKey);
+    }
+
+    private static String getExchangeParameter(MailetConfig mailetConfig) throws MailetException {
+        String exchange = mailetConfig.getInitParameter(EXCHANGE_PARAMETER_NAME);
+        if (StringUtils.isBlank(exchange)) {
+            throw new MailetException("No value for " + EXCHANGE_PARAMETER_NAME + " parameter was provided.");
+        }
+        return exchange;
+    }
+
+    private static Optional<BuiltinExchangeType> getExchangeTypeParameter(MailetConfig mailetConfig) throws MailetException {
+        String exchangeType = mailetConfig.getInitParameter(EXCHANGE_TYPE_PARAMETER_NAME);
+        if (StringUtils.isNotEmpty(exchangeType) && !VALIDATE_EXCHANGE_TYPES.contains(exchangeType)) {
+            throw new MailetException("Invalid value for " + EXCHANGE_TYPE_PARAMETER_NAME + " parameter was provided: " + exchangeType + ". Valid values are: " + VALIDATE_EXCHANGE_TYPES);
+        }
+
+        return Optional.ofNullable(exchangeType)
+            .filter(StringUtils::isNotBlank)
+            .map(String::toUpperCase)
+            .map(BuiltinExchangeType::valueOf);
+    }
+
+    private static String getRoutingKeyParameter(MailetConfig mailetConfig) {
+        return Optional.ofNullable(mailetConfig.getInitParameter(ROUTING_KEY_PARAMETER_NAME))
+            .orElse(ROUTING_KEY_DEFAULT_VALUE);
+    }
+
+    private static AttributeName getAttributeParameter(MailetConfig mailetConfig) throws MailetException {
+        String rawAttribute = mailetConfig.getInitParameter(ATTRIBUTE_PARAMETER_NAME);
+        if (Strings.isNullOrEmpty(rawAttribute)) {
+            throw new MailetException("No value for " + ATTRIBUTE_PARAMETER_NAME + " parameter was provided.");
+        }
+        return AttributeName.of(rawAttribute);
+    }
+}

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/OpenPaasAmqpForwardAttributeIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/OpenPaasAmqpForwardAttributeIntegrationTest.java
@@ -1,0 +1,371 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package com.linagora.tmail;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.james.backends.rabbitmq.Constants.AUTO_ACK;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.inject.Singleton;
+
+import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.mailets.TemporaryJamesServer;
+import org.apache.james.mailets.configuration.CommonProcessors;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.transport.mailets.ContactExtractor;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.transport.matchers.SMTPAuthSuccessful;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.TestIMAPClient;
+import org.apache.mailet.MailetException;
+import org.apache.mailet.base.test.FakeMail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.util.Modules;
+import com.linagora.tmail.configuration.OpenPaasConfiguration;
+import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
+import com.linagora.tmail.mailet.OpenPaasAmqpForwardAttribute;
+import com.linagora.tmail.mailet.OpenPaasAmqpForwardAttributeConfig;
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.GetResponse;
+
+class OpenPaasAmqpForwardAttributeIntegrationTest {
+    public static final String SENDER = "sender@" + DEFAULT_DOMAIN;
+    public static final String TO = "to@" + DEFAULT_DOMAIN;
+    public static final String EXTRACT_ATTRIBUTE = "ExtractedContacts";
+
+    @RegisterExtension
+    public static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
+        .isolationPolicy(RabbitMQExtension.IsolationPolicy.WEAK);
+
+    @RegisterExtension
+    public TestIMAPClient testIMAPClient = new TestIMAPClient();
+    @RegisterExtension
+    public SMTPMessageSender messageSender = new SMTPMessageSender(DEFAULT_DOMAIN);
+
+    private TemporaryJamesServer jamesServer;
+    private Connection rabbitMQConnection;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setUri(rabbitMQExtension.getRabbitMQ().amqpUri());
+
+        rabbitMQConnection = connectionFactory.newConnection();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        System.setProperty("james.exit.on.startup.error", "true");
+        if (jamesServer != null) {
+            jamesServer.shutdown();
+        }
+        if (rabbitMQConnection != null) {
+            rabbitMQConnection.close();
+        }
+    }
+
+    private Optional<String> getAmqpMessage(Channel rabbitMQChannel, String queueName)
+        throws Exception {
+        return Optional.ofNullable(rabbitMQChannel.basicGet(queueName, AUTO_ACK))
+            .map(GetResponse::getBody)
+            .map(value -> new String(value, StandardCharsets.UTF_8));
+    }
+
+    @Nested
+    class WithOpenPaasModuleAndFanoutRabbitMqExchange {
+        void setUpJamesServer(@TempDir File temporaryFolder, String exchange) throws Exception {
+            MailetConfiguration amqpForwardAttributeMailet = MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(OpenPaasAmqpForwardAttribute.class)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, exchange)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME,
+                    BuiltinExchangeType.FANOUT.getType())
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME,
+                    EXTRACT_ATTRIBUTE)
+                .build();
+
+            jamesServer = TemporaryJamesServer.builder()
+                .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
+                    new OpenPaasModule()))
+                .withOverrides(new AbstractModule() {
+                    @Provides
+                    @Singleton
+                    public OpenPaasConfiguration provideOpenPaasConfiguration()
+                        throws URISyntaxException {
+                        return new OpenPaasConfiguration(
+                            AmqpUri.from(rabbitMQExtension.getRabbitMQ().amqpUri()),
+                            URI.create("http://localhost:8081"),
+                            "user",
+                            "password"
+                        );
+                    }
+                })
+                .withOverrides(new InMemoryEmailAddressContactSearchEngineModule())
+                .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()
+                    .postmaster(SENDER)
+                    .putProcessor(
+                        ProcessorConfiguration.transport()
+                            .addMailet(MailetConfiguration.builder()
+                                .matcher(SMTPAuthSuccessful.class)
+                                .mailet(ContactExtractor.class)
+                                .addProperty(ContactExtractor.Configuration.ATTRIBUTE,
+                                    EXTRACT_ATTRIBUTE))
+                            .addMailet(amqpForwardAttributeMailet)
+                            .addMailetsFrom(CommonProcessors.deliverOnlyTransport())))
+                .build(temporaryFolder);
+
+            jamesServer.start();
+            jamesServer.getProbe(DataProbeImpl.class)
+                .fluent()
+                .addDomain(DEFAULT_DOMAIN)
+                .addUser(SENDER, PASSWORD)
+                .addUser(TO, PASSWORD);
+        }
+
+        @Test
+        void recipientsShouldBePublishedToAmqpWhenSendingEmailWithExchangeTypeFanoutConfiguration(
+            @TempDir File temporaryFolder) throws Exception {
+            // Given AmqpForwardAttribute mailet configured with exchange type fanout
+            String exchangeName = "collector:email" + UUID.randomUUID();
+            String routingKey = "routing1" + UUID.randomUUID();
+
+            MailetConfiguration amqpForwardAttributeMailet = MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(OpenPaasAmqpForwardAttribute.class)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME,
+                    exchangeName)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME,
+                    BuiltinExchangeType.FANOUT.getType())
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME,
+                    EXTRACT_ATTRIBUTE)
+                .build();
+
+            setUpJamesServer(temporaryFolder, exchangeName);
+
+            Channel channel = rabbitMQConnection.createChannel();
+            String queueName = channel.queueDeclare().getQueue();
+            channel.queueBind(queueName, exchangeName, routingKey);
+
+            // when sending an email
+            messageSender.connect(LOCALHOST_IP,
+                    jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+                .authenticate(SENDER, PASSWORD)
+                .sendMessage(FakeMail.builder()
+                    .name("name")
+                    .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .setSender(SENDER)
+                        .addToRecipient(TO)
+                        .setSubject("Contact collection Rocks")
+                        .setText("This is my email"))
+                    .sender(SENDER)
+                    .recipients(TO));
+
+            // then the mailet should be published to AMQP
+            testIMAPClient.connect(LOCALHOST_IP,
+                    jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+                .login(TO, PASSWORD)
+                .select(TestIMAPClient.INBOX)
+                .awaitMessage(awaitAtMostOneMinute);
+
+            Optional<String> actual = getAmqpMessage(channel, queueName);
+            assertThat(actual).isNotEmpty();
+            assertThatJson(actual.get()).isEqualTo("""
+                {
+                "userEmail" : "sender@james.org",
+                "emails" : [ "to@james.org"]
+                }
+                """);
+        }
+    }
+
+    @Nested
+    class WithOpenPaasModuleAndDirectRabbitMqExchange {
+        void setUpJamesServer(@TempDir File temporaryFolder, String exchange) throws Exception {
+            MailetConfiguration amqpForwardAttributeMailet = MailetConfiguration.builder()
+                .matcher(All.class)
+                .mailet(OpenPaasAmqpForwardAttribute.class)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, exchange)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME,
+                    BuiltinExchangeType.DIRECT.getType())
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME,
+                    EXTRACT_ATTRIBUTE)
+                .build();
+
+            jamesServer = TemporaryJamesServer.builder()
+                .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
+                    new OpenPaasModule()))
+                .withOverrides(new AbstractModule() {
+                    @Provides
+                    @Singleton
+                    public OpenPaasConfiguration provideOpenPaasConfiguration()
+                        throws URISyntaxException {
+                        return new OpenPaasConfiguration(
+                            AmqpUri.from(rabbitMQExtension.getRabbitMQ().amqpUri()),
+                            URI.create("http://localhost:8081"),
+                            "user",
+                            "password"
+                        );
+                    }
+                })
+                .withOverrides(new InMemoryEmailAddressContactSearchEngineModule())
+                .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()
+                    .postmaster(SENDER)
+                    .putProcessor(
+                        ProcessorConfiguration.transport()
+                            .addMailet(MailetConfiguration.builder()
+                                .matcher(SMTPAuthSuccessful.class)
+                                .mailet(ContactExtractor.class)
+                                .addProperty(ContactExtractor.Configuration.ATTRIBUTE,
+                                    EXTRACT_ATTRIBUTE))
+                            .addMailet(amqpForwardAttributeMailet)
+                            .addMailetsFrom(CommonProcessors.deliverOnlyTransport())))
+                .build(temporaryFolder);
+
+            jamesServer.start();
+            jamesServer.getProbe(DataProbeImpl.class)
+                .fluent()
+                .addDomain(DEFAULT_DOMAIN)
+                .addUser(SENDER, PASSWORD)
+                .addUser(TO, PASSWORD);
+        }
+
+        @Test
+        void mailetShouldWorkNormalWhenExchangeAlreadyExistsWithDifferentConfiguration(
+            @TempDir File temporaryFolder) throws Exception {
+            // Given an exchange already exists with different configuration
+            String exchangeName = "collector:email" + UUID.randomUUID();
+            String routingKey = "routing1" + UUID.randomUUID();
+
+            Channel channel = rabbitMQConnection.createChannel();
+            channel.exchangeDeclare(exchangeName, BuiltinExchangeType.FANOUT, true, true, null);
+            String queueName = channel.queueDeclare().getQueue();
+            channel.queueBind(queueName, exchangeName, routingKey);
+
+            assertThatCode(() -> setUpJamesServer(temporaryFolder, exchangeName))
+                .doesNotThrowAnyException();
+
+            // When sending an email
+            messageSender.connect(LOCALHOST_IP,
+                    jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+                .authenticate(SENDER, PASSWORD)
+                .sendMessage(FakeMail.builder()
+                    .name("name")
+                    .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .setSender(SENDER)
+                        .addToRecipient(TO)
+                        .setSubject("Contact collection Rocks")
+                        .setText("This is my email"))
+                    .sender(SENDER)
+                    .recipients(TO));
+
+            // Then the mailet should publish AQMP message
+            testIMAPClient.connect(LOCALHOST_IP,
+                    jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+                .login(TO, PASSWORD)
+                .select(TestIMAPClient.INBOX)
+                .awaitMessage(awaitAtMostOneMinute);
+
+            Optional<String> actual = getAmqpMessage(channel, queueName);
+            assertThat(actual).isNotEmpty();
+            assertThatJson(actual.get()).isEqualTo("""
+                {
+                "userEmail" : "sender@james.org",
+                "emails" : [ "to@james.org"]
+                }
+                """);
+        }
+    }
+
+    @Nested
+    class WithoutOpenPaasModule {
+        void setUpJamesServer(@TempDir File temporaryFolder) throws Exception {
+            MailetConfiguration amqpForwardAttribute = MailetConfiguration
+                .builder()
+                .matcher(All.class)
+                .mailet(OpenPaasAmqpForwardAttribute.class)
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "dummy_exchange")
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME,
+                    BuiltinExchangeType.FANOUT.getType())
+                .addProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME,
+                    EXTRACT_ATTRIBUTE).build();
+
+            jamesServer = TemporaryJamesServer.builder()
+                .withBase(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE)
+                .withOverrides(new InMemoryEmailAddressContactSearchEngineModule())
+                .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()
+                    .postmaster(SENDER)
+                    .putProcessor(
+                        ProcessorConfiguration.transport()
+                            .addMailet(MailetConfiguration.builder()
+                                .matcher(SMTPAuthSuccessful.class)
+                                .mailet(ContactExtractor.class)
+                                .addProperty(ContactExtractor.Configuration.ATTRIBUTE,
+                                    EXTRACT_ATTRIBUTE))
+                            .addMailet(amqpForwardAttribute)
+                            .addMailetsFrom(CommonProcessors.deliverOnlyTransport())))
+                .build(temporaryFolder);
+
+            jamesServer.start();
+        }
+
+        @Test
+        void serverShouldCrashWhenMailetLoadedButOpenPaasModuleNotEnabled(
+            @TempDir File temporaryFolder) {
+            // It is hard to detect/catch 'System.exit()' so we set the property to false to avoid the system exit.
+            System.setProperty("james.exit.on.startup.error", "false");
+
+            assertThatThrownBy(() -> setUpJamesServer(temporaryFolder))
+                .hasRootCauseInstanceOf(MailetException.class)
+                .hasRootCauseMessage(
+                    "Failed to initialize mailet. OpenPaasModule is required to this mailet to function correctly.");
+        }
+    }
+}

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttributeConfigTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/mailet/OpenPaasAmqpForwardAttributeConfigTest.java
@@ -1,0 +1,141 @@
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.MailetException;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.Exchange;
+import com.rabbitmq.client.BuiltinExchangeType;
+
+public class OpenPaasAmqpForwardAttributeConfigTest {
+
+    @Test
+    void shouldThrowIfAnyFieldIsNull() {
+        assertThatThrownBy(() -> new OpenPaasAmqpForwardAttributeConfig(
+            AttributeName.of("attribute"),
+            Exchange.of("exchange"),
+            BuiltinExchangeType.DIRECT,
+            null
+        ));
+
+        assertThatThrownBy(() -> new OpenPaasAmqpForwardAttributeConfig(
+            AttributeName.of("attribute"),
+            Exchange.of("exchange"),
+            null,
+            ""
+        ));
+
+        assertThatThrownBy(() -> new OpenPaasAmqpForwardAttributeConfig(
+            AttributeName.of("attribute"),
+            null,
+            BuiltinExchangeType.DIRECT,
+            ""
+        ));
+
+        assertThatThrownBy(() -> new OpenPaasAmqpForwardAttributeConfig(
+            null,
+            Exchange.of("exchange"),
+            BuiltinExchangeType.DIRECT,
+            ""
+        ));
+    }
+
+    @Test
+    void fromShouldThrowIfExchangeIsNotSet() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "direct")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .build();
+
+        assertThatThrownBy(() -> OpenPaasAmqpForwardAttributeConfig.from(mailetConfig))
+            .isInstanceOf(MailetException.class);
+    }
+
+    @Test
+    void fromShouldNotThrowIfExchangeIsBlank() throws MailetException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "direct")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "")
+            .build();
+
+        OpenPaasAmqpForwardAttributeConfig subject =
+            OpenPaasAmqpForwardAttributeConfig.from(mailetConfig);
+
+        assertThat(subject.exchange().isDefaultExchange()).isTrue();
+    }
+
+    @Test
+    void fromShouldNotThrowIfExchangeIsValid() throws MailetException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "direct")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "test-exchange_123.name:example")
+            .build();
+
+        OpenPaasAmqpForwardAttributeConfig.from(mailetConfig);
+    }
+
+    @Test
+    void fromShouldThrowIfAttributeIsBlank() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "direct")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "test-exchange_123.name:example")
+            .build();
+
+        assertThatThrownBy(() -> OpenPaasAmqpForwardAttributeConfig.from(mailetConfig))
+            .isInstanceOf(MailetException.class);
+    }
+
+    @Test
+    void fromShouldThrowIfExchangeTypeIsUnknown() {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "unknown")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "test-exchange_123.name:example")
+            .build();
+
+        assertThatThrownBy(() -> OpenPaasAmqpForwardAttributeConfig.from(mailetConfig))
+            .isInstanceOf(MailetException.class);
+    }
+
+    @Test
+    void fromShouldUseDefaultExchangeTypeWhenItIsBlank() throws MailetException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_PARAMETER_NAME, "routingKey")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "test-exchange_123.name:example")
+            .build();
+
+        OpenPaasAmqpForwardAttributeConfig subject =
+            OpenPaasAmqpForwardAttributeConfig.from(mailetConfig);
+
+        assertThat(subject.exchangeType()).isEqualTo(OpenPaasAmqpForwardAttributeConfig.DEFAULT_EXCHANGE_TYPE);
+    }
+
+    @Test
+    void fromShouldUseDefaultRoutingKeyIsNotSet() throws MailetException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.ATTRIBUTE_PARAMETER_NAME, "attribute")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_TYPE_PARAMETER_NAME, "direct")
+            .setProperty(OpenPaasAmqpForwardAttributeConfig.EXCHANGE_PARAMETER_NAME, "test-exchange_123.name:example")
+            .build();
+
+        OpenPaasAmqpForwardAttributeConfig subject =
+            OpenPaasAmqpForwardAttributeConfig.from(mailetConfig);
+
+        assertThat(subject.routingKey()).isEqualTo(OpenPaasAmqpForwardAttributeConfig.ROUTING_KEY_DEFAULT_VALUE);
+    }
+
+}


### PR DESCRIPTION
Closes https://github.com/linagora/tmail-backend/issues/1273

It is the same as AmqpForwardAtribute, but instead of forwarding attributes to a custom Amqp server, it forwards it to the OpenPaas Amqp server.

## TODO

- [x] Write doc.
- [x] Test behavior when OpenPaas module is not loaded.