### PR TITLE
ISSUE-1299 Fix DistributedLinagoraSecondaryBlobStoreTest and TmailEventSerializer

### DIFF
--- a/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/event/TmailEventSerializer.java
+++ b/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/event/TmailEventSerializer.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.linagora.tmail.blob.secondaryblobstore.FailedBlobEvents;
 import com.linagora.tmail.blob.secondaryblobstore.ObjectStorageIdentity;
 
@@ -58,15 +59,11 @@ public class TmailEventSerializer implements EventSerializer {
     }
 
     @Override
-    public String toJson(Collection<Event> events) {
-        try {
-            List<EventDTO> eventDTOs = events.stream()
-                .map(this::toDTO)
-                .toList();
-            return objectMapper.writeValueAsString(eventDTOs);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+    public String toJson(Collection<Event> event) {
+        if (event.size() != 1) {
+            throw new IllegalArgumentException("Not supported for multiple events, please serialize separately");
         }
+        return toJson(event.iterator().next());
     }
 
     @Override
@@ -81,16 +78,7 @@ public class TmailEventSerializer implements EventSerializer {
 
     @Override
     public List<Event> asEvents(String serialized) {
-        try {
-            List<EventDTO> eventDTOs = objectMapper.readValue(
-                serialized,
-                objectMapper.getTypeFactory().constructCollectionType(List.class, EventDTO.class));
-            return eventDTOs.stream()
-                .map(this::fromDTO)
-                .toList();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return ImmutableList.of(asEvent(serialized));
     }
 
 

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedLinagoraSecondaryBlobStoreTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedLinagoraSecondaryBlobStoreTest.java
@@ -38,6 +38,7 @@ import org.apache.james.events.Group;
 import org.apache.james.jmap.JMAPUrls;
 import org.apache.james.jmap.JmapGuiceProbe;
 import org.apache.james.jmap.http.UserCredential;
+import org.apache.james.junit.categories.BasicFeature;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.apache.james.modules.MailboxProbeImpl;
@@ -51,6 +52,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -82,7 +84,7 @@ import io.restassured.config.RestAssuredConfig;
 import reactor.core.publisher.Flux;
 import reactor.util.retry.Retry;
 
-//@Tag(BasicFeature.TAG) TODO https://github.com/linagora/tmail-backend/issues/1299
+@Tag(BasicFeature.TAG)
 class DistributedLinagoraSecondaryBlobStoreTest {
     public static final ConditionFactory calmlyAwait = Awaitility.with()
         .pollInterval(ONE_HUNDRED_MILLISECONDS)


### PR DESCRIPTION
When putting back the distributed integration tests for secondary blobstore, it was broken. I think tmaileventserializer is used by the secondary blobstore, and does not support multiple event serialization. After fixing this the tests are green.

@chibenwa what version of tmail running on cnb prod? could the secondary blobstore been affected lately?