### PR TITLE
ISSUE-1400 Refactor EventAttendanceRepository & related classes

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/AttendanceStatus.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/AttendanceStatus.java
@@ -82,12 +82,12 @@ public enum AttendanceStatus {
         return fromPartStat(partstat);
     }
 
-    public Optional<PartStat> toPartStat() {
+    public PartStat toPartStat() {
         return switch (this) {
-            case Accepted -> Optional.of(PartStat.ACCEPTED);
-            case Declined -> Optional.of(PartStat.DECLINED);
-            case Tentative -> Optional.of(PartStat.TENTATIVE);
-            case NeedsAction -> Optional.of(PartStat.NEEDS_ACTION);
+            case Accepted -> PartStat.ACCEPTED;
+            case Declined -> PartStat.DECLINED;
+            case Tentative -> PartStat.TENTATIVE;
+            case NeedsAction -> PartStat.NEEDS_ACTION;
         };
     }
 

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/EventAttendanceRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/EventAttendanceRepository.java
@@ -18,21 +18,22 @@
 
 package com.linagora.tmail.james.jmap;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.core.Username;
-import org.apache.james.jmap.mail.BlobIds;
+import org.apache.james.jmap.mail.BlobId;
 import org.reactivestreams.Publisher;
-
 
 import com.linagora.tmail.james.jmap.model.CalendarEventAttendanceResults;
 import com.linagora.tmail.james.jmap.model.CalendarEventReplyResults;
 import com.linagora.tmail.james.jmap.model.LanguageLocation;
 
 public interface EventAttendanceRepository {
-   Publisher<CalendarEventAttendanceResults> getAttendanceStatus(Username username, BlobIds calendarEventBlobIds);
+
+   Publisher<CalendarEventAttendanceResults> getAttendanceStatus(Username username, List<BlobId> blobIds);
    
    Publisher<CalendarEventReplyResults> setAttendanceStatus(Username username, AttendanceStatus attendanceStatus,
-                                                            BlobIds eventBlobIds,
+                                                            List<BlobId> eventBlobIds,
                                                             Optional<LanguageLocation> maybePreferredLanguage);
 }

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventAttendanceResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventAttendanceResults.scala
@@ -22,9 +22,10 @@ import com.linagora.tmail.james.jmap.AttendanceStatus
 import org.apache.james.jmap.core.SetError
 import org.apache.james.jmap.core.SetError.SetErrorDescription
 import org.apache.james.jmap.mail.BlobId
-import org.apache.james.mailbox.MailboxSession
 
 object CalendarEventAttendanceResults {
+  val AttendanceResult: CalendarEventAttendanceResults.type = this
+
   def merge(r1: CalendarEventAttendanceResults, r2: CalendarEventAttendanceResults): CalendarEventAttendanceResults =
     CalendarEventAttendanceResults(
       done = r1.done ++ r2.done,
@@ -38,8 +39,14 @@ object CalendarEventAttendanceResults {
   def done(eventAttendanceEntry: EventAttendanceStatusEntry): CalendarEventAttendanceResults =
     CalendarEventAttendanceResults(List(eventAttendanceEntry))
 
+  def done(blobId: String, eventAttendanceStatus: AttendanceStatus): CalendarEventAttendanceResults =
+    done(EventAttendanceStatusEntry(blobId, eventAttendanceStatus))
+
   def notDone(notParsable: CalendarEventNotParsable): CalendarEventAttendanceResults =
-    CalendarEventAttendanceResults(notDone = Some(CalendarEventNotDone(notParsable.asSetErrorMap)))
+    notParsable.value match {
+      case set if set.isEmpty => CalendarEventAttendanceResults()
+      case _ => CalendarEventAttendanceResults(notDone = Some(CalendarEventNotDone(notParsable.asSetErrorMap)))
+    }
 
   def notDone(blobId: BlobId, throwable: Throwable): CalendarEventAttendanceResults =
     CalendarEventAttendanceResults(notDone = Some(CalendarEventNotDone(Map(blobId.value -> asSetError(throwable)))), done = List(), notFound = None)
@@ -56,4 +63,4 @@ case class CalendarEventAttendanceResults(done: List[EventAttendanceStatusEntry]
                                           notFound: Option[CalendarEventNotFound] = Option.empty,
                                           notDone: Option[CalendarEventNotDone] = Option.empty)
 
-case class EventAttendanceStatusEntry(blobId: String, eventAttendanceStatus:AttendanceStatus)
+case class EventAttendanceStatusEntry(blobId: String, eventAttendanceStatus: AttendanceStatus)

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -27,6 +27,8 @@ import org.slf4j.{Logger, LoggerFactory}
 object CalendarEventReplyResults {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[CalendarEventReplyResults])
 
+  val ReplyResults: CalendarEventReplyResults.type = this
+
   def merge(r1: CalendarEventReplyResults, r2: CalendarEventReplyResults): CalendarEventReplyResults =
     CalendarEventReplyResults(
       done = BlobIds(r1.done.value ++ r2.done.value),

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/TMailJMAPModule.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/TMailJMAPModule.scala
@@ -50,6 +50,7 @@ class TMailJMAPModule extends AbstractModule {
   def providePublicAssetTotalSizeLimit(jmapExtensionConfiguration: JMAPExtensionConfiguration): PublicAssetTotalSizeLimit = jmapExtensionConfiguration.publicAssetTotalSizeLimit
 
   @Provides
+  @Singleton
   def provideEventAttendanceRepository(messageIdManager: MessageIdManager, sessionProvider: SessionProvider, calendarEventReplyPerformer: CalendarEventReplyPerformer, messageIdFactory: MessageId.Factory): EventAttendanceRepository =
     new StandaloneEventAttendanceRepository(messageIdManager, sessionProvider, calendarEventReplyPerformer, messageIdFactory)
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventMaybeMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventMaybeMethod.scala
@@ -20,7 +20,7 @@ package com.linagora.tmail.james.jmap.method
 
 import com.linagora.tmail.james.jmap.json.CalendarEventReplySerializer
 import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_CALENDAR
-import com.linagora.tmail.james.jmap.model.{CalendarEventReplyMaybeResponse, CalendarEventReplyRequest}
+import com.linagora.tmail.james.jmap.model.{CalendarEventNotParsable, CalendarEventReplyMaybeResponse, CalendarEventReplyRequest, CalendarEventReplyResults}
 import com.linagora.tmail.james.jmap.{AttendanceStatus, EventAttendanceRepository}
 import eu.timepit.refined.auto._
 import jakarta.inject.Inject
@@ -28,15 +28,17 @@ import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JM
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
 import org.apache.james.jmap.core.{Invocation, SessionTranslator}
 import org.apache.james.jmap.json.ResponseSerializer
+import org.apache.james.jmap.mail.BlobId
 import org.apache.james.jmap.method.{InvocationWithContext, MethodRequiringAccountId}
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
 import org.reactivestreams.Publisher
 import play.api.libs.json.JsObject
-import reactor.core.publisher.Mono
+import reactor.core.scala.publisher.SMono
 
 import scala.compat.java8.OptionConverters
+import scala.jdk.CollectionConverters._
 
 class CalendarEventMaybeMethod @Inject()(val eventAttendanceRepository: EventAttendanceRepository,
                                          val metricFactory: MetricFactory,
@@ -50,15 +52,18 @@ class CalendarEventMaybeMethod @Inject()(val eventAttendanceRepository: EventAtt
   override val requiredCapabilities: Set[CapabilityIdentifier] = Set(JMAP_CORE, LINAGORA_CALENDAR)
 
   override def doProcess(capabilities: Set[CapabilityIdentifier], invocation: InvocationWithContext,
-                         mailboxSession: MailboxSession, request: CalendarEventReplyRequest): Publisher[InvocationWithContext] = {
-    Mono.from(eventAttendanceRepository.setAttendanceStatus(mailboxSession.getUser, AttendanceStatus.Tentative, request.blobIds, OptionConverters.toJava(request.language)))
-      .map(result => CalendarEventReplyMaybeResponse.from(request.accountId, result))
-      .map(response => Invocation(
-        methodName,
-        Arguments(CalendarEventReplySerializer.serialize(response).as[JsObject]),
-        invocation.invocation.methodCallId))
-      .map(InvocationWithContext(_, invocation.processingContext))
-  }
+                         mailboxSession: MailboxSession, request: CalendarEventReplyRequest): Publisher[InvocationWithContext] =
+    CalendarEventReplyRequest.extractParsedBlobIds(request) match {
+      case (notParsable: CalendarEventNotParsable, blobIdList: Seq[BlobId]) =>
+        SMono(eventAttendanceRepository.setAttendanceStatus(mailboxSession.getUser, AttendanceStatus.Tentative, blobIdList.asJava, OptionConverters.toJava(request.language)))
+          .map(result => CalendarEventReplyResults.merge(result, CalendarEventReplyResults.notDone(notParsable)))
+          .map(result => CalendarEventReplyMaybeResponse.from(request.accountId, result))
+          .map(response => Invocation(
+            methodName,
+            Arguments(CalendarEventReplySerializer.serialize(response).as[JsObject]),
+            invocation.invocation.methodCallId))
+          .map(InvocationWithContext(_, invocation.processingContext))
+    }
 
   override def getRequest(mailboxSession: MailboxSession, invocation: Invocation): Either[Exception, CalendarEventReplyRequest] =
     CalendarEventReplySerializer.deserializeRequest(invocation.arguments.value)

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventRejectMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventRejectMethod.scala
@@ -20,7 +20,7 @@ package com.linagora.tmail.james.jmap.method
 
 import com.linagora.tmail.james.jmap.json.CalendarEventReplySerializer
 import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_CALENDAR
-import com.linagora.tmail.james.jmap.model.{CalendarEventReplyAcceptedResponse, CalendarEventReplyRejectedResponse, CalendarEventReplyRequest}
+import com.linagora.tmail.james.jmap.model.{CalendarEventNotParsable, CalendarEventReplyRejectedResponse, CalendarEventReplyRequest, CalendarEventReplyResults}
 import com.linagora.tmail.james.jmap.{AttendanceStatus, EventAttendanceRepository}
 import eu.timepit.refined.auto._
 import jakarta.inject.Inject
@@ -28,6 +28,7 @@ import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JM
 import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
 import org.apache.james.jmap.core.{Invocation, SessionTranslator}
 import org.apache.james.jmap.json.ResponseSerializer
+import org.apache.james.jmap.mail.BlobId
 import org.apache.james.jmap.method.{InvocationWithContext, MethodRequiringAccountId}
 import org.apache.james.jmap.routes.SessionSupplier
 import org.apache.james.mailbox.MailboxSession
@@ -37,6 +38,7 @@ import play.api.libs.json.JsObject
 import reactor.core.publisher.Mono
 
 import scala.compat.java8.OptionConverters
+import scala.jdk.CollectionConverters._
 
 class CalendarEventRejectMethod @Inject()(val eventAttendanceRepository: EventAttendanceRepository,
                                           val metricFactory: MetricFactory,
@@ -56,11 +58,15 @@ class CalendarEventRejectMethod @Inject()(val eventAttendanceRepository: EventAt
                          invocation: InvocationWithContext,
                          mailboxSession: MailboxSession,
                          request: CalendarEventReplyRequest): Publisher[InvocationWithContext] =
-    Mono.from(eventAttendanceRepository.setAttendanceStatus(mailboxSession.getUser, AttendanceStatus.Declined, request.blobIds, OptionConverters.toJava(request.language)))
-      .map(result => CalendarEventReplyRejectedResponse.from(request.accountId, result))
-      .map(response => Invocation(
-        methodName,
-        Arguments(CalendarEventReplySerializer.serialize(response).as[JsObject]),
-        invocation.invocation.methodCallId))
-      .map(InvocationWithContext(_, invocation.processingContext))
+    CalendarEventReplyRequest.extractParsedBlobIds(request) match {
+      case (notParsable: CalendarEventNotParsable, blobIdList: Seq[BlobId]) =>
+        Mono.from(eventAttendanceRepository.setAttendanceStatus(mailboxSession.getUser, AttendanceStatus.Declined, blobIdList.asJava, OptionConverters.toJava(request.language)))
+          .map(result => CalendarEventReplyResults.merge(result, CalendarEventReplyResults.notDone(notParsable)))
+          .map(result => CalendarEventReplyRejectedResponse.from(request.accountId, result))
+          .map(response => Invocation(
+            methodName,
+            Arguments(CalendarEventReplySerializer.serialize(response).as[JsObject]),
+            invocation.invocation.methodCallId))
+          .map(InvocationWithContext(_, invocation.processingContext))
+    }
 }


### PR DESCRIPTION
When I Implementing:
- https://github.com/linagora/tmail-backend/issues/1567

I see a lot of boilerplate in the EventAttendanceRepository 
reason when try to repeated convert `blobId` between scala <-> java in several times.
The code difficult to read.

And the keep of old code `CalendarEventReplyPerformer` make we parsable blobId twice time, it is un necessary. 

So this pr: 

- Reducing boilerplat
- Avoid parse blobId twice time
