### PR TITLE
JAMES-3872: IndexBody.NO whe not used with -Dopensearch.index.listene…

### DIFF
--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailGetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailGetMethodTest.java
@@ -48,7 +48,6 @@ import org.apache.james.mime4j.dom.Message;
 import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.GuiceProbe;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -99,7 +98,7 @@ class PostgresEmailGetMethodTest implements EmailGetMethodContract {
             .overrideWith(new DelegationProbeModule())
             .overrideWith(binder -> binder.bind(OpenSearchMailboxConfiguration.class)
                 .toInstance(OpenSearchMailboxConfiguration.builder()
-                    .indexBody(IndexBody.NO)
+                    .indexBody(IndexBody.YES)
                     .build()))
             .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
                 .addBinding()
@@ -139,12 +138,5 @@ class PostgresEmailGetMethodTest implements EmailGetMethodContract {
             .until(() -> server.getProbe(MessageFastViewProjectionProbe.class)
                 .retrieve(messageId)
                 .isPresent());
-    }
-
-    @Disabled("JAMES-3872: Issue with read attachment level: fix on James first...")
-    @Test
-    @Override
-    public void shouldUseFastViewWithAttachmentMetadataWhenSupportedBodyPropertiesAtAttachmentReadLevel(GuiceJamesServer server) {
-
     }
 }


### PR DESCRIPTION
…r.fetch.full.content=true fails to populate preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage by enabling OpenSearch indexing in test configurations for more comprehensive email retrieval scenario validation.
  * Removed obsolete test case that was previously disabled, reducing maintenance overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->