### PR TITLE
ISSUE-1884 SaaSSubscriptionConsumer should wrap blocking call usersRepository.getUserByName

### DIFF
--- a/tmail-backend/saas/saas-cassandra/src/main/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSAccountRepository.java
+++ b/tmail-backend/saas/saas-cassandra/src/main/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSAccountRepository.java
@@ -28,6 +28,8 @@ import static com.linagora.tmail.saas.api.cassandra.CassandraSaaSDataDefinition.
 import static com.linagora.tmail.saas.api.cassandra.CassandraSaaSDataDefinition.TABLE_NAME;
 import static com.linagora.tmail.saas.api.cassandra.CassandraSaaSDataDefinition.USER;
 
+import java.util.Optional;
+
 import jakarta.inject.Inject;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
@@ -64,7 +66,9 @@ public class CassandraSaaSAccountRepository implements SaaSAccountRepository {
     public Publisher<SaaSAccount> getSaaSAccount(Username username) {
         return Mono.from(executor.executeSingleRow(selectPlanStatement.bind()
                 .setString(USER, username.asString())))
-            .mapNotNull(row -> new SaaSAccount(row.getBoolean(CAN_UPGRADE), row.getBoolean(IS_PAYING)))
+            .mapNotNull(row -> new SaaSAccount(
+                Optional.ofNullable(row.get(CAN_UPGRADE, Boolean.class)).orElse(SaaSAccount.DEFAULT.canUpgrade()),
+                Optional.ofNullable(row.get(IS_PAYING, Boolean.class)).orElse(SaaSAccount.DEFAULT.isPaying())))
             .switchIfEmpty(Mono.just(SaaSAccount.DEFAULT));
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/settings/TWPSettingsConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/settings/TWPSettingsConsumer.java
@@ -37,6 +37,7 @@ import org.apache.james.core.Username;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.model.User;
+import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,6 +184,7 @@ public class TWPSettingsConsumer implements Closeable, Startable {
 
     private Mono<Void> handleSettingsMessage(TWPCommonSettingsMessage message) {
         return Mono.fromCallable(() -> usersRepository.getUserByName(Username.of(message.payload().email())))
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .map(User::getUserName)
             .flatMap(username -> getStoredSettingsVersion(username)
                 .flatMap(storedVersion -> {

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.quota.MaxQuotaManager;
 import org.apache.james.mailbox.quota.UserQuotaRootResolver;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.model.User;
+import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -184,6 +185,7 @@ public class SaaSSubscriptionConsumer implements Closeable, Startable {
     private Mono<Void> handleSubscriptionMessage(SaaSSubscriptionMessage subscriptionMessage) {
         SaaSAccount saaSAccount = new SaaSAccount(subscriptionMessage.canUpgrade(), subscriptionMessage.isPaying());
         return Mono.fromCallable(() -> usersRepository.getUserByName(Username.of(subscriptionMessage.internalEmail())))
+            .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
             .map(User::getUserName)
             .flatMap(username -> Mono.from(saasAccountRepository.upsertSaasAccount(username, saaSAccount))
                 .then(updateStorageQuota(username, subscriptionMessage.mail().storageQuota()))


### PR DESCRIPTION
Fix blocking call:

```java
[ERROR] c.l.t.s.r.s.SaaSSubscriptionConsumer - Error when consuming SaaS subscription message
java.lang.IllegalStateException: blockOptional() is blocking, which is not supported in thread reactor-tcp-nio-5
    at reactor.core.publisher.BlockingOptionalMonoSubscriber.blockingGet(BlockingOptionalMonoSubscriber.java:108)
    at reactor.core.publisher.Mono.blockOptional(Mono.java:1831)
    at org.apache.james.user.postgres.PostgresUsersDAO.getUserByName(PostgresUsersDAO.java:75)
    at org.apache.james.user.lib.UsersRepositoryImpl.getUserByName(UsersRepositoryImpl.java:205)
    at com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.lambda$handleSubscriptionMessage$7(SaaSSubscriptionConsumer.java:191)
    at reactor.core.publisher.MonoCallable$MonoCallableSubscription.request(MonoCallable.java:137)
    at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:171)
    at reactor.core.publisher.MonoFlatMap$FlatMapMain.request(MonoFlatMap.java:194)
```