### PR TITLE
JAMES-4138 [TMail] Update RabbitMQ 4.0.9 for OpenPaaS integration tests

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/test/resources/docker-openpaas-setup.yml
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/resources/docker-openpaas-setup.yml
@@ -53,7 +53,7 @@ services:
       retries: 30
 
   rabbitmq:
-    image: rabbitmq:3.13.3-management
+    image: rabbitmq:4.0.9-management
     hostname: esn-rabbit
     networks:
       - emaily


### PR DESCRIPTION
OpenPaaS ESN does not work well with RabbitMQ 4.1+ versions because this version introduces a `frame_max` breaking change that requires Node.js amqplib library upgrade.

"amqplib versions older than 0.10.7 will not be able to connect to RabbitMQ 4.1.0 and later versions due to the initial AMQP 0-9-1 maximum frame size increase covered above."

cf: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0

