### PR TITLE
Reuse forks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
                     <version>3.3.0</version>
                     <configuration>
                         <argLine>-Xms512m -Xmx1024m</argLine>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>true</reuseForks>
                         <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                         <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                     </configuration>

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/pom.xml
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/pom.xml
@@ -77,4 +77,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>2</forkCount>
+                    <argLine>-Xms1024m -Xmx2048m</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tmail-backend/tmail-third-party/openpaas/pom.xml
+++ b/tmail-backend/tmail-third-party/openpaas/pom.xml
@@ -88,6 +88,17 @@
                     <config>${project.parent.parent.parent.basedir}/.scalafix.conf</config>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1024m</argLine>
+                    <reuseForks>false</reuseForks>
+                    <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This should be the default, disabled where it fails.

We are loosing so much build time...