### PR TITLE
ISSUE-1299 [Build] Make DistributedLinagoraSecondaryBlobStoreTest mor…

### DIFF
--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedLinagoraSecondaryBlobStoreTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedLinagoraSecondaryBlobStoreTest.java
@@ -69,6 +69,7 @@ import org.apache.james.webadmin.routes.TasksRoutes;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -150,24 +151,6 @@ class DistributedLinagoraSecondaryBlobStoreTest {
     static DockerAwsS3Container secondaryS3 = new DockerAwsS3Container();
     static SecondaryS3BlobStoreConfiguration secondaryS3Configuration;
 
-    static {
-        secondaryS3.start();
-        AwsS3AuthConfiguration authConfiguration = AwsS3AuthConfiguration.builder()
-            .endpoint(secondaryS3.getEndpoint())
-            .accessKeyId(DockerAwsS3Container.ACCESS_KEY_ID)
-            .secretKey(DockerAwsS3Container.SECRET_ACCESS_KEY)
-            .build();
-
-        secondaryS3Configuration = new SecondaryS3BlobStoreConfiguration(S3BlobStoreConfiguration.builder()
-            .authConfiguration(authConfiguration)
-            .region(secondaryS3.dockerAwsS3().region())
-            .uploadRetrySpec(Optional.of(Retry.backoff(3, java.time.Duration.ofSeconds(1))
-                .filter(UPLOAD_RETRY_EXCEPTION_PREDICATE)))
-            .readTimeout(Optional.of(Duration.ofMillis(500)))
-            .build(),
-            SECONDARY_BUCKET_SUFFIX);
-    }
-
     @RegisterExtension
     static JamesServerExtension
         testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
@@ -194,6 +177,25 @@ class DistributedLinagoraSecondaryBlobStoreTest {
             .overrideWith(new JmapGuiceKeystoreManagerModule())
             .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class).addBinding().to(BlobStoreProbe.class)))
         .build();
+
+    @BeforeAll
+    static void beforeAll() {
+        secondaryS3.start();
+        AwsS3AuthConfiguration authConfiguration = AwsS3AuthConfiguration.builder()
+            .endpoint(secondaryS3.getEndpoint())
+            .accessKeyId(DockerAwsS3Container.ACCESS_KEY_ID)
+            .secretKey(DockerAwsS3Container.SECRET_ACCESS_KEY)
+            .build();
+
+        secondaryS3Configuration = new SecondaryS3BlobStoreConfiguration(S3BlobStoreConfiguration.builder()
+            .authConfiguration(authConfiguration)
+            .region(secondaryS3.dockerAwsS3().region())
+            .uploadRetrySpec(Optional.of(Retry.backoff(3, java.time.Duration.ofSeconds(1))
+                .filter(UPLOAD_RETRY_EXCEPTION_PREDICATE)))
+            .readTimeout(Optional.of(Duration.ofMillis(500)))
+            .build(),
+            SECONDARY_BUCKET_SUFFIX);
+    }
 
     @AfterAll
     static void afterAll() {


### PR DESCRIPTION
…e stable

By moving static init code to proper BeforeAll static method, on top of being more clean, seems to make the flaky test more stable.

Did try a couple of things, could always reproduce locally flaky test by repeating it 50 times (would start breaking around 20 or 30 runs). But with this, run twice 50 times and was green all the way