### PR TITLE
[FCM] Add error log for FCM push

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebasePushClient.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/firebase/FirebasePushClient.java
@@ -58,7 +58,8 @@ public class FirebasePushClient {
     }
 
     public Mono<Void> push(FirebasePushRequest pushRequest) {
-        return sendReactive(createFcmMessage(pushRequest), !DRY_RUN);
+        return sendReactive(createFcmMessage(pushRequest), !DRY_RUN)
+            .doOnError(throwable -> LOGGER.warn("Error when pushing FCM notification", throwable));
     }
 
     public Mono<Boolean> validateToken(FirebaseToken token) {


### PR DESCRIPTION
Useful to spot the FCM timeout error for example:

```json
{
    "timestamp": "2024-11-26T09:47:47.295Z",
    "level": "ERROR",
    "thread": "firebase-default-0",
    "logger": "com.linagora.tmail.james.jmap.firebase.FirebasePushClient",
    "message": "Error when pushing FCM notification",
    "context": "default",
    "exception": "com.google.firebase.messaging.FirebaseMessagingException: Timed out while making an API call: Error getting access token for service account: Connect timed out, iss: firebase-adminsdk-9scwt@fir-jmap-poc.iam.gserviceaccount.com\n\tat com.google.firebase.messaging.FirebaseMessagingException.withMessagingErrorCode(FirebaseMessagingException.java:51)\n\tat com.google.firebase.messaging.FirebaseMessagingClientImpl$MessagingErrorHandler.createException(FirebaseMessagingClientImpl.java:293)\n\tat com.google.firebase.messaging.FirebaseMessagingClientImpl$MessagingErrorHandler.createException(FirebaseMessagingClientImpl.java:282)\n\tat com.google.firebase.internal.AbstractHttpErrorHandler.handleIOException(AbstractHttpErrorHandler.java:63)\n\tat com.google.firebase.internal.ErrorHandlingHttpClient.createHttpRequest(ErrorHandlingHttpClient.java:141)\n\tat com.google.firebase.internal.ErrorHandlingHttpClient.send(ErrorHandlingHttpClient.java:92)\n\tat com.google.firebase.internal.ErrorHandlingHttpClient.sendAndParse(ErrorHandlingHttpClient.java:72)\n\tat com.google.firebase.messaging.FirebaseMessagingClientImpl.sendSingleRequest(FirebaseMessagingClientImpl.java:127)\n\tat com.google.firebase.messaging.FirebaseMessagingClientImpl.send(FirebaseMessagingClientImpl.java:113)\n\tat com.google.firebase.messaging.FirebaseMessaging$1.execute(FirebaseMessaging.java:141)\n\tat com.google.firebase.messaging.FirebaseMessaging$1.execute(FirebaseMessaging.java:138)\n\tat com.google.firebase.internal.CallableOperation.call(CallableOperation.java:36)\n\tat com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)\n\tat com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:76)\n\tat com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\n\tat java.base/java.lang.Thread.run(Unknown Source)\nCaused by: com.google.auth.oauth2.GoogleAuthException: Error getting access token for service account: Connect timed out, iss: firebase-adminsdk-9scwt@fir-jmap-poc.iam.gserviceaccount.com\n\tat com.google.auth.oauth2.GoogleAuthException.createWithTokenEndpointIOException(GoogleAuthException.java:164)\n\tat com.google.auth.oauth2.ServiceAccountCredentials.refreshAccessToken(ServiceAccountCredentials.java:540)\n\tat com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:270)\n\tat com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:267)\n\tat java.base/java.util.concurrent.FutureTask.run(Unknown Source)\n\tat com.google.auth.oauth2.OAuth2Credentials$RefreshTask.run(OAuth2Credentials.java:635)\n\tat com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)\n\tat com.google.auth.oauth2.OAuth2Credentials$AsyncRefreshResult.executeIfNew(OAuth2Credentials.java:582)\n\tat com.google.auth.oauth2.OAuth2Credentials.asyncFetch(OAuth2Credentials.java:233)\n\tat com.google.auth.oauth2.OAuth2Credentials.getRequestMetadata(OAuth2Credentials.java:183)\n\tat com.google.auth.oauth2.ServiceAccountCredentials.getRequestMetadataForGdu(ServiceAccountCredentials.java:947)\n\tat com.google.auth.oauth2.ServiceAccountCredentials.getRequestMetadata(ServiceAccountCredentials.java:936)\n\tat com.google.auth.http.HttpCredentialsAdapter.initialize(HttpCredentialsAdapter.java:96)\n\tat com.google.firebase.internal.FirebaseRequestInitializer.initialize(FirebaseRequestInitializer.java:55)\n\tat com.google.api.client.http.HttpRequestFactory.buildRequest(HttpRequestFactory.java:91)\n\tat com.google.firebase.internal.HttpRequestInfo.newHttpRequest(HttpRequestInfo.java:105)\n\tat com.google.firebase.internal.ErrorHandlingHttpClient.createHttpRequest(ErrorHandlingHttpClient.java:137)\n\t... 13 common frames omitted\nCaused by: java.net.SocketTimeoutException: Connect timed out\n\tat java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(Unknown Source)\n\tat java.base/sun.nio.ch.NioSocketImpl.connect(Unknown Source)\n\tat java.base/java.net.SocksSocketImpl.connect(Unknown Source)\n\tat java.base/java.net.Socket.connect(Unknown Source)\n\tat java.base/sun.security.ssl.SSLSocketImpl.connect(Unknown Source)\n\tat java.base/sun.net.NetworkClient.doConnect(Unknown Source)\n\tat java.base/sun.net.www.http.HttpClient.openServer(Unknown Source)\n\tat java.base/sun.net.www.http.HttpClient.openServer(Unknown Source)\n\tat java.base/sun.net.www.protocol.https.HttpsClient.<init>(Unknown Source)\n\tat java.base/sun.net.www.protocol.https.HttpsClient.New(Unknown Source)\n\tat java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(Unknown Source)\n\tat java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(Unknown Source)\n\tat java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(Unknown Source)\n\tat java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(Unknown Source)\n\tat java.base/sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(Unknown Source)\n\tat java.base/sun.net.www.protocol.http.HttpURLConnection.getOutputStream(Unknown Source)\n\tat java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getOutputStream(Unknown Source)\n\tat com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:113)\n\tat com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:84)\n\tat com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1012)\n\tat com.google.auth.oauth2.ServiceAccountCredentials.refreshAccessToken(ServiceAccountCredentials.java:535)\n\t... 28 common frames omitted\n"
}
```