### PR TITLE
WIP ISSUE-1585 Fix connections in RedisEventBusClientFactory

### DIFF
--- a/tmail-backend/event-bus-redis/src/main/scala/org/apache/james/events/RedisEventBusClientFactory.scala
+++ b/tmail-backend/event-bus-redis/src/main/scala/org/apache/james/events/RedisEventBusClientFactory.scala
@@ -30,13 +30,9 @@ class RedisEventBusClientFactory @Singleton() @Inject()
 (redisConfiguration: RedisConfiguration, redisClientFactory: RedisClientFactory) {
   val rawRedisClient: AbstractRedisClient = redisConfiguration match {
     case standaloneConfiguration: StandaloneRedisConfiguration => redisClientFactory.createStandaloneClient(standaloneConfiguration)
-    case masterReplicaRedisConfiguration: MasterReplicaRedisConfiguration =>
-      redisClientFactory.createStandaloneClient(new StandaloneRedisConfiguration(masterReplicaRedisConfiguration.redisURI.value.last,
-        masterReplicaRedisConfiguration.useSSL, masterReplicaRedisConfiguration.mayBeSSLConfiguration, masterReplicaRedisConfiguration.ioThreads, masterReplicaRedisConfiguration.workerThreads))
+    case masterReplicaRedisConfiguration: MasterReplicaRedisConfiguration => redisClientFactory.createMasterReplicaClient(masterReplicaRedisConfiguration)
     case clusterRedisConfiguration: ClusterRedisConfiguration => redisClientFactory.createClusterClient(clusterRedisConfiguration)
-    case sentinelRedisConfiguration: SentinelRedisConfiguration =>
-      redisClientFactory.createStandaloneClient(new StandaloneRedisConfiguration(sentinelRedisConfiguration.redisURI,
-        sentinelRedisConfiguration.useSSL, sentinelRedisConfiguration.mayBeSSLConfiguration, sentinelRedisConfiguration.ioThreads, sentinelRedisConfiguration.workerThreads))
+    case sentinelRedisConfiguration: SentinelRedisConfiguration => redisClientFactory.createSentinelClient(sentinelRedisConfiguration)
   }
 
   def createRedisPubSubCommand(): RedisPubSubReactiveCommands[String, String] = rawRedisClient match {


### PR DESCRIPTION
Master replica and sentinel seem to use a redis standalone client setup for some reason, I think could be a reason for sentinel master failover issue? 

Just a draft for now, as core refactoring is underway which i hope should change and ease integration => https://github.com/apache/james-project/pull/2690