### PR TITLE
[JAMES-3693] Up the await time for RedisEventBusServiceSentinelTest

### DIFF
--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RedisEventBusServiceSentinelTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RedisEventBusServiceSentinelTest.java
@@ -76,7 +76,7 @@ public class RedisEventBusServiceSentinelTest {
         // Then dispatch should eventually succeed after sentinel failover process elects a new master
         Awaitility.await()
             .pollInterval(2, TimeUnit.SECONDS)
-            .atMost(20, TimeUnit.SECONDS)
+            .atMost(40, TimeUnit.SECONDS)
             .untilAsserted(() -> assertThatCode(() -> eventBus.dispatch(EVENT, KEY_1).block())
                 .doesNotThrowAnyException());
     }
@@ -98,7 +98,7 @@ public class RedisEventBusServiceSentinelTest {
         // Then register should eventually succeed after sentinel failover process elects a new master
         Awaitility.await()
             .pollInterval(2, TimeUnit.SECONDS)
-            .atMost(20, TimeUnit.SECONDS)
+            .atMost(40, TimeUnit.SECONDS)
             .untilAsserted(() -> assertThatCode(() -> Mono.from(eventBus.register(listener, KEY_1)).block())
                 .doesNotThrowAnyException());
     }


### PR DESCRIPTION
20s was too close to the limit for failover process to finish (even locally) and made it unstable

I wuld guess that with other tests running in parallel it might take longer sometimes