### PR TITLE
fix(rag): removing prefix tmail_ from document id (#2112)

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/DocumentId.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/DocumentId.java
@@ -21,6 +21,6 @@ import org.apache.james.mailbox.model.MessageId;
 
 public record DocumentId(MessageId id) {
     public String asString() {
-        return "tmail_" + id.serialize();
+        return id.serialize();
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerIntegrationTest.java
@@ -141,7 +141,7 @@ public class RagListenerIntegrationTest {
                 .build())
             .withRequestBodyPart(aMultipart()
                 .withName("file")
-                .withFileName("tmail_" + message1.getId().getMessageId().serialize() + ".txt")
+                .withFileName(message1.getId().getMessageId().serialize() + ".txt")
                 .withHeader("Content-Type", containing("text/plain"))
                 .withBody(containing("# Email Headers\n" +
                     "\n" +
@@ -202,7 +202,7 @@ public class RagListenerIntegrationTest {
                 .build())
             .withRequestBodyPart(aMultipart()
                 .withName("file")
-                .withFileName("tmail_" + messageResponse.getId().getMessageId().serialize() + ".txt")
+                .withFileName(messageResponse.getId().getMessageId().serialize() + ".txt")
                 .withHeader("Content-Type", containing("text/plain"))
                 .build()));
     }
@@ -238,7 +238,7 @@ public class RagListenerIntegrationTest {
                 .build())
             .withRequestBodyPart(aMultipart()
                 .withName("file")
-                .withFileName("tmail_" + message1.getId().getMessageId().serialize() + ".txt")
+                .withFileName(message1.getId().getMessageId().serialize() + ".txt")
                 .withHeader("Content-Type", containing("text/plain"))
                 .withBody(containing("# Email Headers\n" +
                     "\n" +

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
@@ -377,7 +377,7 @@ class RagListenerTest {
 
         verify(2, postRequestedFor(urlMatching(RAG_INDEXER_ENDPOINT)));
 
-        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/tmail_1"))
+        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/1"))
             .withHeader("Authorization", equalTo("Bearer dummy-token"))
             .withHeader("Content-Type", containing("multipart/form-data"))
             .withRequestBodyPart(aMultipart()
@@ -407,7 +407,7 @@ class RagListenerTest {
                     "Body of the email"))
                 .build()));
 
-        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/tmail_2"))
+        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/2"))
             .withHeader("Authorization", equalTo("Bearer dummy-token"))
             .withHeader("Content-Type", containing("multipart/form-data"))
             .withRequestBodyPart(aMultipart()
@@ -467,7 +467,7 @@ class RagListenerTest {
 
         verify(1, postRequestedFor(urlMatching(RAG_INDEXER_ENDPOINT)));
 
-        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/tmail_1"))
+        verify(postRequestedFor(urlMatching("/indexer/partition/.*/file/1"))
             .withHeader("Authorization", equalTo("Bearer dummy-token"))
             .withHeader("Content-Type", containing("multipart/form-data"))
             .withRequestBodyPart(aMultipart()


### PR DESCRIPTION
# Summary

This fix restores the broken email link in the Assistant UI.

It was already fixed in the Assistant UI https://github.com/linagora/cozy-libs/pull/2927, but it can be improved further.

We remove the unnecessary `tmail_` prefix. The tmail information is already indicated in the doctype metadata during file indexing, so the prefix is redundant and not needed.

closes #2112