### PR TITLE
FIX Scribe: proxying should preserve configured cors policy

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
@@ -49,7 +49,7 @@ import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
 import io.restassured.specification.RequestSpecification;
 
-public class AIChatCompletionRoutesTest {
+class AIChatCompletionRoutesTest {
     private static final String JMAP_CHAT_COMPLETIONS_ENDPOINT = "/ai/v1/chat/completions";
 
     @RegisterExtension
@@ -117,6 +117,7 @@ public class AIChatCompletionRoutesTest {
             .post()
         .then()
             .statusCode(SC_OK)
+            .header("Access-Control-Allow-Origin", "*")
             .contentType("application/json")
             .extract()
             .body()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI chat completion API now includes proper CORS headers for cross-origin requests from web applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->