### PR TITLE
[FIX] CalendarEventRely should not return serverFail when CalendarEventNotFoundException

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -18,7 +18,9 @@
 
 package com.linagora.tmail.james.jmap.model
 
+import com.linagora.tmail.james.jmap.CalendarEventNotFoundException
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.NoUpdateRequiredException
+import eu.timepit.refined.auto._
 import org.apache.james.jmap.core.SetError
 import org.apache.james.jmap.core.SetError.SetErrorDescription
 import org.apache.james.jmap.mail.{BlobId, BlobIds}
@@ -55,6 +57,9 @@ object CalendarEventReplyResults {
     case _: InvalidCalendarFileException | _: IllegalArgumentException | _: NoUpdateRequiredException =>
       LOGGER.info("Error when replying to event invitation for {}: {}", username, throwable.getMessage)
       SetError.invalidPatch(SetErrorDescription(throwable.getMessage))
+    case _: CalendarEventNotFoundException =>
+      LOGGER.info("Error when replying to event invitation for {}: {}", username, throwable.getMessage)
+      SetError("eventNotFound", SetErrorDescription("The event you reply to does not exist on your calendar"), None)
     case _ =>
       LOGGER.error("serverFail to reply event invitation for {}", username, throwable)
       SetError.serverFail(SetErrorDescription(throwable.getMessage))


### PR DESCRIPTION
`
{"timestamp":"2025-08-04T06:30:11.406Z","level":"ERROR","thread":"reactor-http-epoll-2","logger":"com.linagora.tmail.james.jmap.model.CalendarEventReplyResults","message":"serverFail to generate reply mail for user@domain.tld","context":"default","exception":"com.linagora.tmail.james.jmap.CalendarEventNotFoundException: Calendar event not found for user user@domain.tld and eventUid b97kuj9p64s3ic9g68r36dph95a7crbme4s4uki89do6meb8ahkmurr2dtrg
`

Likely happens when the user tried to reply to an event that is removed.