### PR TITLE
Switch firebase back to 9.3.0

### DIFF
--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -101,7 +101,7 @@
     <properties>
         <james.groupId>org.apache.james</james.groupId>
         <james.version>3.9.0-SNAPSHOT</james.version>
-        <firebase-admin-sdk.version>9.5.0</firebase-admin-sdk.version>
+        <firebase-admin-sdk.version>9.3.0</firebase-admin-sdk.version>
         <bouncycastle.version>1.81</bouncycastle.version>
         <mongodb.version>5.5.1</mongodb.version>
         <scala.base>2.13</scala.base>


### PR DESCRIPTION
In version 9.5.0 systematic timeouts are observed with current code base. Revert.