### PR TITLE
ISSUE-1687 Revise RabbitMQAndRedisEventBusContractTest test suite

### DIFF
--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusTest.java
@@ -39,4 +39,14 @@ public class RabbitMQAndRedisEventBusTest extends RabbitMQAndRedisEventBusContra
     RedisConfiguration redisConfiguration() {
         return StandaloneRedisConfiguration.from(redisExtension.dockerRedis().redisURI().toString());
     }
+
+    @Override
+    public void pauseRedis() {
+        redisExtension.dockerRedis().pause();
+    }
+
+    @Override
+    public void unpauseRedis() {
+        redisExtension.dockerRedis().unPause();
+    }
 }

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithKvrocksSentinelTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithKvrocksSentinelTest.java
@@ -32,4 +32,14 @@ public class RabbitMQAndRedisEventBusWithKvrocksSentinelTest extends RabbitMQAnd
     RedisConfiguration redisConfiguration() {
         return kvrocksSentinelExtension.getKvrocksSentinelCluster().redisSentinelContainerList().getRedisConfiguration();
     }
+
+    @Override
+    void pauseRedis() {
+        kvrocksSentinelExtension.getKvrocksSentinelCluster().kvrocksMasterReplicaContainerList().pauseMasterNode();
+    }
+
+    @Override
+    void unpauseRedis() {
+        kvrocksSentinelExtension.getKvrocksSentinelCluster().kvrocksMasterReplicaContainerList().unPauseMasterNode();
+    }
 }

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithKvrocksTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithKvrocksTest.java
@@ -41,4 +41,14 @@ public class RabbitMQAndRedisEventBusWithKvrocksTest extends RabbitMQAndRedisEve
     RedisConfiguration redisConfiguration() {
         return StandaloneRedisConfiguration.from(kvrocksExtension.dockerKvrocks().redisURI().toString());
     }
+
+    @Override
+    void pauseRedis() {
+        kvrocksExtension.dockerKvrocks().pause();
+    }
+
+    @Override
+    void unpauseRedis() {
+        kvrocksExtension.dockerKvrocks().unPause();
+    }
 }

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithRedisSentinelTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusWithRedisSentinelTest.java
@@ -32,4 +32,15 @@ public class RabbitMQAndRedisEventBusWithRedisSentinelTest extends RabbitMQAndRe
     RedisConfiguration redisConfiguration() {
         return redisSentinelExtension.getRedisSentinelCluster().redisSentinelContainerList().getRedisConfiguration();
     }
+
+    @Override
+    void pauseRedis() {
+        redisSentinelExtension.getRedisSentinelCluster().redisMasterReplicaContainerList().pauseMasterNode();
+    }
+
+    @Override
+    void unpauseRedis() {
+        redisSentinelExtension.getRedisSentinelCluster().redisMasterReplicaContainerList().unPauseMasterNode();
+    }
+
 }


### PR DESCRIPTION
- Polish some tests from pausing RabbitMQ -> pausing Redis instead. 
- For the tests dispatching key events for EXISTING registration after restarting Redis, simply remove them because Redis is not persistent by default. 
- For the test dispatching key events for NEW registration after restarting Redis, remove it because it has been covered by the `RedisStandaloneRestart.newNotificationRegistrationShouldWorkWellAfterRedisRestartTest` test.