### PR TITLE
Add canUpgrade/isPaying to domain subscription message

### DIFF
--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedSaaSModule.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedSaaSModule.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import jakarta.inject.Named;
 
+import org.apache.james.events.EventListener;
 import org.apache.james.user.api.UsernameChangeTaskStep;
 
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
@@ -34,10 +35,13 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.james.jmap.saas.SaaSCapabilitiesModule;
+import com.linagora.tmail.saas.api.SaaSAccountProvisionListener;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.api.SaaSAccountUsernameChangeTaskStep;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
 import com.linagora.tmail.saas.api.cassandra.CassandraSaaSAccountRepository;
 import com.linagora.tmail.saas.api.cassandra.CassandraSaaSDataDefinition;
+import com.linagora.tmail.saas.api.cassandra.CassandraSaaSDomainAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionModule;
 
 public class DistributedSaaSModule extends AbstractModule {
@@ -49,9 +53,16 @@ public class DistributedSaaSModule extends AbstractModule {
         bind(SaaSAccountRepository.class).to(CassandraSaaSAccountRepository.class)
             .in(Scopes.SINGLETON);
 
+        bind(SaaSDomainAccountRepository.class).to(CassandraSaaSDomainAccountRepository.class)
+            .in(Scopes.SINGLETON);
+
         Multibinder.newSetBinder(binder(), UsernameChangeTaskStep.class)
             .addBinding()
             .to(SaaSAccountUsernameChangeTaskStep.class);
+
+        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
+            .addBinding()
+            .to(SaaSAccountProvisionListener.class);
     }
 
     @Provides

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemorySaaSModule.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemorySaaSModule.java
@@ -18,15 +18,19 @@
 
 package com.linagora.tmail.james.app;
 
+import org.apache.james.events.EventListener;
 import org.apache.james.user.api.UsernameChangeTaskStep;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.james.jmap.saas.SaaSCapabilitiesModule;
+import com.linagora.tmail.saas.api.SaaSAccountProvisionListener;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.api.SaaSAccountUsernameChangeTaskStep;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
 import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSDomainAccountRepository;
 
 public class MemorySaaSModule extends AbstractModule {
     @Override
@@ -36,8 +40,15 @@ public class MemorySaaSModule extends AbstractModule {
         bind(SaaSAccountRepository.class).to(MemorySaaSAccountRepository.class)
             .in(Scopes.SINGLETON);
 
+        bind(SaaSDomainAccountRepository.class).to(MemorySaaSDomainAccountRepository.class)
+            .in(Scopes.SINGLETON);
+
         Multibinder.newSetBinder(binder(), UsernameChangeTaskStep.class)
             .addBinding()
             .to(SaaSAccountUsernameChangeTaskStep.class);
+
+        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
+            .addBinding()
+            .to(SaaSAccountProvisionListener.class);
     }
 }

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresSaaSModule.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresSaaSModule.java
@@ -23,6 +23,7 @@ import static com.linagora.tmail.modules.data.TMailPostgresUsersRepositoryModule
 import jakarta.inject.Named;
 
 import org.apache.james.backends.postgres.PostgresTable;
+import org.apache.james.events.EventListener;
 import org.apache.james.user.api.UsernameChangeTaskStep;
 
 import com.google.inject.AbstractModule;
@@ -31,10 +32,13 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.james.jmap.saas.SaaSCapabilitiesModule;
+import com.linagora.tmail.saas.api.SaaSAccountProvisionListener;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.api.SaaSAccountUsernameChangeTaskStep;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
 import com.linagora.tmail.saas.api.postgres.PostgresSaaSAccountRepository;
 import com.linagora.tmail.saas.api.postgres.PostgresSaaSDataDefinition;
+import com.linagora.tmail.saas.api.postgres.PostgresSaaSDomainAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionModule;
 
 public class PostgresSaaSModule extends AbstractModule {
@@ -46,9 +50,16 @@ public class PostgresSaaSModule extends AbstractModule {
         bind(SaaSAccountRepository.class).to(PostgresSaaSAccountRepository.class)
             .in(Scopes.SINGLETON);
 
+        bind(SaaSDomainAccountRepository.class).to(PostgresSaaSDomainAccountRepository.class)
+            .in(Scopes.SINGLETON);
+
         Multibinder.newSetBinder(binder(), UsernameChangeTaskStep.class)
             .addBinding()
             .to(SaaSAccountUsernameChangeTaskStep.class);
+
+        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
+            .addBinding()
+            .to(SaaSAccountProvisionListener.class);
     }
 
     @Provides

--- a/tmail-backend/data/data-cassandra/src/main/java/com/linagora/tmail/domainlist/cassandra/TMailCassandraDomainListDataDefinition.java
+++ b/tmail-backend/data/data-cassandra/src/main/java/com/linagora/tmail/domainlist/cassandra/TMailCassandraDomainListDataDefinition.java
@@ -36,6 +36,8 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 public interface TMailCassandraDomainListDataDefinition {
     String TABLE_NAME = CassandraDomainsTable.TABLE_NAME;
     CqlIdentifier DOMAIN = CassandraDomainsTable.DOMAIN;
+    CqlIdentifier CAN_UPGRADE = CqlIdentifier.fromCql("can_upgrade");
+    CqlIdentifier IS_PAYING = CqlIdentifier.fromCql("is_paying");
 
     CassandraDataDefinition MODULE = CassandraDataDefinition.table(TABLE_NAME)
         .comment("Holds domains this TMail server is operating on.")
@@ -48,6 +50,8 @@ public interface TMailCassandraDomainListDataDefinition {
             .withColumn(MAILS_SENT_PER_DAYS, DataTypes.BIGINT)
             .withColumn(MAILS_RECEIVED_PER_MINUTE, DataTypes.BIGINT)
             .withColumn(MAILS_RECEIVED_PER_HOURS, DataTypes.BIGINT)
-            .withColumn(MAILS_RECEIVED_PER_DAYS, DataTypes.BIGINT))
+            .withColumn(MAILS_RECEIVED_PER_DAYS, DataTypes.BIGINT)
+            .withColumn(CAN_UPGRADE, DataTypes.BOOLEAN)
+            .withColumn(IS_PAYING, DataTypes.BOOLEAN))
         .build();
 }

--- a/tmail-backend/data/data-postgres/src/main/java/com/linagora/tmail/domainlist/postgres/TMailPostgresDomainDataDefinition.java
+++ b/tmail-backend/data/data-postgres/src/main/java/com/linagora/tmail/domainlist/postgres/TMailPostgresDomainDataDefinition.java
@@ -39,12 +39,16 @@ import org.apache.james.domainlist.postgres.PostgresDomainDataDefinition;
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
 
 public interface TMailPostgresDomainDataDefinition {
     interface PostgresDomainTable {
         Table<Record> TABLE_NAME = PostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME;
 
         Field<String> DOMAIN = PostgresDomainDataDefinition.PostgresDomainTable.DOMAIN;
+        Field<Boolean> CAN_UPGRADE = DSL.field("can_upgrade", SQLDataType.BOOLEAN);
+        Field<Boolean> IS_PAYING = DSL.field("is_paying", SQLDataType.BOOLEAN);
 
         PostgresTable TABLE = PostgresTable.name(TABLE_NAME.getName())
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
@@ -55,6 +59,8 @@ public interface TMailPostgresDomainDataDefinition {
                 .column(MAILS_RECEIVED_PER_MINUTE)
                 .column(MAILS_RECEIVED_PER_HOURS)
                 .column(MAILS_RECEIVED_PER_DAYS)
+                .column(CAN_UPGRADE)
+                .column(IS_PAYING)
                 .primaryKey(DOMAIN)))
             .disableRowLevelSecurity()
             .build();

--- a/tmail-backend/saas/saas-api/pom.xml
+++ b/tmail-backend/saas/saas-api/pom.xml
@@ -16,12 +16,26 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-mailet-base</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-mailet-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>event-bus-api</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/SaaSAccountProvisionListener.java
+++ b/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/SaaSAccountProvisionListener.java
@@ -1,0 +1,92 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.events.Event;
+import org.apache.james.events.EventListener;
+import org.apache.james.events.Group;
+import org.apache.james.mailbox.events.MailboxEvents;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
+public class SaaSAccountProvisionListener implements EventListener.ReactiveGroupEventListener {
+
+    public static class SaaSAccountProvisionListenerGroup extends Group {
+
+    }
+
+    private static final SaaSAccountProvisionListenerGroup GROUP = new SaaSAccountProvisionListenerGroup();
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaaSAccountProvisionListener.class);
+
+    private final SaaSDomainAccountRepository saaSDomainAccountRepository;
+    private final SaaSAccountRepository saaSAccountRepository;
+
+    @Inject
+    public SaaSAccountProvisionListener(SaaSDomainAccountRepository saaSDomainAccountRepository,
+                                        SaaSAccountRepository saaSAccountRepository) {
+        this.saaSDomainAccountRepository = saaSDomainAccountRepository;
+        this.saaSAccountRepository = saaSAccountRepository;
+    }
+
+    @Override
+    public Group getDefaultGroup() {
+        return GROUP;
+    }
+
+    @Override
+    public boolean isHandling(Event event) {
+        if (event instanceof MailboxEvents.MailboxAdded mailboxAdded) {
+            return mailboxAdded.getMailboxPath().getName().equalsIgnoreCase(MailboxConstants.INBOX);
+        }
+        return false;
+    }
+
+    @Override
+    public Publisher<Void> reactiveEvent(Event event) {
+        if (!isHandling(event)) {
+            return Mono.empty();
+        }
+
+        Username username = event.getUsername();
+        return username.getDomainPart()
+            .map(domain -> provisionAccountFromDomainDefaults(username, domain))
+            .orElse(Mono.empty());
+    }
+
+    private Mono<Void> provisionAccountFromDomainDefaults(Username username, Domain domain) {
+        return Mono.from(saaSDomainAccountRepository.getSaaSDomainAccount(domain))
+            .flatMap(domainAccount -> {
+                LOGGER.info("Provisioning SaaS account for new user {} from domain {} defaults: canUpgrade={}, isPaying={}",
+                    username.asString(), domain.asString(), domainAccount.canUpgrade(), domainAccount.isPaying());
+                return Mono.from(saaSAccountRepository.upsertSaasAccount(username, domainAccount));
+            })
+            .onErrorResume(e -> {
+                LOGGER.error("Error provisioning SaaS account for user {}", username.asString(), e);
+                return Mono.empty();
+            });
+    }
+}

--- a/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/SaaSDomainAccountRepository.java
+++ b/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/SaaSDomainAccountRepository.java
@@ -1,0 +1,32 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api;
+
+import org.apache.james.core.Domain;
+import org.reactivestreams.Publisher;
+
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+public interface SaaSDomainAccountRepository {
+    Publisher<SaaSAccount> getSaaSDomainAccount(Domain domain);
+
+    Publisher<Void> upsertSaasDomainAccount(Domain domain, SaaSAccount saaSAccount);
+
+    Publisher<Void> deleteSaaSDomainAccount(Domain domain);
+}

--- a/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/memory/MemorySaaSDomainAccountRepository.java
+++ b/tmail-backend/saas/saas-api/src/main/java/com/linagora/tmail/saas/api/memory/MemorySaaSDomainAccountRepository.java
@@ -1,0 +1,49 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.memory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.james.core.Domain;
+import org.reactivestreams.Publisher;
+
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import reactor.core.publisher.Mono;
+
+public class MemorySaaSDomainAccountRepository implements SaaSDomainAccountRepository {
+    private final ConcurrentMap<Domain, SaaSAccount> table = new ConcurrentHashMap<>();
+
+    @Override
+    public Publisher<SaaSAccount> getSaaSDomainAccount(Domain domain) {
+        return Mono.justOrEmpty(table.get(domain));
+    }
+
+    @Override
+    public Publisher<Void> upsertSaasDomainAccount(Domain domain, SaaSAccount saaSAccount) {
+        return Mono.fromRunnable(() -> table.put(domain, saaSAccount));
+    }
+
+    @Override
+    public Publisher<Void> deleteSaaSDomainAccount(Domain domain) {
+        return Mono.fromRunnable(() -> table.remove(domain));
+    }
+}

--- a/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/SaaSAccountProvisionListenerTest.java
+++ b/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/SaaSAccountProvisionListenerTest.java
@@ -1,0 +1,113 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.events.Event;
+import org.apache.james.mailbox.events.MailboxEvents;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.TestId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSDomainAccountRepository;
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import reactor.core.publisher.Mono;
+
+public class SaaSAccountProvisionListenerTest {
+
+    private static final Domain DOMAIN = Domain.of("example.com");
+    private static final Username BOB = Username.of("bob@example.com");
+    private static final MailboxId MAILBOX_ID = TestId.of(1);
+    private static final SaaSAccount DOMAIN_ACCOUNT = new SaaSAccount(false, true);
+
+    private MemorySaaSDomainAccountRepository domainAccountRepository;
+    private MemorySaaSAccountRepository accountRepository;
+    private SaaSAccountProvisionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        domainAccountRepository = new MemorySaaSDomainAccountRepository();
+        accountRepository = new MemorySaaSAccountRepository();
+        listener = new SaaSAccountProvisionListener(domainAccountRepository, accountRepository);
+    }
+
+    private MailboxEvents.MailboxAdded inboxAddedEvent(Username username) {
+        return new MailboxEvents.MailboxAdded(
+            null,
+            username,
+            MailboxPath.forUser(username, MailboxConstants.INBOX),
+            MAILBOX_ID,
+            Event.EventId.random());
+    }
+
+    private MailboxEvents.MailboxAdded mailboxAddedEvent(Username username, String mailboxName) {
+        return new MailboxEvents.MailboxAdded(
+            null,
+            username,
+            MailboxPath.forUser(username, mailboxName),
+            MAILBOX_ID,
+            Event.EventId.random());
+    }
+
+    @Test
+    void shouldProvisionAccountFromDomainDefaults() {
+        Mono.from(domainAccountRepository.upsertSaasDomainAccount(DOMAIN, DOMAIN_ACCOUNT)).block();
+
+        Mono.from(listener.reactiveEvent(inboxAddedEvent(BOB))).block();
+
+        assertThat(Mono.from(accountRepository.getSaaSAccount(BOB)).block())
+            .isEqualTo(DOMAIN_ACCOUNT);
+    }
+
+    @Test
+    void shouldNotProvisionWhenNoDomainDefaults() {
+        Mono.from(listener.reactiveEvent(inboxAddedEvent(BOB))).block();
+
+        assertThat(Mono.from(accountRepository.getSaaSAccount(BOB)).block())
+            .isEqualTo(SaaSAccount.DEFAULT);
+    }
+
+    @Test
+    void shouldIgnoreNonInboxMailboxCreation() {
+        Mono.from(domainAccountRepository.upsertSaasDomainAccount(DOMAIN, DOMAIN_ACCOUNT)).block();
+
+        Mono.from(listener.reactiveEvent(mailboxAddedEvent(BOB, "Sent"))).block();
+
+        assertThat(Mono.from(accountRepository.getSaaSAccount(BOB)).block())
+            .isEqualTo(SaaSAccount.DEFAULT);
+    }
+
+    @Test
+    void isHandlingShouldReturnTrueForInboxCreation() {
+        assertThat(listener.isHandling(inboxAddedEvent(BOB))).isTrue();
+    }
+
+    @Test
+    void isHandlingShouldReturnFalseForNonInboxMailbox() {
+        assertThat(listener.isHandling(mailboxAddedEvent(BOB, "Drafts"))).isFalse();
+    }
+}

--- a/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/SaaSDomainAccountRepositoryContract.java
+++ b/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/SaaSDomainAccountRepositoryContract.java
@@ -1,0 +1,101 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Domain;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import reactor.core.publisher.Mono;
+
+public interface SaaSDomainAccountRepositoryContract {
+
+    SaaSAccount SAAS_ACCOUNT = new SaaSAccount(false, true);
+    SaaSAccount SAAS_ACCOUNT_2 = new SaaSAccount(true, true);
+
+    Domain DOMAIN = Domain.of("example.com");
+    Domain OTHER_DOMAIN = Domain.of("other.com");
+
+    SaaSDomainAccountRepository testee();
+
+    @Test
+    default void upsertSaasDomainAccountShouldSucceed() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isEqualTo(SAAS_ACCOUNT);
+    }
+
+    @Test
+    default void getSaaSDomainAccountShouldReturnEmptyWhenNotFound() {
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isNull();
+    }
+
+    @Test
+    default void upsertSaasDomainAccountShouldOverridePreviousValue() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT_2)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isEqualTo(SAAS_ACCOUNT_2);
+    }
+
+    @Test
+    default void deleteSaaSDomainAccountShouldSucceed() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+        Mono.from(testee().deleteSaaSDomainAccount(DOMAIN)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isNull();
+    }
+
+    @Test
+    default void deleteSaaSDomainAccountShouldBeIdempotent() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+
+        Mono.from(testee().deleteSaaSDomainAccount(DOMAIN)).block();
+        Mono.from(testee().deleteSaaSDomainAccount(DOMAIN)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isNull();
+    }
+
+    @Test
+    default void upsertShouldNotAffectOtherDomains() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(OTHER_DOMAIN)).block())
+            .isNull();
+    }
+
+    @Test
+    default void setSaaSDomainAccountAfterDeleteShouldSucceed() {
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT)).block();
+        Mono.from(testee().deleteSaaSDomainAccount(DOMAIN)).block();
+
+        Mono.from(testee().upsertSaasDomainAccount(DOMAIN, SAAS_ACCOUNT_2)).block();
+
+        assertThat(Mono.from(testee().getSaaSDomainAccount(DOMAIN)).block())
+            .isEqualTo(SAAS_ACCOUNT_2);
+    }
+}

--- a/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/memory/MemorySaaSDomainAccountRepositoryTest.java
+++ b/tmail-backend/saas/saas-api/src/test/java/com/linagora/tmail/saas/api/memory/MemorySaaSDomainAccountRepositoryTest.java
@@ -1,0 +1,39 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepositoryContract;
+
+public class MemorySaaSDomainAccountRepositoryTest implements SaaSDomainAccountRepositoryContract {
+
+    private MemorySaaSDomainAccountRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new MemorySaaSDomainAccountRepository();
+    }
+
+    @Override
+    public SaaSDomainAccountRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/saas/saas-cassandra/src/main/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSDomainAccountRepository.java
+++ b/tmail-backend/saas/saas-cassandra/src/main/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSDomainAccountRepository.java
@@ -1,0 +1,103 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.cassandra;
+
+import static com.datastax.oss.driver.api.core.type.codec.TypeCodecs.BOOLEAN;
+import static com.datastax.oss.driver.api.core.type.codec.TypeCodecs.TEXT;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.update;
+import static com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition.CAN_UPGRADE;
+import static com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition.DOMAIN;
+import static com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition.IS_PAYING;
+import static com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition.TABLE_NAME;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.core.Domain;
+import org.reactivestreams.Publisher;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import reactor.core.publisher.Mono;
+
+public class CassandraSaaSDomainAccountRepository implements SaaSDomainAccountRepository {
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement selectStatement;
+    private final PreparedStatement clearStatement;
+
+    @Inject
+    public CassandraSaaSDomainAccountRepository(CqlSession session) {
+        this.executor = new CassandraAsyncExecutor(session);
+        this.insertStatement = session.prepare(insertInto(TABLE_NAME)
+            .value(DOMAIN, bindMarker(DOMAIN))
+            .value(CAN_UPGRADE, bindMarker(CAN_UPGRADE))
+            .value(IS_PAYING, bindMarker(IS_PAYING))
+            .build());
+        this.selectStatement = session.prepare(selectFrom(TABLE_NAME)
+            .columns(CAN_UPGRADE, IS_PAYING)
+            .whereColumn(DOMAIN).isEqualTo(bindMarker(DOMAIN))
+            .build());
+        this.clearStatement = session.prepare(update(TABLE_NAME)
+            .setColumn(CAN_UPGRADE, bindMarker(CAN_UPGRADE))
+            .setColumn(IS_PAYING, bindMarker(IS_PAYING))
+            .whereColumn(DOMAIN).isEqualTo(bindMarker(DOMAIN))
+            .build());
+    }
+
+    @Override
+    public Publisher<SaaSAccount> getSaaSDomainAccount(Domain domain) {
+        return Mono.from(executor.executeSingleRow(selectStatement.bind()
+                .setString(DOMAIN, domain.asString())))
+            .flatMap(row -> {
+                Boolean canUpgrade = row.get(CAN_UPGRADE, Boolean.class);
+                Boolean isPaying = row.get(IS_PAYING, Boolean.class);
+                if (canUpgrade == null && isPaying == null) {
+                    return Mono.empty();
+                }
+                return Mono.just(new SaaSAccount(
+                    Optional.ofNullable(canUpgrade).orElse(SaaSAccount.DEFAULT.canUpgrade()),
+                    Optional.ofNullable(isPaying).orElse(SaaSAccount.DEFAULT.isPaying())));
+            });
+    }
+
+    @Override
+    public Publisher<Void> upsertSaasDomainAccount(Domain domain, SaaSAccount saaSAccount) {
+        return Mono.from(executor.executeVoid(insertStatement.bind()
+            .set(DOMAIN, domain.asString(), TEXT)
+            .set(CAN_UPGRADE, saaSAccount.canUpgrade(), BOOLEAN)
+            .set(IS_PAYING, saaSAccount.isPaying(), BOOLEAN)));
+    }
+
+    @Override
+    public Publisher<Void> deleteSaaSDomainAccount(Domain domain) {
+        return Mono.from(executor.executeVoid(clearStatement.bind()
+            .set(DOMAIN, domain.asString(), TEXT)
+            .setToNull(CAN_UPGRADE)
+            .setToNull(IS_PAYING)));
+    }
+}

--- a/tmail-backend/saas/saas-cassandra/src/test/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSDomainAccountRepositoryTest.java
+++ b/tmail-backend/saas/saas-cassandra/src/test/java/com/linagora/tmail/saas/api/cassandra/CassandraSaaSDomainAccountRepositoryTest.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.cassandra;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepositoryContract;
+
+public class CassandraSaaSDomainAccountRepositoryTest implements SaaSDomainAccountRepositoryContract {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(TMailCassandraDomainListDataDefinition.MODULE);
+
+    private CassandraSaaSDomainAccountRepository repository;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandraCluster) {
+        repository = new CassandraSaaSDomainAccountRepository(cassandraCluster.getConf());
+    }
+
+    @Override
+    public SaaSDomainAccountRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/saas/saas-postgres/src/main/java/com/linagora/tmail/saas/api/postgres/PostgresSaaSDomainAccountRepository.java
+++ b/tmail-backend/saas/saas-postgres/src/main/java/com/linagora/tmail/saas/api/postgres/PostgresSaaSDomainAccountRepository.java
@@ -1,0 +1,81 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.postgres;
+
+import static com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition.PostgresDomainTable.CAN_UPGRADE;
+import static com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition.PostgresDomainTable.DOMAIN;
+import static com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition.PostgresDomainTable.IS_PAYING;
+import static com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.backends.postgres.utils.PostgresExecutor;
+import org.apache.james.core.Domain;
+import org.reactivestreams.Publisher;
+
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import reactor.core.publisher.Mono;
+
+public class PostgresSaaSDomainAccountRepository implements SaaSDomainAccountRepository {
+    private final PostgresExecutor executor;
+
+    @Inject
+    public PostgresSaaSDomainAccountRepository(PostgresExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public Publisher<SaaSAccount> getSaaSDomainAccount(Domain domain) {
+        return Mono.from(executor.executeRow(dsl -> Mono.from(dsl.select(CAN_UPGRADE, IS_PAYING)
+                .from(TABLE_NAME)
+                .where(DOMAIN.eq(domain.asString())))))
+            .flatMap(row -> {
+                Boolean canUpgrade = row.get(CAN_UPGRADE);
+                Boolean isPaying = row.get(IS_PAYING);
+                if (canUpgrade == null && isPaying == null) {
+                    return Mono.empty();
+                }
+                return Mono.just(new SaaSAccount(
+                    canUpgrade != null ? canUpgrade : SaaSAccount.DEFAULT.canUpgrade(),
+                    isPaying != null ? isPaying : SaaSAccount.DEFAULT.isPaying()));
+            });
+    }
+
+    @Override
+    public Publisher<Void> upsertSaasDomainAccount(Domain domain, SaaSAccount saaSAccount) {
+        return executor.executeVoid(dsl -> Mono.from(dsl.insertInto(TABLE_NAME)
+            .set(DOMAIN, domain.asString())
+            .set(CAN_UPGRADE, saaSAccount.canUpgrade())
+            .set(IS_PAYING, saaSAccount.isPaying())
+            .onConflict(DOMAIN)
+            .doUpdate()
+            .set(CAN_UPGRADE, saaSAccount.canUpgrade())
+            .set(IS_PAYING, saaSAccount.isPaying())));
+    }
+
+    @Override
+    public Publisher<Void> deleteSaaSDomainAccount(Domain domain) {
+        return executor.executeVoid(dsl -> Mono.from(dsl.update(TABLE_NAME)
+            .set(CAN_UPGRADE, (Boolean) null)
+            .set(IS_PAYING, (Boolean) null)
+            .where(DOMAIN.eq(domain.asString()))));
+    }
+}

--- a/tmail-backend/saas/saas-postgres/src/test/java/com/linagora/tmail/saas/api/postgres/PostgresSaaSDomainAccountRepositoryTest.java
+++ b/tmail-backend/saas/saas-postgres/src/test/java/com/linagora/tmail/saas/api/postgres/PostgresSaaSDomainAccountRepositoryTest.java
@@ -1,0 +1,46 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.saas.api.postgres;
+
+import org.apache.james.backends.postgres.PostgresDataDefinition;
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepositoryContract;
+
+public class PostgresSaaSDomainAccountRepositoryTest implements SaaSDomainAccountRepositoryContract {
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(
+        PostgresDataDefinition.aggregateModules(TMailPostgresDomainDataDefinition.MODULE));
+
+    private PostgresSaaSDomainAccountRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new PostgresSaaSDomainAccountRepository(postgresExtension.getDefaultPostgresExecutor());
+    }
+
+    @Override
+    public SaaSDomainAccountRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionMessage.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionMessage.java
@@ -25,17 +25,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
 public interface SaaSDomainSubscriptionMessage {
-    record SaaSDomainValidSubscriptionMessage(String domain, Optional<Boolean> mailDnsConfigurationValidated, Optional<SaasFeatures> features) implements SaaSDomainSubscriptionMessage {
+    record SaaSDomainValidSubscriptionMessage(String domain,
+                                                  Optional<Boolean> mailDnsConfigurationValidated,
+                                                  Optional<SaasFeatures> features,
+                                                  Optional<Boolean> canUpgrade,
+                                                  Optional<Boolean> isPaying) implements SaaSDomainSubscriptionMessage {
 
         @JsonCreator
         public SaaSDomainValidSubscriptionMessage(@JsonProperty("domain") String domain,
                                                   @JsonProperty("mailDnsConfigurationValidated") Optional<Boolean> mailDnsConfigurationValidated,
-                                                  @JsonProperty("features") Optional<SaasFeatures> features) {
+                                                  @JsonProperty("features") Optional<SaasFeatures> features,
+                                                  @JsonProperty("canUpgrade") Optional<Boolean> canUpgrade,
+                                                  @JsonProperty("isPaying") Optional<Boolean> isPaying) {
             Preconditions.checkNotNull(domain, "domain cannot be null");
 
             this.domain = domain;
             this.mailDnsConfigurationValidated = mailDnsConfigurationValidated;
             this.features = features;
+            this.canUpgrade = canUpgrade;
+            this.isPaying = isPaying;
         }
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionModule.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionModule.java
@@ -43,6 +43,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.linagora.tmail.rate.limiter.api.RateLimitingRepository;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.TWPCommonRabbitMQConfiguration;
 
 public class SaaSSubscriptionModule extends AbstractModule {
@@ -83,12 +84,18 @@ public class SaaSSubscriptionModule extends AbstractModule {
                                                                          SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration,
                                                                          DomainList domainList,
                                                                          MaxQuotaManager maxQuotaManager,
-                                                                         RateLimitingRepository rateLimitingRepository) {
+                                                                         RateLimitingRepository rateLimitingRepository,
+                                                                         UsersRepository usersRepository,
+                                                                         SaaSAccountRepository saaSAccountRepository,
+                                                                         SaaSDomainAccountRepository saaSDomainAccountRepository) {
         return new SaaSDomainSubscriptionConsumer(channelPool, rabbitMQConfiguration, twpCommonRabbitMQConfiguration,
             saasSubscriptionRabbitMQConfiguration,
             new SaaSDomainSubscriptionHandlerImpl(domainList,
                 maxQuotaManager,
-                rateLimitingRepository));
+                rateLimitingRepository,
+                usersRepository,
+                saaSAccountRepository,
+                saaSDomainAccountRepository));
     }
 
     @ProvidesIntoSet

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumerTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumerTest.java
@@ -43,6 +43,7 @@ import org.apache.james.domainlist.api.mock.SimpleDomainList;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.inmemory.quota.InMemoryPerUserMaxQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.user.memory.MemoryUsersRepository;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -54,6 +55,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linagora.tmail.rate.limiter.api.RateLimitingRepository;
 import com.linagora.tmail.rate.limiter.api.memory.MemoryRateLimitingRepository;
 import com.linagora.tmail.rate.limiter.api.model.RateLimitingDefinition;
+import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSDomainAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.TWPCommonRabbitMQConfiguration;
 
 import reactor.core.publisher.Mono;
@@ -120,7 +123,10 @@ class SaaSDomainSubscriptionConsumerTest {
             SaaSSubscriptionRabbitMQConfiguration.DEFAULT,
             new SaaSDomainSubscriptionHandlerImpl(domainList,
                 maxQuotaManager,
-                rateLimitingRepository));
+                rateLimitingRepository,
+                MemoryUsersRepository.withVirtualHosting(domainList),
+                new MemorySaaSAccountRepository(),
+                new MemorySaaSDomainAccountRepository()));
         testee.init();
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionDeserializerTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionDeserializerTest.java
@@ -276,6 +276,60 @@ public class SaaSDomainSubscriptionDeserializerTest {
 
             assertThat(parsed.features().get().mail().get().storageQuota()).isEqualTo(-1L);
         }
+
+        @Test
+        void parseMessageWithCanUpgradeAndIsPayingShouldSucceed() {
+            String validMessage = """
+            {
+                "domain": "twake.app",
+                "mailDnsConfigurationValidated": true,
+                "canUpgrade": false,
+                "isPaying": true
+            }
+            """;
+
+            SaaSDomainValidSubscriptionMessage message = (SaaSDomainValidSubscriptionMessage) SaaSSubscriptionDeserializer.parseAMQPDomainMessage(validMessage);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(message.domain()).isEqualTo("twake.app");
+                softly.assertThat(message.canUpgrade()).contains(false);
+                softly.assertThat(message.isPaying()).contains(true);
+            });
+        }
+
+        @Test
+        void parseMessageWithoutCanUpgradeAndIsPayingShouldReturnEmpty() {
+            String validMessage = """
+            {
+                "domain": "twake.app",
+                "mailDnsConfigurationValidated": true
+            }
+            """;
+
+            SaaSDomainValidSubscriptionMessage message = (SaaSDomainValidSubscriptionMessage) SaaSSubscriptionDeserializer.parseAMQPDomainMessage(validMessage);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(message.canUpgrade()).isEmpty();
+                softly.assertThat(message.isPaying()).isEmpty();
+            });
+        }
+
+        @Test
+        void parseMessageWithOnlyIsPayingShouldSucceed() {
+            String validMessage = """
+            {
+                "domain": "twake.app",
+                "isPaying": true
+            }
+            """;
+
+            SaaSDomainValidSubscriptionMessage message = (SaaSDomainValidSubscriptionMessage) SaaSSubscriptionDeserializer.parseAMQPDomainMessage(validMessage);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(message.canUpgrade()).isEmpty();
+                softly.assertThat(message.isPaying()).contains(true);
+            });
+        }
     }
 
     @Nested

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionHandlerImplTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionHandlerImplTest.java
@@ -5,17 +5,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 
 import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaSizeLimit;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.api.mock.SimpleDomainList;
 import org.apache.james.mailbox.inmemory.quota.InMemoryPerUserMaxQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.rate.limiter.api.RateLimitingRepository;
 import com.linagora.tmail.rate.limiter.api.memory.MemoryRateLimitingRepository;
 import com.linagora.tmail.rate.limiter.api.model.RateLimitingDefinition;
+import com.linagora.tmail.saas.api.SaaSAccountRepository;
+import com.linagora.tmail.saas.api.SaaSDomainAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSDomainAccountRepository;
+import com.linagora.tmail.saas.model.SaaSAccount;
 
 import reactor.core.publisher.Mono;
 
@@ -27,16 +35,23 @@ public class SaaSDomainSubscriptionHandlerImplTest {
     private DomainList domainList;
     private MaxQuotaManager maxQuotaManager;
     private RateLimitingRepository rateLimitingRepository;
+    private UsersRepository usersRepository;
+    private SaaSAccountRepository saaSAccountRepository;
+    private SaaSDomainAccountRepository saaSDomainAccountRepository;
 
     private SaaSDomainSubscriptionHandlerImpl handler;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         domainList = new SimpleDomainList();
         maxQuotaManager = new InMemoryPerUserMaxQuotaManager();
         rateLimitingRepository = new MemoryRateLimitingRepository();
+        usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+        saaSAccountRepository = new MemorySaaSAccountRepository();
+        saaSDomainAccountRepository = new MemorySaaSDomainAccountRepository();
 
-        handler = new SaaSDomainSubscriptionHandlerImpl(domainList, maxQuotaManager, rateLimitingRepository);
+        handler = new SaaSDomainSubscriptionHandlerImpl(domainList, maxQuotaManager, rateLimitingRepository,
+            usersRepository, saaSAccountRepository, saaSDomainAccountRepository);
     }
 
     @Test
@@ -55,7 +70,9 @@ public class SaaSDomainSubscriptionHandlerImplTest {
         SaasFeatures features = new SaasFeatures(Optional.of(mail));
 
         SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
-            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName, Optional.of(MAIL_DNS_CONFIGURATION_VALIDATED), Optional.of(features));
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.of(MAIL_DNS_CONFIGURATION_VALIDATED), Optional.of(features),
+                Optional.empty(), Optional.empty());
 
         handler.handleMessage(message).block();
 
@@ -103,7 +120,9 @@ public class SaaSDomainSubscriptionHandlerImplTest {
         Domain domain = Domain.of(domainName);
 
         SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
-            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName, Optional.of(MAIL_DNS_CONFIGURATION_VALIDATED), Optional.empty());
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.of(MAIL_DNS_CONFIGURATION_VALIDATED), Optional.empty(),
+                Optional.empty(), Optional.empty());
 
         // First add
         handler.handleMessage(message).block();
@@ -125,5 +144,120 @@ public class SaaSDomainSubscriptionHandlerImplTest {
         handler.handleMessage(message).block();
 
         assertThat(domainList.containsDomain(domain)).isFalse();
+    }
+
+    @Test
+    void shouldApplyAccountSettingsToExistingUsers() throws Exception {
+        String domainName = "account.com";
+        Domain domain = Domain.of(domainName);
+        domainList.addDomain(domain);
+
+        Username bob = Username.of("bob@account.com");
+        Username alice = Username.of("alice@account.com");
+        usersRepository.addUser(bob, "password");
+        usersRepository.addUser(alice, "password");
+
+        SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.empty(), Optional.empty(),
+                Optional.of(false), Optional.of(true));
+
+        handler.handleMessage(message).block();
+
+        SaaSAccount expectedAccount = new SaaSAccount(false, true);
+        assertThat(Mono.from(saaSAccountRepository.getSaaSAccount(bob)).block()).isEqualTo(expectedAccount);
+        assertThat(Mono.from(saaSAccountRepository.getSaaSAccount(alice)).block()).isEqualTo(expectedAccount);
+    }
+
+    @Test
+    void shouldStoreDomainDefaultsWhenAccountSettingsPresent() throws Exception {
+        String domainName = "defaults.com";
+        Domain domain = Domain.of(domainName);
+        domainList.addDomain(domain);
+
+        SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.empty(), Optional.empty(),
+                Optional.of(false), Optional.of(true));
+
+        handler.handleMessage(message).block();
+
+        SaaSAccount domainAccount = Mono.from(saaSDomainAccountRepository.getSaaSDomainAccount(domain)).block();
+        assertThat(domainAccount).isEqualTo(new SaaSAccount(false, true));
+    }
+
+    @Test
+    void shouldNotApplyAccountSettingsWhenBothFieldsAbsent() throws Exception {
+        String domainName = "nofields.com";
+        Domain domain = Domain.of(domainName);
+        domainList.addDomain(domain);
+
+        Username bob = Username.of("bob@nofields.com");
+        usersRepository.addUser(bob, "password");
+
+        SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty());
+
+        handler.handleMessage(message).block();
+
+        // SaaS account should remain at default since no account settings were applied
+        assertThat(Mono.from(saaSAccountRepository.getSaaSAccount(bob)).block()).isEqualTo(SaaSAccount.DEFAULT);
+    }
+
+    @Test
+    void shouldSucceedWhenDomainHasNoUsers() throws Exception {
+        String domainName = "empty.com";
+        domainList.addDomain(Domain.of(domainName));
+
+        SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.empty(), Optional.empty(),
+                Optional.of(true), Optional.of(true));
+
+        // Should not throw
+        handler.handleMessage(message).block();
+
+        SaaSAccount domainAccount = Mono.from(saaSDomainAccountRepository.getSaaSDomainAccount(Domain.of(domainName))).block();
+        assertThat(domainAccount).isEqualTo(new SaaSAccount(true, true));
+    }
+
+    @Test
+    void shouldDeleteDomainDefaultsOnCancellation() throws Exception {
+        String domainName = "cancel.com";
+        Domain domain = Domain.of(domainName);
+        domainList.addDomain(domain);
+
+        // First set domain defaults
+        Mono.from(saaSDomainAccountRepository.upsertSaasDomainAccount(domain, new SaaSAccount(false, true))).block();
+
+        SaaSDomainSubscriptionMessage.SaaSDomainCancelSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainCancelSubscriptionMessage(domainName, DOMAIN_DISABLED);
+
+        handler.handleMessage(message).block();
+
+        assertThat(Mono.from(saaSDomainAccountRepository.getSaaSDomainAccount(domain)).block()).isNull();
+    }
+
+    @Test
+    void shouldUseDefaultCanUpgradeWhenOnlyIsPayingProvided() throws Exception {
+        String domainName = "partial.com";
+        Domain domain = Domain.of(domainName);
+        domainList.addDomain(domain);
+
+        Username bob = Username.of("bob@partial.com");
+        usersRepository.addUser(bob, "password");
+
+        SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage message =
+            new SaaSDomainSubscriptionMessage.SaaSDomainValidSubscriptionMessage(domainName,
+                Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.of(true));
+
+        handler.handleMessage(message).block();
+
+        // canUpgrade should use DEFAULT value (true), isPaying should be true
+        SaaSAccount expectedAccount = new SaaSAccount(SaaSAccount.DEFAULT.canUpgrade(), true);
+        assertThat(Mono.from(saaSAccountRepository.getSaaSAccount(bob)).block()).isEqualTo(expectedAccount);
     }
 }


### PR DESCRIPTION
## Problem

The domain subscription handler currently handles DNS validation, storage quota, and rate limiting when a domain subscription message arrives from RabbitMQ. However, there is no way to set `canUpgrade` and `isPaying` at the domain level.

These two flags are read per-user by `SaaSCapabilityFactory` (exposed via JMAP capabilities) and the `IsPaying` mailet matcher. Unlike rate limiting, which has a built-in domain-level fallback in the mailets, `canUpgrade`/`isPaying` have no domain fallback — they are only read from the user table. This means there is currently no way to control these values for all users of a domain at once.

## Solution

Add `canUpgrade` and `isPaying` as optional fields to `SaaSDomainValidSubscriptionMessage`. When a domain subscription message arrives with these fields:

1. **Store domain-level defaults** as new columns (`can_upgrade`, `is_paying`) in the existing `domains` table. This follows the same pattern used for domain-level rate limiting — no new table is created.

2. **Propagate to all existing users** in that domain by iterating through `UsersRepository.listUsersOfADomainReactive` and upserting each user's `SaaSAccount` in the `user` table.

3. **Provision future users automatically** via a new `SaaSAccountProvisionListener` that listens for INBOX creation events. When a new user's INBOX is created, the listener reads the domain defaults and applies them to the new user.

Both fields are `Optional<Boolean>` for backward compatibility — existing messages without these fields are processed exactly as before. When only one field is provided, the other uses the default value from `SaaSAccount.DEFAULT`.

On domain cancellation, the domain-level defaults are cleared (columns set to null).