### PR TITLE
[FIX] TeamMailboxRepositoryImpl: createMailboxReliably should be fully idempotent

### DIFF
--- a/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailboxRepository.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailboxRepository.scala
@@ -30,7 +30,7 @@ import jakarta.inject.Inject
 import org.apache.james.UserEntityValidator
 import org.apache.james.core.{Domain, Username}
 import org.apache.james.mailbox.exception.{MailboxExistsException, MailboxNotFoundException}
-import org.apache.james.mailbox.model.MailboxACL.{EntryKey, NameType, Rfc4314Rights, Right}
+import org.apache.james.mailbox.model.MailboxACL.{EntryKey, NameType, Right}
 import org.apache.james.mailbox.model.search.{MailboxQuery, PrefixedWildcard}
 import org.apache.james.mailbox.model.{MailboxACL, MailboxPath}
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory
@@ -126,12 +126,12 @@ class TeamMailboxRepositoryImpl @Inject()(mailboxManager: MailboxManager,
 
   private def createMailboxReliably(path: MailboxPath, teamMailbox: TeamMailbox, session: MailboxSession) =
     SMono(mailboxManager.createMailboxReactive(path, session))
-      .`then`(SMono(mailboxManager.applyRightsCommandReactive(path, MailboxACL.command.key(EntryKey.createUserEntryKey(teamMailbox.admin, false)).rights(MailboxACL.FULL_RIGHTS).asAddition(), session)))
-      .`then`(SMono(mailboxManager.applyRightsCommandReactive(path, MailboxACL.command.key(EntryKey.createUserEntryKey(teamMailbox.self, false)).rights(MailboxACL.FULL_RIGHTS).asAddition(), session)))
       .onErrorResume {
         case _: MailboxExistsException => SMono.empty
         case e => SMono.error(e)
       }
+      .`then`(SMono(mailboxManager.applyRightsCommandReactive(path, MailboxACL.command.key(EntryKey.createUserEntryKey(teamMailbox.admin, false)).rights(MailboxACL.FULL_RIGHTS).asAddition(), session)))
+      .`then`(SMono(mailboxManager.applyRightsCommandReactive(path, MailboxACL.command.key(EntryKey.createUserEntryKey(teamMailbox.self, false)).rights(MailboxACL.FULL_RIGHTS).asAddition(), session)))
 
   override def deleteTeamMailbox(teamMailbox: TeamMailbox): Publisher[Void] =
     deleteTeamMailboxFoldersReliably(teamMailbox, createSession(teamMailbox))


### PR DESCRIPTION
The `smtpShouldAcceptSubmissionFromExtraSender` test is flaky.

It seems that `createMailboxReliably` is not fully idempotent today.

Because default team mailboxes are created in parallel (`flatMap`), a child path can create the parent first. Then parent `createMailboxReactive` returns `MailboxExistsException`, and the current code skips ACL provisioning for that parent mailbox. That can leave missing admin ACL on the root team mailbox and break `addExtraSender` (team mailbox admin does not have enough ACL to add sender).

Fix: catch `MailboxExistsException` right after `createMailboxReactive`, then still run ACL `applyRightsCommandReactive`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team mailbox creation now reliably applies administrator and user access permissions, even when the initial creation process encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->