### PR TITLE
[ISSUE-1324] advertize that subaddressing is supported

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/TeamMailboxesContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/TeamMailboxesContract.scala
@@ -45,6 +45,7 @@ import org.apache.james.webadmin.WebAdminUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility
 import org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS
+import org.hamcrest.Matchers.{equalTo, hasKey}
 import org.junit.jupiter.api.{BeforeEach, Tag, Test}
 import play.api.libs.json.{JsArray, Json}
 import sttp.capabilities.WebSockets
@@ -3124,6 +3125,22 @@ trait TeamMailboxesContract {
            |			},
            |			"c1"]]
            |}""".stripMargin)
+  }
+
+  @Test
+  def shouldReturnSubaddressingSupportedInTeamMailboxesCapability(): Unit = {
+    val subaddressingSupported = true
+
+    `given`()
+    .when()
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .get("/session")
+    .`then`
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .body("capabilities", hasKey("urn:apache:james:params:jmap:mail:shares"))
+      .body("capabilities.'urn:apache:james:params:jmap:mail:shares'", hasKey("subaddressingSupported"))
+      .body("capabilities.'urn:apache:james:params:jmap:mail:shares'.subaddressingSupported", equalTo(subaddressingSupported))
   }
 
   private def authenticatedRequest(server: GuiceJamesServer): RequestT[Identity, Either[String, String], Any] = {


### PR DESCRIPTION
tackling [ticket 1324](https://github.com/linagora/tmail-backend/issues/1324): 

subaddressing has now been implemented on the backend side, but not fully deployed. we need to have the frontend automatically detect if the backend supports subaddressing or not.

in [this james PR](https://github.com/apache/james-project/pull/2521), i modified the `urn:apache:james:params:jmap:mail:shares` capability to add a `subaddressingSupported` property (boolean). if this property is not defined, then it should be assumed it is not supported.