### PR TITLE
ISSUE-2022 Implement AlignFromHeaderWithMailFrom

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
@@ -1,0 +1,71 @@
+= Extra Mailets
+:navtitle: Extra Mailets
+
+This page documents additional mailets provided by TMail for specific use cases.
+
+== AlignFromHeaderWithMailFrom
+
+=== Purpose
+
+The `AlignFromHeaderWithMailFrom` mailet rewrites the `From` header to align with the envelope sender (MAIL FROM) address. This is particularly useful for email forwarding scenarios to preserve DKIM alignment and avoid spam filter issues.
+
+When emails are forwarded, the envelope sender (MAIL FROM) is typically rewritten to the forwarder's address, but the `From` header remains unchanged. This creates a DKIM alignment mismatch that can trigger spam filters. This mailet solves this problem by aligning both addresses.
+
+Use cases:
+
+* *Email forwarding*: When implementing email forwarding services to maintain DKIM alignment
+* *Email aliasing*: When routing emails through aliases while preserving sender information
+* *Mailing lists*: When forwarding list emails while maintaining proper email authentication
+
+=== How it works
+
+The mailet performs the following transformations:
+
+1. Extracts the original `From` header address and display name
+2. Stores the original email address in an `Original-From` header
+3. Rewrites the `From` header to use the MAIL FROM address
+4. Preserves the original sender information in the display name
+
+*Example transformation:*
+
+Original:
+
+....
+MAIL FROM: alice@us.com
+From: "Bob External" <bob@external.com>
+....
+
+After transformation:
+
+....
+MAIL FROM: alice@us.com
+From: "Bob External (bob@external.com)" <alice@us.com>
+Original-From: bob@external.com
+....
+
+=== Configuration
+
+==== Parameters
+
+[cols="1,1,3", options="header"]
+|===
+|Parameter
+|Default
+|Description
+
+|misAlignProcessor
+|error
+|The processor to which mails with unparseable or missing From headers will be redirected for error handling.
+|===
+
+==== Usage with DKIM signature stripping
+
+To achieve proper DKIM alignment for forwarded emails, it's recommended to strip existing DKIM signatures before running this mailet. Use the `RemoveMimeHeader` mailet for this purpose.
+
+*Sample configuration:*
+
+....
+<mailet match="All" class="com.linagora.tmail.mailet.AlignFromHeaderWithMailFrom">
+  <misAlignProcessor>error</misAlignProcessor>
+</mailet>
+....

--- a/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/index.adoc
@@ -26,3 +26,4 @@ This includes:
 - link:ecosystem-discovery.adoc[Linagora Ecosystem discovery]
 - link:twake-workplace.adoc[Twake Workplace Integration]
 - link:I18NDSNBounce.adoc[Internationalized DSN Bounce]
+- link:extra-mailet.adoc[Extra mailets]

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/AlignFromHeaderWithMailFrom.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/AlignFromHeaderWithMailFrom.java
@@ -1,0 +1,173 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.mime4j.dom.address.Mailbox;
+import org.apache.james.mime4j.field.Fields;
+import org.apache.james.mime4j.field.address.LenientAddressParser;
+import org.apache.james.util.StreamUtils;
+import org.apache.mailet.Mail;
+import org.apache.mailet.ProcessingState;
+import org.apache.mailet.base.GenericMailet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * AlignFromHeaderWithMailFrom rewrites the From header to align with the MAIL FROM address.
+ * This is useful for email forwarding to preserve DKIM alignment.
+ *
+ * <p>The mailet performs the following transformations:</p>
+ * <ul>
+ *     <li>Stores the original From header in an "Original-From" header</li>
+ *     <li>Rewrites the From header to use the MAIL FROM address</li>
+ *     <li>Preserves the original sender information in the display name</li>
+ * </ul>
+ *
+ * <p>Example transformation:</p>
+ * <pre>
+ * From: "Bob External" &lt;bob@external.com&gt;
+ * MAIL FROM: alice@us.com
+ *
+ * Becomes:
+ * From: "Bob External (bob@external.com)" &lt;alice@us.com&gt;
+ * Original-From: bob@external.com
+ * </pre>
+ *
+ * <p>Configuration parameters:</p>
+ * <ul>
+ *     <li><b>misAlignProcessor</b> (optional): The processor to which mails with unparseable From headers
+ *         or no From header will be redirected. Defaults to "error".</li>
+ * </ul>
+ *
+ * <p>Mails with missing or unparseable From headers are redirected to the configured processor
+ * (via misAlignProcessor parameter) for error handling.</p>
+ *
+ * <p>To strip existing DKIM signatures (recommended for forwarding), use RemoveMimeHeader before this mailet:</p>
+ * <pre><code>
+ * &lt;mailet match="All" class="RemoveMimeHeader"&gt;
+ *   &lt;name&gt;DKIM-Signature&lt;/name&gt;
+ * &lt;/mailet&gt;
+ * &lt;mailet match="All" class="AlignFromHeaderWithMailFrom"&gt;
+ *   &lt;misAlignProcessor&gt;error&lt;/misAlignProcessor&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ */
+public class AlignFromHeaderWithMailFrom extends GenericMailet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlignFromHeaderWithMailFrom.class);
+
+    private static final String FROM_HEADER = "From";
+    private static final String ORIGINAL_FROM_HEADER = "Original-From";
+
+    private String misAlignProcessor;
+
+    @Override
+    public void init() throws MessagingException {
+        misAlignProcessor = getInitParameter("misAlignProcessor", Mail.ERROR);
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return "AlignFromHeaderWithMailFrom Mailet";
+    }
+
+    @Override
+    public Collection<ProcessingState> requiredProcessingState() {
+        return ImmutableList.of(new ProcessingState(misAlignProcessor));
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        Optional<Mailbox> maybeOriginalFrom = retrieveOriginalFrom(mail);
+
+        if (!maybeOriginalFrom.isPresent()) {
+            LOGGER.warn("Could not parse From header for mail {}, skipping alignment", mail.getName());
+            mail.setState(misAlignProcessor);
+            return;
+        }
+
+        Mailbox originalFrom = maybeOriginalFrom.get();
+
+        mail.getMaybeSender()
+            .asOptional()
+            .filter(mailFromAddress -> !originalFrom.getAddress().equalsIgnoreCase(mailFromAddress.asString()))
+            .ifPresent(Throwing.consumer(mailFromAddress -> reAlignMessage(mail, originalFrom, mailFromAddress)));
+    }
+
+    private static Optional<Mailbox> retrieveOriginalFrom(Mail mail) throws MessagingException {
+        return Optional.ofNullable(mail.getMessage().getHeader(FROM_HEADER))
+            .filter(headers -> headers.length > 0)
+            .flatMap(AlignFromHeaderWithMailFrom::retrieveFirstMailbox);
+    }
+
+    private static Optional<Mailbox> retrieveFirstMailbox(String[] fromHeaders) {
+        return StreamUtils.ofNullables(fromHeaders)
+            .flatMap(headerLine -> LenientAddressParser.DEFAULT
+                .parseAddressList(headerLine)
+                .flatten()
+                .stream())
+            .findFirst();
+    }
+
+    private void reAlignMessage(Mail mail, Mailbox originalFrom, MailAddress mailFromAddress) throws MessagingException {
+        mail.getMessage().setHeader(ORIGINAL_FROM_HEADER, originalFrom.getAddress());
+        String newDisplayName = buildNewDisplayName(originalFrom);
+        String newFromHeader = formatFromHeader(newDisplayName, mailFromAddress.asString());
+
+        mail.getMessage().setHeader(FROM_HEADER, newFromHeader);
+        mail.getMessage().saveChanges();
+
+        LOGGER.info("Aligned From header for mail {}: {} -> {}", mail.getName(), originalFrom.getAddress(), mailFromAddress.asString());
+    }
+
+    private String buildNewDisplayName(Mailbox originalFrom) {
+        if (Strings.isNullOrEmpty(originalFrom.getName())) {
+            return String.format("(%s)", originalFrom.getAddress());
+        }
+        return String.format("%s (%s)", originalFrom.getName(), originalFrom.getAddress());
+    }
+
+    private String formatFromHeader(String displayName, String emailAddress) {
+        int atIndex = emailAddress.indexOf('@');
+        if (atIndex == -1) {
+            return emailAddress;
+        }
+
+        String localPart = emailAddress.substring(0, atIndex);
+        String domain = emailAddress.substring(atIndex + 1);
+
+        return Fields.from(asMailbox(displayName, localPart, domain)).getBody();
+    }
+
+    private static Mailbox asMailbox(String displayName, String localPart, String domain) {
+        if (Strings.isNullOrEmpty(displayName)) {
+            return new Mailbox(localPart, domain);
+        }
+        return new Mailbox(displayName, localPart, domain);
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/AlignFromHeaderWithMailFromTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/AlignFromHeaderWithMailFromTest.java
@@ -1,0 +1,187 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.mailet.Mail;
+import org.apache.mailet.Mailet;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AlignFromHeaderWithMailFromTest {
+    private static final String ORIGINAL_FROM_HEADER = "Original-From";
+    private static final String FROM_HEADER = "From";
+
+    private Mailet mailet;
+
+    @BeforeEach
+    void setUp() {
+        mailet = new AlignFromHeaderWithMailFrom();
+    }
+
+    @Test
+    void getMailetInfoShouldReturnExpectedValue() {
+        assertThat(mailet.getMailetInfo()).isEqualTo("AlignFromHeaderWithMailFrom Mailet");
+    }
+
+    @Test
+    void shouldAlignFromHeaderWithMailFrom() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("bob@external.com", "Bob External"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("\"Bob External (bob@external.com)\" <alice@us.com>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).containsExactly("bob@external.com");
+    }
+
+    @Test
+    void shouldAlignFromHeaderWithoutPersonalName() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("bob@external.com"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("\"(bob@external.com)\" <alice@us.com>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).containsExactly("bob@external.com");
+    }
+
+    @Test
+    void shouldSkipWhenFromHeaderAlreadyAligned() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("alice@us.com", "Alice"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("Alice <alice@us.com>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).isNull();
+    }
+
+    @Test
+    void shouldSkipWhenNoMailFromAddress() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("bob@external.com", "Bob External"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("Bob External <bob@external.com>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).isNull();
+    }
+
+    @Test
+    void shouldSkipWhenNoFromHeader() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).isNull();
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).isNull();
+    }
+
+    @Test
+    void shouldHandleComplexDisplayNames() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("bob@external.com", "Bob \"The Builder\" External"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("\"Bob \\\"The Builder\\\" External (bob@external.com)\" <alice@us.com>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).containsExactly("bob@external.com");
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveComparison() throws Exception {
+        mailet.init(FakeMailetConfig.builder().build());
+
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("ALICE@US.COM", "Alice"))
+            .build();
+
+        Mail mail = FakeMail.builder()
+            .name("mail")
+            .sender("alice@us.com")
+            .mimeMessage(message)
+            .build();
+
+        mailet.service(mail);
+
+        assertThat(mail.getMessage().getHeader(FROM_HEADER)).containsExactly("Alice <ALICE@US.COM>");
+        assertThat(mail.getMessage().getHeader(ORIGINAL_FROM_HEADER)).isNull();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AlignFromHeaderWithMailFrom mailet to align From headers with MAIL FROM addresses while preserving original message addresses. Maintains DKIM alignment for forwarding, aliasing, and mailing list scenarios.

* **Documentation**
  * Added new documentation page detailing Extra Mailets configuration, including configuration parameters and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->