### PR TITLE
[ENHANCEMENT] Log HTTP method of request when fallback proxying

### DIFF
--- a/twake-calendar-side-service/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/FallbackProxy.java
+++ b/twake-calendar-side-service/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/FallbackProxy.java
@@ -64,7 +64,7 @@ public class FallbackProxy {
     }
 
     public Mono<Void> forwardRequest(HttpServerRequest request, HttpServerResponse response) {
-        LOGGER.warn("Proxying {}", request.uri());
+        LOGGER.warn("Proxying {} {}", request.method(), request.uri());
         return request.receive().aggregate().asByteArray()
             .switchIfEmpty(Mono.just("".getBytes()))
             .flatMap(payload -> handleAuthIfNeeded(request)


### PR DESCRIPTION
The current log without HTTP Method make confuse for "guess" which feature is missing

Eg:
```
10:01:13.508 [WARN ] c.l.c.r.FallbackProxy - Proxying /api/users/5f50a663bdaffe002629099c
```

Maybe it is UPDATE api
not GET
![image](https://github.com/user-attachments/assets/467e0643-615c-44c8-8cbb-4557a6e62353)
