### PR TITLE
[FIX] CalendarEventReply method should not return NoUpdateRequiredException as serverFail

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -18,10 +18,10 @@
 
 package com.linagora.tmail.james.jmap.model
 
+import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.NoUpdateRequiredException
 import org.apache.james.jmap.core.SetError
 import org.apache.james.jmap.core.SetError.SetErrorDescription
 import org.apache.james.jmap.mail.{BlobId, BlobIds}
-import org.apache.james.mailbox.MailboxSession
 import org.slf4j.{Logger, LoggerFactory}
 
 object CalendarEventReplyResults {
@@ -52,7 +52,7 @@ object CalendarEventReplyResults {
     done(BlobId.of(blobId).get)
 
   private def asSetError(throwable: Throwable, username: String): SetError = throwable match {
-    case _: InvalidCalendarFileException | _: IllegalArgumentException =>
+    case _: InvalidCalendarFileException | _: IllegalArgumentException | _: NoUpdateRequiredException =>
       LOGGER.info("Error when generate reply mail for {}: {}", username, throwable.getMessage)
       SetError.invalidPatch(SetErrorDescription(throwable.getMessage))
     case _ =>

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -53,10 +53,10 @@ object CalendarEventReplyResults {
 
   private def asSetError(throwable: Throwable, username: String): SetError = throwable match {
     case _: InvalidCalendarFileException | _: IllegalArgumentException | _: NoUpdateRequiredException =>
-      LOGGER.info("Error when generate reply mail for {}: {}", username, throwable.getMessage)
+      LOGGER.info("Error when replying to event invitation for {}: {}", username, throwable.getMessage)
       SetError.invalidPatch(SetErrorDescription(throwable.getMessage))
     case _ =>
-      LOGGER.error("serverFail to generate reply mail for {}", username, throwable)
+      LOGGER.error("serverFail to reply event invitation for {}", username, throwable)
       SetError.serverFail(SetErrorDescription(throwable.getMessage))
   }
 }


### PR DESCRIPTION

`
{"timestamp":"2025-07-24T08:22:15.262Z","level":"ERROR","thread":"reactor-http-epoll-2","logger":"com.linagora.tmail.james.jmap.model.CalendarEventReplyResults","message":"serverFail to generate reply mail for abc@xyz.org","context":"default","exception":"com.linagora.tmail.james.jmap.calendar.CalendarEventModifier$NoUpdateRequiredException: null
    at com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.apply(CalendarEventModifier.scala:143)
`