### PR TITLE
Should not send request to caldav server when recipient is not part of the attendee list

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
@@ -21,6 +21,7 @@ package com.linagora.tmail;
 import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
 import static org.apache.james.mailets.configuration.Constants.PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 
 import java.io.File;
@@ -31,6 +32,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -66,6 +68,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.util.Modules;
@@ -306,6 +309,24 @@ public class CalDavCollectIntegrationTest {
     }
 
     @Test
+    void mailetShouldCallOrNotCallDavServerToCreateNewCalendarObjectIfRecipientIsOrNotInvited(@TempDir File temporaryFolder) throws Exception {
+        String mimeMessageId = UUID.randomUUID().toString();
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache", generateEmailTemplateData(sender, receiver, mimeMessageId, mimeMessageId));
+
+        sendMessage(sender, ImmutableList.of(receiver, notInvited), mail, mimeMessageId);
+
+        DavCalendarObject result1 = davClient.getCalendarObject(new DavUser(receiver.id(), receiver.email()), new EventUid(mimeMessageId)).block();
+
+        DavCalendarObject result2 = davClient.getCalendarObject(new DavUser(notInvited.id(), notInvited.email()), new EventUid(mimeMessageId)).block();
+
+        assertSoftly(softly -> {
+            softly.assertThat(result1).isNotNull();
+            softly.assertThat(result2).isNull();
+        });
+
+    }
+
+    @Test
     void mailetShouldCallDavSeverToDeleteCalendarObjectWhenIcsMethodIsCancel(@TempDir File temporaryFolder) throws Exception {
         String mimeMessageId = UUID.randomUUID().toString();
         String calendarUid = UUID.randomUUID().toString();
@@ -506,11 +527,19 @@ public class CalDavCollectIntegrationTest {
     }
 
     private void sendMessage(OpenPaasUser sender, OpenPaasUser receiver, String mail, String mimeMessageId) throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        sendMessage(sender, ImmutableList.of(receiver), mail, mimeMessageId);
+    }
+
+    private void sendMessage(OpenPaasUser sender, List<OpenPaasUser> receivers, String mail, String mimeMessageId) throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        List<String> receiverEmails = receivers.stream()
+                .map(OpenPaasUser::email)
+                .toList();
+
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .authenticate(sender.email(), PASSWORD)
-            .sendMessageWithHeaders(sender.email(), receiver.email(), mail);
+            .sendMessageWithHeaders(sender.email(), receiverEmails, mail);
 
-        awaitMessage(receiver, mimeMessageId);
+        receivers.forEach(receiver -> awaitMessage(receiver, mimeMessageId));
     }
 
     private void awaitMessage(OpenPaasUser receiver, String mimeMessageId) {

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
@@ -309,7 +309,7 @@ public class CalDavCollectIntegrationTest {
     }
 
     @Test
-    void mailetShouldCallOrNotCallDavServerToCreateNewCalendarObjectIfRecipientIsOrNotInvited(@TempDir File temporaryFolder) throws Exception {
+    void mailetShouldOnlyCallDavServerToCreateNewCalendarObjectForInvitedRecipientsWhenMailContainsBothInvitedRecipientsAndUninvitedRecipients(@TempDir File temporaryFolder) throws Exception {
         String mimeMessageId = UUID.randomUUID().toString();
         String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache", generateEmailTemplateData(sender, receiver, mimeMessageId, mimeMessageId));
 


### PR DESCRIPTION
Draft for now, as the fixup! with the extra test allowed me to catch an other issue.

In fact ICALToJsonAttribute is storing json attributes per each recipient...

In CalDavCollect we process each json attribute... and loop on each mail recipient. 

So on that extra test I still can see a 400 call to caldav but for the correct receiver user because... we do the request twice in that scenario. First request is fine, second is a fail

We should just likely only loop on json attributes and extract the recipient from it, and not looping again on the list of recipients.

Will fix tomorrow.

Don't hesitate to give early feedback.

I thought as well about filtering on ICALToJsonAttribute but that implies a james code change, which I'm not sure is justified.