### PR TITLE
[Build] Update the build timeout to 4h

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
     options {
         // Configure an overall timeout for the build.
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
     }
     


### PR DESCRIPTION
Been observing multiple builds failing on the 3h timeout lately. We keep having more code and tests it seems.