### PR TITLE
ISSUE-1392 OpenPaasContactsConsumer - fallback _id to userId when empty

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/ContactRabbitMqMessage.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/ContactRabbitMqMessage.java
@@ -2,12 +2,15 @@ package com.linagora.tmail.contact;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public record ContactRabbitMqMessage(JCardObject vcard,
-                                     @JsonProperty(value = "_id") String openPaasUserId) {
+                                     @JsonProperty(value = "_id") String openPaasUserId,
+                                     @JsonProperty(value = "userId") String userId) {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -21,5 +24,9 @@ public record ContactRabbitMqMessage(JCardObject vcard,
         } catch (IOException e) {
             throw new RuntimeException("Failed to parse ContactRabbitMqMessage", e);
         }
+    }
+
+    public String openPaasUserId() {
+        return StringUtils.defaultIfEmpty(this.openPaasUserId,this.userId);
     }
 }


### PR DESCRIPTION
resolve https://github.com/linagora/tmail-backend/issues/1392#issuecomment-2551167506