### PR TITLE
Document email retrieval and label setting with JMAP

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/jmapLabels.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/jmapLabels.adoc
@@ -182,7 +182,7 @@ Request:
 }
 ```
 
-Similarily a label can be added to an email by setting the corresponding `keyword` using `Email/set`. For instance:
+Similarly a label can be added to an email by setting the corresponding `keyword` using `Email/set`. For instance:
 
 Request:
 ```json


### PR DESCRIPTION
Added examples for retrieving and setting emails with labels using JMAP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New section explaining how to retrieve emails by label using label-based query filters, with example request payloads.
  * Added guidance and examples for assigning labels to emails via update operations, including sample JSON requests for managing keyword-based labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->