### PR TITLE
Align bouncycastle version with James

### DIFF
--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -108,7 +108,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.version>3.10.0-SNAPSHOT</james.version>
         <firebase-admin-sdk.version>9.3.0</firebase-admin-sdk.version>
-        <bouncycastle.version>1.81</bouncycastle.version>
+        <bouncycastle.version>1.82</bouncycastle.version>
         <mongodb.version>5.5.1</mongodb.version>
         <scala.base>2.13</scala.base>
     </properties>


### PR DESCRIPTION
Align bouncycastle version with James: https://github.com/apache/james-project/blob/0cd58041113e45c8346e9889c74fd60594f59462/pom.xml#L681

Food for thought: having two `bouncycastle.version`: one in James and one on TMail is really error-prone. I did have a very quick look, but did not find a way to reference both of them to the same property yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a cryptographic library dependency to the latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->