### PR TITLE
Upgrade glowroot to v0.14.2 (support java 21)

### DIFF
--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -386,10 +386,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/glowroot/glowroot/releases/download/v0.14.0/glowroot-0.14.0-dist.zip</url>
+                            <url>https://github.com/glowroot/glowroot/releases/download/v0.14.2/glowroot-0.14.2-dist.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <md5>16073f10204751cd71d3b4ea93be2649</md5>
+                            <md5>ac3e10a91f13b5d0758ab4b016cf2ea4</md5>
                         </configuration>
                     </execution>
                     <execution>

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -200,10 +200,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/glowroot/glowroot/releases/download/v0.14.0/glowroot-0.14.0-dist.zip</url>
+                            <url>https://github.com/glowroot/glowroot/releases/download/v0.14.2/glowroot-0.14.2-dist.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <md5>16073f10204751cd71d3b4ea93be2649</md5>
+                            <md5>ac3e10a91f13b5d0758ab4b016cf2ea4</md5>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Spotted while attempting to run Glowroot in `linagora/tmail-backend:memory-1.0.1` to gather metrics.

Error:
```
java.lang.IllegalArgumentException: Unsupported class file major version 67
2025-01-02T08:06:18.214431500Z 	at org.glowroot.agent.shaded.org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
```

We should upgrade glowroot to support java 21

- [x] Tested, new version works 