### PR TITLE
[ENHANCEMENT] OidcBackchannelLogoutRoutes should not require authentication

### DIFF
--- a/tmail-backend/webadmin/webadmin-oidc-backchannel/src/main/java/com/linagora/tmail/webadmin/OidcBackchannelLogoutRoutes.java
+++ b/tmail-backend/webadmin/webadmin-oidc-backchannel/src/main/java/com/linagora/tmail/webadmin/OidcBackchannelLogoutRoutes.java
@@ -27,7 +27,7 @@ import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.webadmin.Constants;
-import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.PublicRoutes;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
@@ -44,7 +44,7 @@ import com.linagora.tmail.james.jmap.oidc.Sid;
 import spark.Route;
 import spark.Service;
 
-public class OidcBackchannelLogoutRoutes implements Routes {
+public class OidcBackchannelLogoutRoutes implements PublicRoutes {
     public static final String BASE_PATH = "/add-revoked-token";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OidcBackchannelLogoutRoutes.class);


### PR DESCRIPTION
So backchannel logout won't fail when webadmin authentication is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * OIDC backchannel logout routes reclassified as public endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->