### PR TITLE
ISSUE-1763 [OIDC] Accept missing `aud` in the introspection response

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/java/com/linagora/tmail/common/OidcAuthenticationContract.java
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/java/com/linagora/tmail/common/OidcAuthenticationContract.java
@@ -296,6 +296,39 @@ public abstract class OidcAuthenticationContract {
     }
 
     @Test
+    void shouldAcceptMissingAudInIntrospectionResponse() {
+        updateMockServerUserInfoResponse(EMAIL_CLAIM_VALUE);
+
+        updateMockerServerSpecifications(INTROSPECT_TOKEN_URI_PATH, """
+            {
+                "exp": %d,
+                "scope": "openid email profile",
+                "client_id": "tmail",
+                "active": true,
+                "sub": "twake-mail-dev",
+                "sid": "dT/8+UDx1lWp1bRZkdhbS1i6ZfYhf8+bWAZQs8p0T/c",
+                "iss": "https://sso.linagora.com"
+              }""".formatted(TOKEN_EXPIRATION_TIME), 200);
+
+        given()
+            .headers(getHeadersWith(AUTH_HEADER))
+            .body(ECHO_REQUEST_OBJECT())
+        .when()
+            .post()
+        .then()
+            .statusCode(200);
+
+        // verify the second call which uses the cache would still be fine
+        given()
+            .headers(getHeadersWith(AUTH_HEADER))
+            .body(ECHO_REQUEST_OBJECT())
+        .when()
+            .post()
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void shouldRejectWhenUserInfoFails() {
         updateMockerServerSpecifications(INTROSPECT_TOKEN_URI_PATH, """
             {

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/OidcAuthenticationStrategy.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/OidcAuthenticationStrategy.java
@@ -22,6 +22,7 @@ import static org.apache.james.jmap.http.JWTAuthenticationStrategy.AUTHORIZATION
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -81,13 +82,16 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
             .onErrorMap(UserInfoCheckException.class, e -> new UnauthorizedException("Invalid OIDC token when user info check", e));
     }
 
-    private boolean isAudienceAccepted(List<Aud> tokenAudiences) {
-        for (Aud aud: auds) {
-            if (tokenAudiences.contains(aud)) {
-                return true;
-            }
-        }
-        return false;
+    private boolean isAudienceAccepted(Optional<List<Aud>> maybeTokenAudiences) {
+        return maybeTokenAudiences.map(tokenAudiences -> {
+                for (Aud aud: auds) {
+                    if (tokenAudiences.contains(aud)) {
+                        return true;
+                    }
+                }
+                return false;
+            })
+            .orElse(true); // if no audience is present in the introspection response, we ignore audience validation
     }
 
     @Override

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/OidcEndpointsInfoResolver.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/OidcEndpointsInfoResolver.java
@@ -21,6 +21,7 @@ package com.linagora.tmail.james.jmap.oidc;
 import java.net.URL;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -86,14 +87,16 @@ public class OidcEndpointsInfoResolver implements TokenInfoResolver {
             extractAudience(introspectionResponse));
     }
 
-    private static List<Aud> extractAudience(TokenIntrospectionResponse introspectionResponse) {
-        JsonNode audJson = introspectionResponse.json().get("aud");
-        if (audJson.isArray()) {
-            return Iterators.toStream(audJson.iterator())
-                .map(JsonNode::asText)
-                .map(Aud::new)
-                .toList();
-        }
-        return ImmutableList.of(new Aud(audJson.asText()));
+    private static Optional<List<Aud>> extractAudience(TokenIntrospectionResponse introspectionResponse) {
+        return Optional.ofNullable(introspectionResponse.json().get("aud"))
+            .map(audJson -> {
+                if (audJson.isArray()) {
+                    return Iterators.toStream(audJson.iterator())
+                        .map(JsonNode::asText)
+                        .map(Aud::new)
+                        .toList();
+                }
+                return ImmutableList.of(new Aud(audJson.asText()));
+            });
     }
 }

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/TokenInfo.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/oidc/TokenInfo.java
@@ -24,14 +24,18 @@ import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 
-public record TokenInfo(String email, Optional<Sid> sid, Instant exp, List<Aud> aud) {
+public record TokenInfo(String email, Optional<Sid> sid, Instant exp, Optional<List<Aud>> aud) {
 
     public String asString() {
         return MoreObjects.toStringHelper(this)
             .add("email", email)
             .add("sid", Optional.ofNullable(sid).flatMap(sidValue -> sidValue.map(Sid::value)).orElse(null))
             .add("exp", exp)
-            .add("aud", Optional.ofNullable(aud).orElseGet(List::of).stream().map(Aud::value).toList())
+            .add("aud", aud.map(audList -> audList
+                    .stream()
+                    .map(Aud::value)
+                    .toList())
+                .orElse(null))
             .toString();
     }
 }


### PR DESCRIPTION
If OIDC server does not return `aud` as part of the introspection response, we can ignore audience validation.