### PR TITLE
ISSUE-1803 Implement rate-limiting for AIBot

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -155,11 +155,10 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
-   <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
-       <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
-       <matcher match="SenderIsLocal"/>
-   </matcher>
-   ...
+    <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
+        <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
+        <matcher match="SenderIsLocal"/>
+    </matcher>
     ...
     <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
         <consume>false</consume>

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -62,14 +62,20 @@ Modify the `mailetcontainer.xml` file by adding the following lines:
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
+    <matcher name="aibot-allowed" match="org.apache.james.mailetcontainer.impl.matchers.And">
+        <!-- Only answer to local users -->
+        <matcher match="SenderIsLocal"/>
+        <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
+    </matcher>
+
     ...
     <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
         <consume>false</consume>
     </mailet>
 
     <!-- Put the AIBotMailet after LocalDelivery so the GPT reply would come after the asking question -->
-    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"
-            class="com.linagora.tmail.mailet.AIBotMailet"/>
+    <mailet match="aibot-allowed" class="com.linagora.tmail.mailet.AIBotMailet"/>
+    <mailet match="All" class="Null"/>
 </processor>
 ```
 
@@ -153,8 +159,9 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
     <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
         <consume>false</consume>
     </mailet>
+
     <!-- Put the rate limit before AIBotMailet -->
-    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerSenderRateLimit">
+    <mailet match="aibot-allowed" class="PerSenderRateLimit">
         <keyPrefix>AIBotPerSenderRateLimit</keyPrefix>
         <duration>1d</duration>
         <precision>1h</precision>
@@ -162,7 +169,7 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
         <size>100K</size>
         <exceededProcessor>tooMuchMails</exceededProcessor>
     </mailet>
-    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerRecipientRateLimit">
+    <mailet match="aibot-allowed" class="PerRecipientRateLimit">
         <keyPrefix>AIBotRecipientRateLimit</keyPrefix>
         <duration>1d</duration>
         <precision>1h</precision>
@@ -170,8 +177,7 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
         <size>100K</size>
         <exceededProcessor>tooMuchMails</exceededProcessor>
     </mailet>
-
-    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="com.linagora.tmail.mailet.AIBotMailet"/>
+    <mailet match="aibot-allowed" class="com.linagora.tmail.mailet.AIBotMailet"/>
 </processor>
 
 <processor state="tooMuchMails" enableJmx="true">

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -58,10 +58,6 @@ curl <baseURL>/chat/completions \
 
 ### Mailet configuration
 
-> [!WARNING] AI Security warning
-> 
-> By default, AIBot is vulnerable to Denial of Service (DoS) attacks and must be defended explicitly. The configuration files below and in `sample_conf/` need to be adjusted. See [rate-limiting](#rate-limiting) for more details.
-
 Modify the `mailetcontainer.xml` file by adding the following lines:
 
 ```xml
@@ -120,26 +116,32 @@ You can test the AIBot extension with the demo server.
 
 Sample configuration files are located in the `demo/tmail` directory. Modify these files as needed, and proceed with the [demo instructions](../../../demo/README.md). The default bot address is `gpt@tmail.com`.
 
-# Security configuration
+## Considerations for deployment
 
-The AIBot extension must be defended against [cybersecurity attacks](https://genai.owasp.org/llm-top-10/) for deployment. Recommended configuration steps are described below.
-
-## Rate-limiting
-
-This section provides more details on configuring rate limits for AIBot.
-
-### Threat model
+> [!NOTE] Scope of this section
+> 
+> AIBot is still in development phase. It lacks the robustness, scalability and security hardening required for real-world deployment.
+>
+> This section provides general guidance for operators who still wish to experiment with deploying AIBot in a production environment. These recommendations are **not a substitute for comprehensive security practices** and should be treated as starting points for curious readers.
 
 <details>
   <summary>Read more...</summary>
+
+---
+The AIBot extension must be defended against [cybersecurity attacks](https://genai.owasp.org/llm-top-10/) for production deployment. Recommended configuration steps are described below.
+
+### Rate-limiting
+
+This section provides more details on configuring rate limits for AIBot.
+
+#### Threat model
+
 Rate-limiting is critical to mitigate [Denial of Service attacks on LLMs](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/). Indeed, a malicious user could send a high volume of emails to AIBot, forcing the extension to make API requests to the LLM service for each interaction. This could lead to:
 
 - **Server overload** on the email or the LLM provider, potentially causing service degradation or complete unavailability.
 - [**Denial of Wallet**](https://www.sciencedirect.com/science/article/pii/S221421262100079X) due to API credit overconsumption, which could cause financial exhaustion and service blocking by the LLM provider.
- 
-</details>
 
-### Configuration
+#### Configuration
 
 Use the [`rate-limiter` mailet](https://github.com/apache/james-project/tree/master/server/mailet/rate-limiter) from Apache James by following its setup instructions.
 
@@ -189,9 +191,9 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
 
     This mailet bounds all the mails received by AIBot, regardless of the sender, preventing [Denial of Wallet attacks](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/).
 
-You must modify these values taking into account your threat model (e.g. number of email accounts used for DDoS) and LLM-specific factors such as budget, server performance and context size. You may also configure [throttling](https://github.com/apache/james-project/tree/master/server/mailet/rate-limiter#throttling) if the bot answers don't need to be instantaneous.
+You must modify these values taking into account your threat model (e.g. number of email accounts used for DDoS) and LLM-specific factors such as budget, server performance and context size. Beware that the email headers add a constant factor to all mails, and the traffic volume of an email thread is quadratic with respect to its length. You may also configure [throttling](https://github.com/apache/james-project/tree/master/server/mailet/rate-limiter#throttling) if the bot answers don't need to be instantaneous.
 
-## Controlling costs of LLM answers
+### Controlling costs of LLM answers
 
 LLMs can consume significant amounts of API credits, especially when generating long responses. If left unbounded, this can lead to Denial of Wallet attacks.
 
@@ -200,14 +202,15 @@ If you can configure the default chat parameters of your model, we recommend to 
 - maximum completion tokens 
 - reasoning effort (if applicable)
 
-# Troubleshooting
+</details>
 
-## No response received
+## Troubleshooting
+
+### No response received
 
 1. [Verify your API configuration](#sanity-check)
 2. Make sure the same bot address is used in the mailet configuration and in the properties file
-3. [Review your rate limit configuration](#rate-limiting)
 
-## API quota issues
+### API quota issues
 
 Demo APIs often have usage quotas. Ensure your requests are not being rate limited due to heavy usage or automated scripts.

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -155,7 +155,7 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
-    <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
+    <matcher name="aibot-allowed" match="org.apache.james.mailetcontainer.impl.matchers.And">
         <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
         <matcher match="SenderIsLocal"/>
     </matcher>

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -155,6 +155,11 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
+  <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
+      <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
+      <matcher match="SenderIsLocal"/>
+  </matcher>
+   ...
     ...
     <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
         <consume>false</consume>

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -143,7 +143,7 @@ Rate-limiting is critical to mitigate [Denial of Service attacks on LLMs](https:
 
 Use the [`rate-limiter` mailet](https://github.com/apache/james-project/tree/master/server/mailet/rate-limiter) from Apache James by following its setup instructions.
 
-We suggest to add the two following rate-limiting rules in `mailetcontainer.xml`:
+We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such as below:
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
@@ -152,25 +152,30 @@ We suggest to add the two following rate-limiting rules in `mailetcontainer.xml`
         <consume>false</consume>
     </mailet>
     <!-- Put the rate limit before AIBotMailet -->
-    <mailet matcher="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerSenderRateLimit">
-      <keyPrefix>AIBotPerSenderRateLimit</keyPrefix>
-      <duration>1d</duration>
-      <precision>1h</precision>
-      <count>100</count>
-      <size>100K</size>
-      <totalSize>200K</totalSize>
-      <exceededProcessor>tooMuchMails</exceededProcessor>
-  </mailet>
-  <mailet matcher="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerRecipientRateLimitMailet">
-    <keyPrefix>AIBotRecipientRateLimit</keyPrefix>
-    <duration>1d</duration>
-    <precision>1h</precision>
-    <count>1000</count>
-    <size>100K</size>
-    <exceededProcessor>tooMuchMails</exceededProcessor>
-  </mailet>
+    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerSenderRateLimit">
+        <keyPrefix>AIBotPerSenderRateLimit</keyPrefix>
+        <duration>1d</duration>
+        <precision>1h</precision>
+        <count>100</count>
+        <size>100K</size>
+        <exceededProcessor>tooMuchMails</exceededProcessor>
+    </mailet>
+    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="PerRecipientRateLimit">
+        <keyPrefix>AIBotRecipientRateLimit</keyPrefix>
+        <duration>1d</duration>
+        <precision>1h</precision>
+        <count>1000</count>
+        <size>100K</size>
+        <exceededProcessor>tooMuchMails</exceededProcessor>
+    </mailet>
 
-  <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="com.linagora.tmail.mailet.AIBotMailet"/>
+    <mailet match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}" class="com.linagora.tmail.mailet.AIBotMailet"/>
+</processor>
+
+<processor state="tooMuchMails" enableJmx="true">
+    <mailet match="All" class="Bounce">
+        <message>Rate limit exceeded!</message>
+    </mailet>
 </processor>
 ```
 

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -155,10 +155,10 @@ We suggest to add at least two rate-limiting rules in `mailetcontainer.xml` such
 
 ```xml
 <processor state="local-delivery" enableJmx="true">
-  <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
-      <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
-      <matcher match="SenderIsLocal"/>
-  </matcher>
+   <matcher name="allow-aibot" match="org.apache.james.mailetcontainer.impl.matchers.And">
+       <matcher match="com.linagora.tmail.mailet.RecipientsContain={your bot address here}"/>
+       <matcher match="SenderIsLocal"/>
+   </matcher>
    ...
     ...
     <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">

--- a/tmail-backend/tmail-third-party/ai-bot/sample_conf/mailetcontainer.xml
+++ b/tmail-backend/tmail-third-party/ai-bot/sample_conf/mailetcontainer.xml
@@ -92,6 +92,15 @@
             <mailet match="All" class="AddDeliveredToHeader"/>
             <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
             <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery"/>
+
+            <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
+                <consume>false</consume>
+            </mailet>
+
+            <!-- Put rate limit mailets for AIBot here -->
+
+            <!-- Replace gpt@example.com with your bot address -->
+            <mailet match="com.linagora.tmail.mailet.RecipientsContain=gpt@example.com" class="com.linagora.tmail.mailet.AIBotMailet"/>
         </processor>
 
         <processor state="relay" enableJmx="true">

--- a/tmail-backend/tmail-third-party/ai-bot/sample_conf/mailetcontainer.xml
+++ b/tmail-backend/tmail-third-party/ai-bot/sample_conf/mailetcontainer.xml
@@ -87,20 +87,21 @@
         </processor>
 
         <processor state="local-delivery" enableJmx="true">
+            <matcher name="aibot-allowed" match="org.apache.james.mailetcontainer.impl.matchers.And">
+                <matcher match="SenderIsLocal"/>
+                <matcher match="com.linagora.tmail.mailet.RecipientsContain=gpt@example.com"/>
+            </matcher>
             <mailet match="All" class="VacationMailet"/>
             <mailet match="All" class="Sieve"/>
             <mailet match="All" class="AddDeliveredToHeader"/>
             <mailet match="All" class="org.apache.james.jmap.mailet.filter.JMAPFiltering"/>
-            <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery"/>
 
             <mailet match="All" class="com.linagora.tmail.mailets.TmailLocalDelivery">
                 <consume>false</consume>
             </mailet>
 
-            <!-- Put rate limit mailets for AIBot here -->
-
-            <!-- Replace gpt@example.com with your bot address -->
-            <mailet match="com.linagora.tmail.mailet.RecipientsContain=gpt@example.com" class="com.linagora.tmail.mailet.AIBotMailet"/>
+            <mailet match="aibot-allowed" class="com.linagora.tmail.mailet.AIBotMailet"/>
+            <mailet match="All" class="Null"/>
         </processor>
 
         <processor state="relay" enableJmx="true">


### PR DESCRIPTION
Closes #1803

Updated the AIBot documentation with security warnings so the reader is invited to use the Apache James rate-limiting mailet. Rate-limiting is a suitable mitigation against Denial of Service and [Denial of Wallet](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/) attacks.

Suggested limiting LLM output length to defend against DoW.