### PR TITLE
ISSUE-2176 TMailValidRcptHandler should handle subAdressing for Team …

### DIFF
--- a/tmail-backend/integration-tests/smtp/smtp-integration-tests-common/src/main/java/com/linagora/tmail/james/common/TeamMailboxSmtpContract.java
+++ b/tmail-backend/integration-tests/smtp/smtp-integration-tests-common/src/main/java/com/linagora/tmail/james/common/TeamMailboxSmtpContract.java
@@ -121,6 +121,14 @@ public abstract class TeamMailboxSmtpContract {
     }
 
     @Test
+    void smtpShouldAcceptSubAddressedTeamMailboxRecipient() throws Exception {
+        assertThatCode(() -> messageSender
+            .authenticate(BOB.asString(), BOB_PASSWORD)
+            .sendMessage(BOB.asString(), "marketing+subfolder@" + DOMAIN.asString()))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
     void teamMailboxShouldReceivedEmailFromAuthenticatedUser(GuiceJamesServer server) throws Exception {
         Username andre = Username.fromLocalPartWithDomain("andre", DOMAIN);
         String andrePassword = "123456";

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
@@ -53,7 +53,8 @@ public class TMailValidRcptHandler extends ValidRcptHandler {
     }
 
     private boolean isATeamMailbox(MailAddress recipient) {
-        return TeamMailbox.asTeamMailbox(recipient)
+        MailAddress strippedRecipient = recipient.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        return TeamMailbox.asTeamMailbox(strippedRecipient)
             .map(tm -> Mono.from(teamMailboxRepository.exists(tm)).block())
             .getOrElse(() -> false);
     }


### PR DESCRIPTION
…mailboxes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMTP mail handler now correctly accepts emails sent to subaddressed team mailbox recipients, enabling proper routing for team mailboxes with address extensions (e.g., marketing+subfolder@domain).

* **Tests**
  * Added test coverage for subaddressed team mailbox recipients in SMTP integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->