### PR TITLE
Disable AIBotMailetTest

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIBotMailetTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIBotMailetTest.java
@@ -14,10 +14,12 @@ import org.apache.mailet.MailetException;
 import org.apache.mailet.base.MailAddressFixture;
 import org.apache.mailet.base.test.FakeMailetConfig;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+@Disabled("insufficient_quota error from OpenAI")
 class AIBotMailetTest {
     public static MailAddress createMailAddress(String mailAddress) {
         try {


### PR DESCRIPTION
Somehow OpenAI returns the `insufficient_quota` error (even on my local machine). Could be something hiding behind.

Let's disable this test for now.