### PR TITLE
JCardObjectDeserializer: sanitize `mailto:` prefix

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/contact/JCardObjectDeserializerTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/contact/JCardObjectDeserializerTest.java
@@ -184,6 +184,20 @@ class JCardObjectDeserializerTest {
     }
 
     @Test
+    void shouldParseEmailAddressWhenMailToPrefix() throws AddressException {
+        JCardObject cardObject = deserialize("""
+            [
+             "vcard",
+               [
+                 [ "email",   {}, "text", "mailto:jhon@doe.com" ]
+               ]
+            ]
+            """);
+
+        assertThat(cardObject.mailAddresses().getFirst()).isEqualTo(new MailAddress("jhon@doe.com"));
+    }
+
+    @Test
     void shouldThrowOnBadPayload() {
         assertThatThrownBy(() -> deserialize("BAD_PAYLOAD"));
     }


### PR DESCRIPTION
Spotted on MU preprod:

```java
{
    "timestamp": "2025-03-10T06:01:25.790Z",
    "level": "INFO",
    "thread": "rabbitmq-driver-8",
    "logger": "com.linagora.tmail.contact.JCardObjectDeserializer",
    "message": "Invalid contact mail address 'mailto:test21@test.org' found in JCard Object",
    "context": "default"
}
```


