### PR TITLE
[IMPROVEMENT] SabreContactsConsumer: better control consumer concurrency

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.contact;
 
 import static com.linagora.tmail.OpenPaasModule.OPENPAAS_INJECTION_KEY;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.Closeable;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class SabreContactsConsumer implements Closeable {
 
     private Disposable doConsumeContactMessages(String queue, ContactHandler contactHandler) {
         return delivery(queue)
-            .flatMap(delivery -> messageConsume(delivery, delivery.getBody(), contactHandler))
+            .flatMap(delivery -> messageConsume(delivery, delivery.getBody(), contactHandler), DEFAULT_CONCURRENCY)
             .subscribe();
     }
 

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
@@ -50,6 +50,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
+import reactor.rabbitmq.ConsumeOptions;
 import reactor.rabbitmq.Receiver;
 
 public class SabreContactsConsumer implements Closeable {
@@ -107,7 +108,7 @@ public class SabreContactsConsumer implements Closeable {
 
     public Flux<AcknowledgableDelivery> delivery(String queue) {
         return Flux.using(receiverProvider::createReceiver,
-            receiver -> receiver.consumeManualAck(queue),
+            receiver -> receiver.consumeManualAck(queue, new ConsumeOptions().qos(DEFAULT_CONCURRENCY)),
             Receiver::close);
     }
 


### PR DESCRIPTION

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/2cf8843c-d2f1-48d6-aec8-597d6da777ee" />


3000 timeout errors during the spam campaign:
```java
{"timestamp":"2025-06-11T07:51:31.593Z","level":"ERROR","thread":"reactor-http-epoll-3","logger":"com.linagora.tmail.contact.SabreContactsConsumer","message":"Error when consume message","context":"default","exception":"com.linagora.tmail.api.OpenPaasRestClientException: Failed to retrieve user mail using OpenPaas id 67537d58c3a168001bf7d02e
	at com.linagora.tmail.api.OpenPaasRestClient.lambda$retrieveMailAddress$3(OpenPaasRestClient.java:88)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onError(FluxMapFuseable.java:142)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onError(FluxMapFuseable.java:142)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onError(MonoFlatMap.java:180)
	at reactor.core.publisher.SerializedSubscriber.onError(SerializedSubscriber.java:124)
	at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.whenError(FluxRetryWhen.java:229)
	at reactor.core.publisher.FluxRetryWhen$RetryWhenOtherSubscriber.onError(FluxRetryWhen.java:279)
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onError(FluxContextWrite.java:121)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.maybeOnError(FluxConcatMapNoPrefetch.java:327)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onNext(FluxConcatMapNoPrefetch.java:212)
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107)
	at reactor.core.publisher.SinkManyEmitterProcessor.drain(SinkManyEmitterProcessor.java:476)
	at reactor.core.publisher.SinkManyEmitterProcessor$EmitterInner.drainParent(SinkManyEmitterProcessor.java:620)
	at reactor.core.publisher.FluxPublish$PubSubInner.request(FluxPublish.java:874)
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.request(FluxContextWrite.java:136)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.request(FluxConcatMapNoPrefetch.java:337)
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.request(FluxContextWrite.java:136)
	at reactor.core.publisher.Operators$DeferredSubscription.request(Operators.java:1743)
	at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onError(FluxRetryWhen.java:196)
	at reactor.core.publisher.MonoCreate$DefaultMonoSink.error(MonoCreate.java:205)
	at reactor.netty.http.client.HttpClientConnect$HttpObserver.onUncaughtException(HttpClientConnect.java:403)
	at reactor.netty.ReactorNetty$CompositeConnectionObserver.onUncaughtException(ReactorNetty.java:708)
	at reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire.onUncaughtException(DefaultPooledConnectionProvider.java:223)
	at reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnection.onUncaughtException(DefaultPooledConnectionProvider.java:476)
	at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:247)
	at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:468)
	at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:515)
	at reactor.netty.channel.ChannelOperationsHandler.exceptionCaught(ChannelOperationsHandler.java:145)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:346)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:325)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:317)
	at io.netty.handler.timeout.ReadTimeoutHandler.readTimedOut(ReadTimeoutHandler.java:98)
	at io.netty.handler.timeout.ReadTimeoutHandler.channelIdle(ReadTimeoutHandler.java:90)
	at io.netty.handler.timeout.IdleStateHandler$ReaderIdleTimeoutTask.run(IdleStateHandler.java:525)
	at io.netty.handler.timeout.IdleStateHandler$AbstractIdleTask.run(IdleStateHandler.java:497)
	at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:153)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:408)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: io.netty.handler.timeout.ReadTimeoutException: null
"}
```

During the spam incident, SabreContactsConsumer fired around 50 `GET /api/users/...` requests per second to ESN to resolve user mail address. Although the user API of ESN should not rely on Sabre,the  ESN service was degraded because of timeout calls to Sabre, resulting in the above timeout. 

It is better to control the consumer concurrency anyway.