### PR TITLE
(JAMES-4099) Ensure TeamMailboxes work with newly introduced configurable mailbox path delimiter

### DIFF
--- a/tmail-backend/imap-extensions/src/test/java/org/apache/james/imap/main/TMailPathConverterTest.java
+++ b/tmail-backend/imap-extensions/src/test/java/org/apache/james/imap/main/TMailPathConverterTest.java
@@ -1,62 +1,144 @@
 package org.apache.james.imap.main;
 
 import org.apache.james.core.Username;
-import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.junit.jupiter.api.Nested;
 
 import com.linagora.tmail.imap.TMailPathConverter;
 
-public class TMailPathConverterTest extends PathConverterBasicContract implements TeamMailboxPathConverterContract {
-    private final PathConverter pathConverter = new TMailPathConverter.Factory().forSession(mailboxSession);
+public class TMailPathConverterTest {
+    @Nested
+    public class BasicContract {
+        @Nested
+        public class DotDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.DOT.value;
+            }
+        }
 
-    @Override
-    public PathConverter pathConverter() {
-        return pathConverter;
-    }
+        @Nested
+        public class SlashDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.SLASH.value;
+            }
+        }
 
-    @Override
-    public PathConverter teamMailboxPathConverter() {
-        return pathConverter;
-    }
+        @Nested
+        public class PipeDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.PIPE.value;
+            }
+        }
 
-    @Override
-    public Username teamMailboxUsername() {
-        return Username.of("team-mailbox");
-    }
+        @Nested
+        public class CommaDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.COMMA.value;
+            }
+        }
 
-    @Override
-    public MailboxSession mailboxSession() {
-        return mailboxSession;
-    }
+        @Nested
+        public class ColonDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.COLON.value;
+            }
+        }
 
-    @Override
-    public char folderDelimiter() {
-        return MailboxConstants.MailboxFolderDelimiter.DOT.value;
+        @Nested
+        public class SemicolonDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.SEMICOLON.value;
+            }
+        }
+
+        public abstract static class TestBase extends PathConverterBasicContract {
+            private final PathConverter pathConverter = new TMailPathConverter.Factory().forSession(mailboxSession);
+
+            @Override
+            public PathConverter pathConverter() {
+                return pathConverter;
+            }
+
+            @Nested
+            class WithEmail extends PathConverterBasicContract.WithEmail {
+                private final PathConverter pathConverter = new TMailPathConverter.Factory().forSession(mailboxWithEmailSession);
+
+                @Override
+                public PathConverter pathConverter() {
+                    return pathConverter;
+                }
+            }
+        }
     }
 
     @Nested
-    class WithEmail extends PathConverterBasicContract.WithEmail implements TeamMailboxPathConverterContract {
-        private final PathConverter pathConverter = new TMailPathConverter.Factory().forSession(mailboxWithEmailSession);
-
-        @Override
-        public PathConverter pathConverter() {
-            return pathConverter;
+    public class TeamMailboxContract {
+        @Nested
+        public class DotDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.DOT.value;
+            }
         }
 
-        @Override
-        public PathConverter teamMailboxPathConverter() {
-            return pathConverter;
+        @Nested
+        public class SlashDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.SLASH.value;
+            }
         }
 
-        @Override
-        public Username teamMailboxUsername() {
-            return Username.of("team-mailbox@apache.org");
+        @Nested
+        public class PipeDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.PIPE.value;
+            }
         }
 
-        @Override
-        public MailboxSession mailboxSession() {
-            return mailboxSession;
+        @Nested
+        public class CommaDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.COMMA.value;
+            }
+        }
+
+        @Nested
+        public class ColonDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.COLON.value;
+            }
+        }
+
+        @Nested
+        public class SemicolonDelimiter extends TestBase {
+            @Override
+            public char folderDelimiter() {
+                return MailboxConstants.MailboxFolderDelimiter.SEMICOLON.value;
+            }
+        }
+
+        public abstract static class TestBase extends TeamMailboxPathConverterContract {
+            private final PathConverter pathConverter = new TMailPathConverter.Factory().forSession(mailboxSession);
+
+            @Override
+            public PathConverter teamMailboxPathConverter() {
+                return pathConverter;
+            }
+
+            @Override
+            public Username teamMailboxUsername() {
+                return Username.of("team-mailbox");
+            }
         }
     }
 }

--- a/tmail-backend/imap-extensions/src/test/java/org/apache/james/imap/main/TeamMailboxPathConverterContract.java
+++ b/tmail-backend/imap-extensions/src/test/java/org/apache/james/imap/main/TeamMailboxPathConverterContract.java
@@ -22,45 +22,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
+import org.apache.james.mailbox.model.MailboxFolderDelimiterAwareTest;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.junit.jupiter.api.Test;
 
-public interface TeamMailboxPathConverterContract {
-    boolean RELATIVE = true;
+public abstract class TeamMailboxPathConverterContract extends MailboxFolderDelimiterAwareTest {
+    public static final boolean RELATIVE = true;
 
-    PathConverter teamMailboxPathConverter();
+    public final MailboxSession mailboxSession = MailboxSessionUtil.create(Username.of("username"), folderDelimiter());
 
-    Username teamMailboxUsername();
+    abstract PathConverter teamMailboxPathConverter();
 
-    MailboxSession mailboxSession();
+    abstract Username teamMailboxUsername();
+
 
     @Test
-    default void buildFullPathShouldAcceptTeamMailboxName() {
-        assertThat(teamMailboxPathConverter().buildFullPath("#TeamMailbox.sale"))
+    public void buildFullPathShouldAcceptTeamMailboxName() {
+        assertThat(teamMailboxPathConverter().buildFullPath(adjustToActiveFolderDelimiter("#TeamMailbox.sale")))
             .isEqualTo(new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"));
     }
 
     @Test
-    default void buildFullPathShouldShouldReturnFullTeamMailboxName() {
-        assertThat(teamMailboxPathConverter().buildFullPath("#TeamMailbox.sale.INBOX"))
-            .isEqualTo(new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale.INBOX"));
+    public void buildFullPathShouldShouldReturnFullTeamMailboxName() {
+        assertThat(teamMailboxPathConverter().buildFullPath(adjustToActiveFolderDelimiter("#TeamMailbox.sale.INBOX")))
+            .isEqualTo(new MailboxPath("#TeamMailbox", teamMailboxUsername(),  adjustToActiveFolderDelimiter("sale.INBOX")));
     }
 
     @Test
-    default void buildFullPathWithTeamMailboxNamespaceShouldIgnoreCase() {
-        assertThat(teamMailboxPathConverter().buildFullPath("#teammailbox.sale"))
+    public void buildFullPathWithTeamMailboxNamespaceShouldIgnoreCase() {
+        assertThat(teamMailboxPathConverter().buildFullPath(adjustToActiveFolderDelimiter("#teammailbox.sale")))
             .isEqualTo(new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"));
     }
 
     @Test
-    default void mailboxNameShouldReturnNamespaceAndNameWhenRelative() {
-        assertThat(teamMailboxPathConverter().mailboxName(RELATIVE, new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"), mailboxSession()))
-            .contains("#TeamMailbox.sale");
+    public void mailboxNameShouldReturnNamespaceAndNameWhenRelative() {
+        assertThat(teamMailboxPathConverter().mailboxName(RELATIVE, new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"), mailboxSession))
+            .contains(adjustToActiveFolderDelimiter("#TeamMailbox.sale"));
     }
 
     @Test
-    default void mailboxNameShouldReturnNamespaceAndNameWhenNotRelative() {
-        assertThat(teamMailboxPathConverter().mailboxName(!RELATIVE, new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"), mailboxSession()))
-            .contains("#TeamMailbox.sale");
+    public void mailboxNameShouldReturnNamespaceAndNameWhenNotRelative() {
+        assertThat(teamMailboxPathConverter().mailboxName(!RELATIVE, new MailboxPath("#TeamMailbox", teamMailboxUsername(), "sale"), mailboxSession))
+            .contains(adjustToActiveFolderDelimiter("#TeamMailbox.sale"));
     }
 }

--- a/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailbox.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailbox.scala
@@ -119,7 +119,7 @@ object TeamMailbox {
   def from(mailboxPath: MailboxPath): Option[TeamMailbox] = mailboxPath.getNamespace match {
     case TEAM_MAILBOX_NAMESPACE =>
       for {
-        name <- TeamMailboxName.validate(mailboxPath.getHierarchyLevels('.').get(0).getName())
+        name <- TeamMailboxName.validate(mailboxPath.getHierarchyLevels(MailboxConstants.FOLDER_DELIMITER).get(0).getName())
           .map(nameValue => TeamMailboxName(nameValue))
           .toOption
         domain <- mailboxPath.getUser.getDomainPart.toScala
@@ -151,11 +151,11 @@ case class TeamMailbox(domain: Domain, mailboxName: TeamMailboxName) {
 
   def mailboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), mailboxName.value)
 
-  def mailboxPath(subPath : String): MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.$subPath")
+  def mailboxPath(subPath : String): MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.FOLDER_DELIMITER}$subPath")
 
-  def inboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.${MailboxConstants.INBOX}")
+  def inboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.FOLDER_DELIMITER}${MailboxConstants.INBOX}")
 
-  def sentPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.Sent")
+  def sentPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.FOLDER_DELIMITER}Sent")
 
   def defaultMailboxPaths: Seq[MailboxPath] = Seq(
     mailboxPath,


### PR DESCRIPTION
@chibenwa As promised in #1405, this PR ensures TeamMailboxes work with [the newly introduced configurable path delimiter](https://github.com/apache/james-project/pull/2588) and adjusts the `TmailPathConverterTests` accordingly.