### PR TITLE
synchronize tmail's auto-complete database after openpaas user update/delete operations

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/ContactRabbitMqMessage.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/ContactRabbitMqMessage.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public record ContactAddedRabbitMqMessage(String bookId, String bookName, String contactId,
+public record ContactRabbitMqMessage(String bookId, String bookName, String contactId,
                                           String userId, JCardObject vcard) {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -14,11 +14,11 @@ public record ContactAddedRabbitMqMessage(String bookId, String bookName, String
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
-    static ContactAddedRabbitMqMessage fromJSON(byte[] jsonBytes) {
+    static ContactRabbitMqMessage fromJSON(byte[] jsonBytes) {
         try {
-            return objectMapper.readValue(jsonBytes, ContactAddedRabbitMqMessage.class);
+            return objectMapper.readValue(jsonBytes, ContactRabbitMqMessage.class);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to parse ContactAddedRabbitMqMessage", e);
+            throw new RuntimeException("Failed to parse ContactRabbitMqMessage", e);
         }
     }
 }


### PR DESCRIPTION
tackling the Synchronise contact delete #1275 and Synchronise contact update #1274 issues

i basically created two more exchanges and two more queues, and depending on the queue, the message is treated differently (new `updateContact` and `deleteContact` similar to the existing `indexContactIfNeeded`).

since the key for these `index`, `update`, `delete` operations is the `accountId` which is obtained through the mail address, the entry is correctly updated when the address does not change (previous entry replaced by the new one, cf the test `contactShouldBeUpdatedWhenContactUserUpdatedMessageWithSameAddress`), whereas if the address is updated then both the old and the new entries are there (cf the test `newContactShouldBeAddedWhenContactUserUpdatedMessageWithUpdatedAddress`)