### PR TITLE
ISSUE-2130 Alternative: Use substring_analyzer for subject and address substring matching

### DIFF
--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailCriterionConverter.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailCriterionConverter.java
@@ -30,6 +30,8 @@
 
 package com.linagora.tmail.mailbox.opensearch;
 
+import static org.apache.james.backends.opensearch.IndexCreationFactory.RAW;
+
 import jakarta.inject.Inject;
 
 import org.apache.james.mailbox.model.SearchQuery;
@@ -120,7 +122,27 @@ public class TmailCriterionConverter extends DefaultCriterionConverter {
                 .build()
                 .toQuery();
         }
-        return super.manageAddressFields(headerName, value);
+        String fieldName = getFieldNameFromHeaderName(headerName);
+        return new BoolQuery.Builder()
+            .should(new MatchQuery.Builder()
+                .field(fieldName + "." + JsonMessageConstants.EMailer.NAME)
+                .query(new FieldValue.Builder().stringValue(value).build())
+                .operator(Operator.And)
+                .build().toQuery())
+            .should(new MatchQuery.Builder()
+                .field(fieldName + "." + JsonMessageConstants.EMailer.ADDRESS)
+                .query(new FieldValue.Builder().stringValue(value).build())
+                .operator(Operator.And)
+                .build().toQuery())
+            .should(new MatchQuery.Builder()
+                .field(fieldName + "." + JsonMessageConstants.EMailer.DOMAIN)
+                .query(new FieldValue.Builder().stringValue(value).build())
+                .build().toQuery())
+            .should(new MatchQuery.Builder()
+                .field(fieldName + "." + JsonMessageConstants.EMailer.ADDRESS + "." + RAW)
+                .query(new FieldValue.Builder().stringValue(value).build())
+                .build().toQuery())
+            .build().toQuery();
     }
 
     @Override

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailMailboxMappingFactory.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailMailboxMappingFactory.java
@@ -73,6 +73,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
     private static final String NGRAM = "ngram";
     private static final String NGRAM_ANALYZER = "ngram_analyzer";
     private static final String FILENAME_ANALYZER = "filename_analyzer";
+    private static final String SUBSTRING_ANALYZER = "substring_analyzer";
     private static final String NGRAM_TOKENIZER = "ngram_tokenizer";
     private static final String WHITESPACE_TOKENIZER = "whitespace";
     private static final String LOWERCASE = "lowercase";
@@ -166,7 +167,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                     .properties(ImmutableMap.of(
                         JsonMessageConstants.EMailer.NAME, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -180,8 +181,8 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                             .build(),
                         JsonMessageConstants.EMailer.ADDRESS, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(STANDARD)
-                                .searchAnalyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
+                                .searchAnalyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -204,7 +205,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                 .build())
             .put(JsonMessageConstants.SUBJECT, new Property.Builder()
                 .text(new TextProperty.Builder()
-                    .analyzer(KEEP_MAIL_AND_URL)
+                    .analyzer(SUBSTRING_ANALYZER)
                     .fields(getSubjectFieds())
                     .build())
                 .build())
@@ -213,7 +214,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                     .properties(ImmutableMap.of(
                         JsonMessageConstants.EMailer.NAME, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -227,8 +228,8 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                             .build(),
                         JsonMessageConstants.EMailer.ADDRESS, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(STANDARD)
-                                .searchAnalyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
+                                .searchAnalyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -242,7 +243,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                     .properties(ImmutableMap.of(
                         JsonMessageConstants.EMailer.NAME, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -256,8 +257,8 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                             .build(),
                         JsonMessageConstants.EMailer.ADDRESS, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(STANDARD)
-                                .searchAnalyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
+                                .searchAnalyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -270,7 +271,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                 .object(new ObjectProperty.Builder()
                     .properties(ImmutableMap.of(
                         JsonMessageConstants.EMailer.NAME, new Property.Builder()
-                            .text(new TextProperty.Builder().analyzer(KEEP_MAIL_AND_URL).build())
+                            .text(new TextProperty.Builder().analyzer(SUBSTRING_ANALYZER).build())
                             .build(),
                         JsonMessageConstants.EMailer.DOMAIN, new Property.Builder()
                             .text(new TextProperty.Builder()
@@ -280,8 +281,8 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                             .build(),
                         JsonMessageConstants.EMailer.ADDRESS, new Property.Builder()
                             .text(new TextProperty.Builder()
-                                .analyzer(STANDARD)
-                                .searchAnalyzer(KEEP_MAIL_AND_URL)
+                                .analyzer(SUBSTRING_ANALYZER)
+                                .searchAnalyzer(SUBSTRING_ANALYZER)
                                 .fields(RAW, new Property.Builder()
                                     .keyword(new KeywordProperty.Builder().normalizer(CASE_INSENSITIVE).build())
                                     .build())
@@ -395,6 +396,12 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                         .filter(ASCIIFOLDING, LOWERCASE)
                         .build()))
                     .put(FILENAME_ANALYZER, new Analyzer.Builder()
+                        .custom(new CustomAnalyzer.Builder()
+                            .tokenizer(WHITESPACE_TOKENIZER)
+                            .filter(WORD_DELIMITER_GRAPH, ASCIIFOLDING, LOWERCASE)
+                            .build())
+                        .build())
+                    .put(SUBSTRING_ANALYZER, new Analyzer.Builder()
                         .custom(new CustomAnalyzer.Builder()
                             .tokenizer(WHITESPACE_TOKENIZER)
                             .filter(WORD_DELIMITER_GRAPH, ASCIIFOLDING, LOWERCASE)


### PR DESCRIPTION
## Summary

Alternative approach to #2131 for fixing JMAP Email/query subject and address filter substring matching.

**Problem:** The `uax_url_email` tokenizer (used by `KEEP_MAIL_AND_URL` analyzer) splits on `-`, `[`, `]`, `.` etc., making it impossible to match substrings like `nas-backup`, `example.com`, or `alice-test@domain.tld`.

**This PR's approach:** Replace the analyzer itself rather than switching to WildcardQuery.

- Introduces a `substring_analyzer` using `whitespace` tokenizer + `word_delimiter_graph` filter + `asciifolding` + `lowercase`
- `word_delimiter_graph` splits tokens at non-alphanumeric boundaries (e.g. `nas-backup.example.com` → `nas`, `backup`, `example`, `com`)
- Standard `MatchQuery` with `Operator.And` then naturally matches substrings without needing WildcardQuery

### Comparison with PR #2131 (WildcardQuery approach)

| Aspect | #2131 (WildcardQuery) | This PR (substring_analyzer) |
|--------|----------------------|------------------------------|
| Query type | WildcardQuery with `*term*` | Standard MatchQuery with AND |
| Performance | Slower (wildcard scan) | Faster (inverted index lookup) |
| Analyzer change | None | New analyzer on subject + address fields |
| Reindexation | Not required | **Required** |
| Scope | Subject only | Subject + address fields (fixes MAILBOX-401 too) |

### Trade-offs

- **Pro:** Better query performance (inverted index vs wildcard scan)
- **Pro:** Fixes both subject AND address hyphen matching (MAILBOX-401)
- **Pro:** Cleaner approach — no WildcardQuery wrapping needed
- **Con:** Requires reindexation of existing data
- **Con:** Changes the analyzer, which affects how all data is tokenized

## Changes

- **TmailMailboxMappingFactory**: Add `substring_analyzer`, apply to subject, from/to/cc/bcc name and address fields
- **TmailCriterionConverter**: Override `manageAddressFields` with `Operator.And` on name/address clauses to prevent false positives
- **Tests**: Re-enable 3 MAILBOX-401 hyphen address tests, add 3 new subject substring tests

## Test plan

- [ ] CI passes all 161 TmailOpenSearchIntegrationTest tests
- [ ] Subject search matches substrings with hyphens (`nas-backup`)
- [ ] Subject search matches substrings with dots (`example.com`)
- [ ] Address search matches hyphenated local parts (`alice-test`)
- [ ] Address search matches hyphenated domains (`domain-test.tld`)
- [ ] Existing address exact match still works
- [ ] No false positives on address search

Closes #2130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email address field searching to match across name, address, domain, and raw address variations.

* **New Features**
  * Introduced substring-based search analyzer for enhanced matching across email fields.

* **Tests**
  * Re-enabled address matching tests and added new test coverage for searches with special characters, hyphens, and compound names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->