### PR TITLE
Openpaas Module - Improve test class isolation for Guice server

### DIFF
--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventAcceptMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventAcceptMethodTest.java
@@ -57,7 +57,7 @@ public class DistributedOpenPaaSCalendarEventAcceptMethodTest extends LinagoraCa
     static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationFromClasspath()
+            .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
             .blobStore(BlobStoreConfiguration.builder()
                 .s3()
                 .noSecondaryS3BlobStore()

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventMaybeMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventMaybeMethodTest.java
@@ -59,7 +59,7 @@ public class DistributedOpenPaaSCalendarEventMaybeMethodTest extends LinagoraCal
         testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationFromClasspath()
+            .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
             .blobStore(BlobStoreConfiguration.builder()
                 .s3()
                 .noSecondaryS3BlobStore()

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventRejectMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/DistributedOpenPaaSCalendarEventRejectMethodTest.java
@@ -59,7 +59,7 @@ public class DistributedOpenPaaSCalendarEventRejectMethodTest extends LinagoraCa
         testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationFromClasspath()
+            .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
             .blobStore(BlobStoreConfiguration.builder()
                 .s3()
                 .noSecondaryS3BlobStore()

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/OpenpaasTestUtils.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/OpenpaasTestUtils.java
@@ -1,0 +1,42 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.openpaas;
+
+import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
+
+import java.io.File;
+
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.common.TemporaryTmailServerUtils;
+
+public class OpenpaasTestUtils {
+
+    public static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
+        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
+            .addAll(BASE_CONFIGURATION_FILE_NAMES)
+            .add("mailetcontainer_openpaas_dav.xml")
+            .add("rabbitmq.properties")
+            .add("managesieveserver.xml")
+            .build());
+        serverUtils.copyResource("mailetcontainer_openpaas_dav.xml", "mailetcontainer.xml");
+        return serverUtils.getConfigurationPath();
+    }
+}

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/resources/mailetcontainer_openpaas_dav.xml
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/resources/mailetcontainer_openpaas_dav.xml
@@ -83,6 +83,12 @@
                 <rawSource>rawIcalendar2</rawSource>
                 <onMailetException>ignore</onMailetException>
             </mailet>
+            <mailet match="com.linagora.tmail.mailet.IsOpenPaasRabbitMqSetup" class="com.linagora.tmail.mailet.OpenPaasAmqpForwardAttribute">
+                <attribute>icalendarAsJson2</attribute>
+                <exchange>james:events</exchange>
+                <exchange_type>fanout</exchange_type>
+                <routing_key>icalendar_routing_key2</routing_key>
+            </mailet>
             <!-- End of ICAL pipeline -->
             <mailet match="All" class="RecipientRewriteTable">
                 <errorProcessor>rrt-error</errorProcessor>

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/java/com/linagora/tmail/common/TemporaryTmailServerUtils.java
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/java/com/linagora/tmail/common/TemporaryTmailServerUtils.java
@@ -1,0 +1,94 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.common;
+
+import static org.apache.james.filesystem.api.FileSystem.FILE_PROTOCOL;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.google.common.collect.ImmutableList;
+
+public class TemporaryTmailServerUtils {
+    public static final List<String> BASE_CONFIGURATION_FILE_NAMES = ImmutableList.of(
+        "dnsservice.xml",
+        "domainlist.xml",
+        "imapserver.xml",
+        "keystore",
+        "listeners.xml",
+        "mailetcontainer.xml",
+        "mailrepositorystore.xml",
+        "smtpserver.xml",
+        "webadmin.properties",
+        "firebase.properties",
+        "jmap.properties");
+
+    private final Path configFolder;
+    private final List<String> configFileNames;
+
+    public TemporaryTmailServerUtils(File workingDir, List<String> configFileNames) {
+        Path workingDirPath = workingDir.toPath();
+        this.configFileNames = configFileNames;
+        this.configFolder = workingDirPath.resolve("conf");
+
+        try {
+            Files.createDirectories(configFolder);
+            copyAllResources();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create configuration folder or copy resources", e);
+        }
+    }
+
+    private void copyAllResources() {
+        configFileNames.forEach(fileName -> copyResource(fileName, fileName));
+    }
+
+    public void copyResource(String resourceName, String targetName) {
+        copyResource(configFolder, resourceName, targetName);
+    }
+
+    public static void copyResource(Path destinationFolder, String resourceName, String targetName) {
+        Path targetPath = destinationFolder.resolve(targetName);
+        URL resourceUrl = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource(resourceName),
+            "Failed to load configuration resource: " + resourceName);
+
+        try (InputStream inputStream = resourceUrl.openStream(); OutputStream outputStream = Files.newOutputStream(targetPath)) {
+            inputStream.transferTo(outputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Error copying resource: " + resourceName, e);
+        }
+    }
+
+    public Path getConfigFolder() {
+        return configFolder;
+    }
+
+    public Configuration.ConfigurationPath getConfigurationPath() {
+        return new Configuration.ConfigurationPath(FILE_PROTOCOL + configFolder.toAbsolutePath() + File.separator);
+    }
+}

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventCounterAcceptMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventCounterAcceptMethodTest.java
@@ -48,6 +48,7 @@ import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.common.CalendarEventCounterAcceptMethodContract;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.james.openpaas.OpenpaasTestUtils;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
 import net.fortuna.ical4j.model.Calendar;
@@ -64,7 +65,7 @@ public class MemoryCalendarEventCounterAcceptMethodTest implements CalendarEvent
         jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
         MemoryConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationFromClasspath()
+            .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
             .usersRepository(DEFAULT)
             .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
             .openPaasModuleChooserConfiguration(OpenPaasModuleChooserConfiguration.ENABLED_DAV)

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventSupportCapabilityTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryCalendarEventSupportCapabilityTest.java
@@ -39,6 +39,7 @@ import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.common.CalendarEventSupportCapabilityContract;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.james.openpaas.OpenpaasTestUtils;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
 public class MemoryCalendarEventSupportCapabilityTest implements CalendarEventSupportCapabilityContract {
@@ -59,7 +60,7 @@ public class MemoryCalendarEventSupportCapabilityTest implements CalendarEventSu
 
         guiceJamesServer = MemoryServer.createServer(MemoryConfiguration.builder()
                 .workingDirectory(tmpDir)
-                .configurationFromClasspath()
+                .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
                 .usersRepository(DEFAULT)
                 .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
                 .openPaasModuleChooserConfiguration(openPaasModuleChooserConfigurationPair.getKey())

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryLinagoraCalendarEventAttendanceGetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryLinagoraCalendarEventAttendanceGetMethodTest.java
@@ -45,6 +45,7 @@ import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.common.LinagoraCalendarEventAttendanceGetMethodContract;
 import com.linagora.tmail.james.jmap.calendar.CalendarEventHelper;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.james.openpaas.OpenpaasTestUtils;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
 public class MemoryLinagoraCalendarEventAttendanceGetMethodTest {
@@ -96,7 +97,7 @@ public class MemoryLinagoraCalendarEventAttendanceGetMethodTest {
             jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
             MemoryConfiguration.builder()
                 .workingDirectory(tmpDir)
-                .configurationFromClasspath()
+                .configurationPath(OpenpaasTestUtils.setupConfigurationPath(tmpDir))
                 .usersRepository(DEFAULT)
                 .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
                 .openPaasModuleChooserConfiguration(OpenPaasModuleChooserConfiguration.ENABLED_DAV)

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/OpenpaasTestUtils.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/openpaas/OpenpaasTestUtils.java
@@ -1,0 +1,43 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.openpaas;
+
+import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
+
+import java.io.File;
+
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.common.TemporaryTmailServerUtils;
+
+public class OpenpaasTestUtils {
+
+    public static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
+        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
+            .addAll(BASE_CONFIGURATION_FILE_NAMES)
+            .add("mailetcontainer_with_amqpforward_openpass.xml")
+            .add("linagora-ecosystem.properties")
+            .add("usersrepository.xml")
+            .add("pop3server.xml")
+            .build());
+        serverUtils.copyResource("mailetcontainer_with_amqpforward_openpass.xml", "mailetcontainer.xml");
+        return serverUtils.getConfigurationPath();
+    }
+}


### PR DESCRIPTION
This PR makes it easier to write test classes with the Guice James server, ensuring independence from specific configuration files and avoiding mixing them into a single file, such as `mailetcontainer.xml`.