### PR TITLE
ISSUE-2159 Webadmin route to manage labels

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -579,6 +579,98 @@ Return codes:
 - `400` the target user is a system user or a team mailbox member
 - `404` the team mailbox does not exist
 
+== JMAP Labels
+
+Labels are user-defined tags that can be attached to JMAP messages. Each label has a display name, an internal keyword (IMAP flag), and optional color and description.
+
+=== List labels of a user
+
+....
+curl -XGET http://ip:port/users/user@domain.tld/labels
+....
+
+Returns the list of labels for the given user:
+
+....
+[
+  {
+    "id": "$label1",
+    "displayName": "Work",
+    "keyword": "$label1",
+    "color": "#ff0000",
+    "description": "Work emails"
+  },
+  ...
+]
+....
+
+The `color` and `description` fields are omitted when not set.
+
+Return codes:
+
+- `200` The label list was successfully retrieved
+- `404` The user does not exist
+
+=== Create a label
+
+....
+curl -XPOST http://ip:port/users/user@domain.tld/labels \
+  -H "Content-Type: application/json" \
+  -d '{"displayName": "Work", "color": "#ff0000", "description": "Work emails"}'
+....
+
+Creates a new label for the user. The `color`, `description`, and `keyword` fields are optional.
+
+If `keyword` is omitted, a random value is generated. If provided, it must be both a valid JMAP keyword (RFC 8621) and a valid JMAP id (alphanumeric and hyphens only — no `$` prefix).
+
+Returns the created label:
+
+....
+{
+  "id": "$label1",
+  "displayName": "Work",
+  "keyword": "$label1",
+  "color": "#ff0000",
+  "description": "Work emails"
+}
+....
+
+Return codes:
+
+- `201` The label was successfully created
+- `400` `displayName` is missing, empty, or the `color` has an invalid format
+- `404` The user does not exist
+
+=== Update a label
+
+....
+curl -XPATCH http://ip:port/users/user@domain.tld/labels/{labelId} \
+  -H "Content-Type: application/json" \
+  -d '{"displayName": "Job", "color": "#abcdef", "description": null}'
+....
+
+Fully replaces `displayName`, `color`, and `description` on a label. All three fields must be
+provided. `color` and `description` accept `null` to clear the field.
+
+Return codes:
+
+- `204` The label was successfully updated
+- `400` `displayName` is missing, null, or empty, or the `color` has an invalid format
+- `404` The user or the label does not exist
+
+=== Delete a label
+
+....
+curl -XDELETE http://ip:port/users/user@domain.tld/labels/{labelId}
+....
+
+Deletes a label.
+
+Return codes:
+
+- `204` The label was successfully deleted (idempotent — also returned if the label did not exist)
+- `404` The user does not exist
+
 == Rate limiting
 
 === Update rate limits of a user

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -139,6 +139,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-jmap-labels</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-webadmin-team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -220,6 +220,7 @@ import com.linagora.tmail.webadmin.TeamMailboxRoutesModule;
 import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
+import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 
@@ -267,6 +268,7 @@ public class DistributedServer {
         new UserQuotaReporterRoutesModule(),
         new TeamMailboxModule(),
         new TeamMailboxRoutesModule(),
+        new LabelRoutesModule(),
         new SieveRoutesModule(),
         new WebAdminServerModule(),
         new WebAdminReIndexingTaskSerializationModule(),

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -103,6 +103,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-jmap-labels</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-webadmin-team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -124,6 +124,7 @@ import com.linagora.tmail.webadmin.TeamMailboxRoutesModule;
 import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
+import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 
@@ -183,6 +184,7 @@ public class MemoryServer {
           WEBADMIN,
           new TeamMailboxModule(),
           new TeamMailboxRoutesModule(),
+          new LabelRoutesModule(),
           new DKIMMailetModule())
         .with(new TeamMailboxModule(),
             new TMailScanningQuotaSearcherModule(),

--- a/tmail-backend/apps/postgres/pom.xml
+++ b/tmail-backend/apps/postgres/pom.xml
@@ -253,6 +253,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-jmap-labels</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-webadmin-team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -201,6 +201,7 @@ import com.linagora.tmail.webadmin.TeamMailboxRoutesModule;
 import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
+import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 
@@ -298,6 +299,7 @@ public class PostgresTmailServer {
         new SieveRoutesModule(),
         new TeamMailboxModule(),
         new TeamMailboxRoutesModule(),
+        new LabelRoutesModule(),
         new UserIdentityModule(),
         new ContactIndexingModule(),
         new WebAdminMailOverWebModule(),

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -96,6 +96,7 @@
         <module>webadmin/webadmin-mailbox</module>
         <module>webadmin/webadmin-oidc-backchannel</module>
         <module>webadmin/webadmin-protocols</module>
+        <module>webadmin/webadmin-jmap-labels</module>
         <module>webadmin/webadmin-team-mailboxes</module>
         <module>webadmin/webadmin-rate-limit</module>
         <module>healthcheck</module>
@@ -304,6 +305,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>tmail-webadmin-mailbox</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>webadmin-jmap-labels</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tmail-backend/webadmin/webadmin-jmap-labels/pom.xml
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~  As a subpart of Twake Mail, this file is edited by Linagora.   ~
+  ~                                                                 ~
+  ~  https://twake-mail.com/                                        ~
+  ~  https://linagora.com                                           ~
+  ~                                                                 ~
+  ~  This file is subject to The Affero Gnu Public License          ~
+  ~  version 3.                                                     ~
+  ~                                                                 ~
+  ~  https://www.gnu.org/licenses/agpl-3.0.en.html                  ~
+  ~                                                                 ~
+  ~  This program is distributed in the hope that it will be        ~
+  ~  useful, but WITHOUT ANY WARRANTY; without even the implied     ~
+  ~  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR        ~
+  ~  PURPOSE. See the GNU Affero General Public License for         ~
+  ~  more details.                                                  ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tmail-backend</artifactId>
+        <groupId>com.linagora.tmail</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webadmin-jmap-labels</artifactId>
+    <name>Twake Mail :: WebAdmin :: JMAP Labels</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/CreateLabelRequest.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/CreateLabelRequest.java
@@ -1,0 +1,132 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import java.util.Optional;
+
+import org.apache.james.jmap.mail.Keyword;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.linagora.tmail.james.jmap.model.Color;
+import com.linagora.tmail.james.jmap.model.DisplayName;
+import com.linagora.tmail.james.jmap.model.Label;
+import com.linagora.tmail.james.jmap.model.LabelCreationRequest;
+import com.linagora.tmail.james.jmap.model.LabelId;
+
+import scala.Option;
+import scala.compat.java8.OptionConverters;
+
+public record CreateLabelRequest(String displayName, String color, Optional<String> description, Optional<String> keyword) {
+    @JsonCreator
+    public CreateLabelRequest(@JsonProperty("displayName") String displayName,
+                              @JsonProperty("color") String color,
+                              @JsonProperty("description") Optional<String> description,
+                              @JsonProperty("keyword") Optional<String> keyword) {
+        this.displayName = displayName;
+        this.color = color;
+        this.description = description;
+        this.keyword = keyword;
+    }
+
+    private DisplayName validateDisplayName() {
+        if (displayName == null || displayName.isBlank()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("'displayName' is required and must not be empty")
+                .haltError();
+        }
+        return new DisplayName(displayName);
+    }
+
+    private Option<Color> toScalaColor() {
+        if (color == null) {
+            return scalaNone();
+        }
+        scala.util.Either<IllegalArgumentException, Color> result = Color.validate(color);
+        if (result.isLeft()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message(result.left().get().getMessage())
+                .haltError();
+        }
+        return scalaSome(result.toOption().get());
+    }
+
+    private Option<String> toScalaDescription() {
+        return OptionConverters.toScala(description);
+    }
+
+    public Optional<String> validatedKeyword() {
+        return keyword
+            .map(value -> {
+                if (!Keyword.of(value).isSuccess()) {
+                    throw ErrorResponder.builder()
+                        .statusCode(HttpStatus.BAD_REQUEST_400)
+                        .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                        .message("Invalid keyword '%s'", value)
+                        .haltError();
+                }
+                return value;
+            });
+    }
+
+    public Label asLabel() {
+        Preconditions.checkState(keyword.isPresent());
+        String validatedKeyword = this.keyword.get();
+
+        return new Label(
+            toLabelId(validatedKeyword),
+            validateDisplayName(),
+            validatedKeyword,
+            toScalaColor(),
+            toScalaDescription());
+    }
+
+    private LabelId toLabelId(String validatedKeyword) {
+        try {
+            return LabelId.fromKeyword(validatedKeyword);
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid keyword '%s': must also be a valid JMAP id (alphanumeric and hyphens only)", validatedKeyword)
+                .haltError();
+        }
+    }
+
+    public LabelCreationRequest toCreationRequest() {
+        return new LabelCreationRequest(validateDisplayName(), toScalaColor(), toScalaDescription());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Option<T> scalaSome(T value) {
+        return OptionConverters.toScala(Optional.of(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Option<T> scalaNone() {
+        return OptionConverters.toScala(Optional.empty());
+    }
+}

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelDTO.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelDTO.java
@@ -1,0 +1,48 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.linagora.tmail.james.jmap.model.Label;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LabelDTO {
+    public final String id;
+    public final String displayName;
+    public final String keyword;
+    public final String color;
+    public final String description;
+
+    public LabelDTO(String id, String displayName, String keyword, String color, String description) {
+        this.id = id;
+        this.displayName = displayName;
+        this.keyword = keyword;
+        this.color = color;
+        this.description = description;
+    }
+
+    public static LabelDTO from(Label label) {
+        return new LabelDTO(
+            label.id().serialize(),
+            label.displayName().value(),
+            label.keyword(),
+            label.color().isDefined() ? label.color().get().value() : null,
+            label.description().isDefined() ? label.description().get() : null);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelRoutes.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelRoutes.java
@@ -1,0 +1,175 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+import static spark.Spark.halt;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.jmap.mail.Keyword;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonExtractException;
+import org.apache.james.webadmin.utils.JsonExtractor;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.linagora.tmail.james.jmap.label.LabelRepository;
+import com.linagora.tmail.james.jmap.model.DescriptionUpdate;
+import com.linagora.tmail.james.jmap.model.Label;
+import com.linagora.tmail.james.jmap.model.LabelId;
+import com.linagora.tmail.james.jmap.model.LabelNotFoundException;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import scala.compat.java8.OptionConverters;
+import spark.Request;
+import spark.Service;
+
+public class LabelRoutes implements Routes {
+    static final String USERS_BASE = SEPARATOR + "users";
+    private static final String USERNAME_PARAM = ":username";
+    private static final String LABEL_ID_PARAM = ":labelId";
+    static final String LABELS_PATH = USERS_BASE + SEPARATOR + USERNAME_PARAM + SEPARATOR + "labels";
+    static final String SPECIFIC_LABEL_PATH = LABELS_PATH + SEPARATOR + LABEL_ID_PARAM;
+
+    private final LabelRepository labelRepository;
+    private final UsersRepository usersRepository;
+    private final JsonTransformer jsonTransformer;
+    private final JsonExtractor<CreateLabelRequest> createExtractor;
+    private final JsonExtractor<UpdateLabelRequest> updateExtractor;
+
+    @Inject
+    public LabelRoutes(LabelRepository labelRepository, UsersRepository usersRepository,
+                       JsonTransformer jsonTransformer) {
+        this.labelRepository = labelRepository;
+        this.usersRepository = usersRepository;
+        this.jsonTransformer = jsonTransformer;
+        this.createExtractor = new JsonExtractor<>(CreateLabelRequest.class);
+        this.updateExtractor = new JsonExtractor<>(UpdateLabelRequest.class);
+    }
+
+    @Override
+    public String getBasePath() {
+        return USERS_BASE;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(LABELS_PATH, (req, res) -> listLabels(req), jsonTransformer);
+        service.post(LABELS_PATH, this::createLabel, jsonTransformer);
+        service.patch(SPECIFIC_LABEL_PATH, (req, res) -> {
+            updateLabel(req);
+            return halt(HttpStatus.NO_CONTENT_204);
+        });
+        service.delete(SPECIFIC_LABEL_PATH, (req, res) -> {
+            deleteLabel(req);
+            return halt(HttpStatus.NO_CONTENT_204);
+        });
+    }
+
+    private Object listLabels(Request request) throws UsersRepositoryException {
+        Username username = extractUsername(request);
+        assertUserExists(username);
+
+        return Flux.from(labelRepository.listLabels(username))
+            .map(LabelDTO::from)
+            .collectList()
+            .block();
+    }
+
+    private Object createLabel(Request request, spark.Response response) throws UsersRepositoryException, JsonExtractException {
+        Username username = extractUsername(request);
+        assertUserExists(username);
+        CreateLabelRequest body = createExtractor.parse(request.body());
+
+        Label created = body.validatedKeyword()
+            .map(keyword -> {
+                Label label = body.asLabel();
+                Mono.from(labelRepository.addLabel(username, label)).block();
+                return label;
+            })
+            .orElseGet(() -> Mono.from(labelRepository.addLabel(username, body.toCreationRequest())).block());
+
+        response.status(HttpStatus.CREATED_201);
+        return LabelDTO.from(created);
+    }
+
+    private void updateLabel(Request request) throws UsersRepositoryException, JsonExtractException {
+        Username username = extractUsername(request);
+        assertUserExists(username);
+        LabelId labelId = extractLabelId(request);
+        UpdateLabelRequest body = updateExtractor.parse(request.body());
+
+        try {
+            Mono.from(labelRepository.updateLabel(
+                    username, labelId,
+                    OptionConverters.toScala(Optional.of(body.displayName())),
+                    OptionConverters.toScala(body.color()),
+                    OptionConverters.toScala(Optional.of(new DescriptionUpdate(OptionConverters.toScala(body.description()))))))
+                .block();
+        } catch (LabelNotFoundException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Label '%s' not found for user '%s'", labelId.serialize(), username.asString())
+                .haltError();
+        }
+    }
+
+    private void deleteLabel(Request request) throws UsersRepositoryException {
+        Username username = extractUsername(request);
+        assertUserExists(username);
+        LabelId labelId = extractLabelId(request);
+
+        Mono.from(labelRepository.deleteLabel(username, labelId)).block();
+    }
+
+    private Username extractUsername(Request request) {
+        return Username.of(request.params(USERNAME_PARAM));
+    }
+
+    private LabelId extractLabelId(Request request) {
+        String rawId = request.params(LABEL_ID_PARAM);
+        if (!Keyword.of(rawId).isSuccess()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid label id '%s'", rawId)
+                .haltError();
+        }
+        return LabelId.fromKeyword(rawId);
+    }
+
+    private void assertUserExists(Username username) throws UsersRepositoryException {
+        if (!usersRepository.contains(username)) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("User '%s' does not exist", username.asString())
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelRoutesModule.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/LabelRoutesModule.java
@@ -1,0 +1,33 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import org.apache.james.webadmin.Routes;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class LabelRoutesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Routes.class)
+            .addBinding()
+            .to(LabelRoutes.class);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/UpdateLabelRequest.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/main/java/com/linagora/tmail/webadmin/label/UpdateLabelRequest.java
@@ -1,0 +1,63 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import java.util.Optional;
+
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.james.jmap.model.Color;
+import com.linagora.tmail.james.jmap.model.DisplayName;
+
+public record UpdateLabelRequest(DisplayName displayName, Optional<Color> color, Optional<String> description) {
+
+    @JsonCreator
+    public UpdateLabelRequest(
+        @JsonProperty("displayName") String displayName,
+        @JsonProperty("color") Optional<String> color,
+        @JsonProperty("description") Optional<String> description) {
+        this(validateDisplayName(displayName), color.map(UpdateLabelRequest::asColor), description);
+    }
+
+    private static DisplayName validateDisplayName(String value) {
+        if (value == null || value.isBlank()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("'displayName' is required and must not be empty")
+                .haltError();
+        }
+        return new DisplayName(value);
+    }
+
+    private static Color asColor(String value) {
+        scala.util.Either<IllegalArgumentException, Color> result = Color.validate(value);
+        if (result.isLeft()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message(result.left().get().getMessage())
+                .haltError();
+        }
+        return result.toOption().get();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-jmap-labels/src/test/java/com/linagora/tmail/webadmin/label/LabelRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-jmap-labels/src/test/java/com/linagora/tmail/webadmin/label/LabelRoutesTest.java
@@ -1,0 +1,478 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.label;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
+import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
+import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
+import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.james.jmap.label.LabelRepository;
+import com.linagora.tmail.james.jmap.label.MemoryLabelRepository;
+import com.linagora.tmail.james.jmap.model.Color;
+import com.linagora.tmail.james.jmap.model.DisplayName;
+import com.linagora.tmail.james.jmap.model.Label;
+import com.linagora.tmail.james.jmap.model.LabelCreationRequest;
+
+import io.restassured.RestAssured;
+import reactor.core.publisher.Mono;
+import scala.Option;
+import scala.Option$;
+import scala.compat.java8.OptionConverters;
+
+class LabelRoutesTest {
+    private static final Username BOB = Username.of("bob@linagora.com");
+    private static final String BOB_LABELS_PATH = "/users/bob@linagora.com/labels";
+
+    private WebAdminServer webAdminServer;
+    private LabelRepository labelRepository;
+    private UsersRepository usersRepository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        labelRepository = new MemoryLabelRepository();
+        usersRepository = mock(UsersRepository.class);
+        when(usersRepository.contains(BOB)).thenReturn(true);
+
+        LabelRoutes routes = new LabelRoutes(labelRepository, usersRepository, new JsonTransformer());
+        webAdminServer = WebAdminUtils.createWebAdminServer(routes).start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Option<Color> noColor() {
+        return OptionConverters.toScala(Optional.empty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Option<String> noDescription() {
+        return OptionConverters.toScala(Optional.empty());
+    }
+
+    @Nested
+    class GetLabels {
+        @Test
+        void getLabelsReturnsEmptyListWhenNone() {
+            when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .contentType(JSON)
+                .body(".", hasSize(0));
+        }
+
+        @Test
+        void getLabelsReturnsExistingLabels() {
+            LabelCreationRequest req1 = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            LabelCreationRequest req2 = new LabelCreationRequest(
+                new DisplayName("Personal"), noColor(), noDescription());
+            Mono.from(labelRepository.addLabel(BOB, req1)).block();
+            Mono.from(labelRepository.addLabel(BOB, req2)).block();
+
+            String response = when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .contentType(JSON)
+                .body(".", hasSize(2))
+                .extract().body().asString();
+
+            assertThatJson(response).isArray()
+                .anySatisfy(node -> assertThatJson(node).node("displayName").isEqualTo("\"Work\""))
+                .anySatisfy(node -> assertThatJson(node).node("displayName").isEqualTo("\"Personal\""));
+        }
+
+        @Test
+        void getLabelsReturnsAllFieldsWhenSet() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Urgent"),
+                Option$.MODULE$.apply(Color.validate("#ff0000").toOption().get()),
+                Option$.MODULE$.apply("Very important emails"));
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            String response = when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .contentType(JSON)
+                .body(".", hasSize(1))
+                .extract().body().asString();
+
+            assertThatJson(response).isArray().first()
+                .satisfies(node -> {
+                    assertThatJson(node).node("id").isNotNull();
+                    assertThatJson(node).node("displayName").isEqualTo("\"Urgent\"");
+                    assertThatJson(node).node("keyword").isNotNull();
+                    assertThatJson(node).node("color").isEqualTo("\"#ff0000\"");
+                    assertThatJson(node).node("description").isEqualTo("\"Very important emails\"");
+                });
+        }
+
+        @Test
+        void getLabelsReturns404WhenUserDoesNotExist() throws Exception {
+            when(usersRepository.contains(Username.of("unknown@linagora.com"))).thenReturn(false);
+
+            when()
+                .get("/users/unknown@linagora.com/labels")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+    }
+
+    @Nested
+    class CreateLabel {
+        @Test
+        void createLabelReturns201WithCreatedLabel() {
+            String response = given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(CREATED_201)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(response)
+                .node("id").isNotNull();
+            assertThatJson(response)
+                .node("displayName").isEqualTo("\"Work\"");
+            assertThatJson(response)
+                .node("keyword").isNotNull();
+        }
+
+        @Test
+        void createLabelWithAllFields() {
+            String response = given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"color\": \"#ff0000\", \"description\": \"work emails\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(CREATED_201)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(response).node("displayName").isEqualTo("\"Work\"");
+            assertThatJson(response).node("color").isEqualTo("\"#ff0000\"");
+            assertThatJson(response).node("description").isEqualTo("\"work emails\"");
+        }
+
+        @Test
+        void createLabelReturns400WhenDisplayNameMissing() {
+            given()
+                .contentType(JSON)
+                .body("{\"color\": \"#ff0000\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void createLabelReturns400WhenDisplayNameEmpty() {
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void createLabelReturns400WhenColorInvalid() {
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"color\": \"notacolor\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void createLabelReturns404WhenUserDoesNotExist() throws Exception {
+            when(usersRepository.contains(Username.of("unknown@linagora.com"))).thenReturn(false);
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\"}")
+            .when()
+                .post("/users/unknown@linagora.com/labels")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void createLabelWithExplicitKeyword() {
+            String response = given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"keyword\": \"label42\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(CREATED_201)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(response).node("keyword").isEqualTo("\"label42\"");
+            assertThatJson(response).node("id").isEqualTo("\"label42\"");
+        }
+
+        @Test
+        void createLabelReturns400WhenKeywordStartsWithDollar() {
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"keyword\": \"$label42\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void createLabelWithoutKeywordGeneratesRandom() {
+            String response = given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(CREATED_201)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(response).node("keyword").isNotNull();
+        }
+
+        @Test
+        void createLabelReturns400WhenKeywordInvalid() {
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"keyword\": \"invalid keyword!\"}")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void createLabelReturns400OnEmptyBody() {
+            given()
+                .contentType(JSON)
+                .body("")
+            .when()
+                .post(BOB_LABELS_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+    }
+
+    @Nested
+    class UpdateLabel {
+        @Test
+        void updateLabelReturns204OnSuccess() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Job\"}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/" + created.id().serialize())
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void updateLabelPersistsDisplayNameChange() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Job\"}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/" + created.id().serialize());
+
+            String response = when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .extract().body().asString();
+
+            assertThatJson(response).isArray().first()
+                .satisfies(node -> assertThatJson(node).node("displayName").isEqualTo("\"Job\""));
+        }
+
+        @Test
+        void updateLabelCanSetColor() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"color\": \"#abcdef\"}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/" + created.id().serialize());
+
+            String response = when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .extract().body().asString();
+
+            assertThatJson(response).isArray().first()
+                .satisfies(node -> assertThatJson(node).node("color").isEqualTo("\"#abcdef\""));
+        }
+
+        @Test
+        void updateLabelReturns400WhenDisplayNameNull() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": null}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/" + created.id().serialize())
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void updateLabelReturns400WhenColorInvalid() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Work\", \"color\": \"notacolor\"}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/" + created.id().serialize())
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void updateLabelReturns404WhenLabelDoesNotExist() {
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Job\"}")
+            .when()
+                .patch(BOB_LABELS_PATH + "/nonexistent-label-id")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void updateLabelReturns404WhenUserDoesNotExist() throws Exception {
+            when(usersRepository.contains(Username.of("unknown@linagora.com"))).thenReturn(false);
+
+            given()
+                .contentType(JSON)
+                .body("{\"displayName\": \"Job\"}")
+            .when()
+                .patch("/users/unknown@linagora.com/labels/someid")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+    }
+
+    @Nested
+    class DeleteLabel {
+        @Test
+        void deleteLabelReturns204OnSuccess() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            when()
+                .delete(BOB_LABELS_PATH + "/" + created.id().serialize())
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteLabelActuallyRemovesIt() {
+            LabelCreationRequest req = new LabelCreationRequest(
+                new DisplayName("Work"), noColor(), noDescription());
+            Label created = Mono.from(labelRepository.addLabel(BOB, req)).block();
+
+            when().delete(BOB_LABELS_PATH + "/" + created.id().serialize());
+
+            when()
+                .get(BOB_LABELS_PATH)
+            .then()
+                .statusCode(OK_200)
+                .body(".", hasSize(0));
+        }
+
+        @Test
+        void deleteLabelReturns204WhenLabelDoesNotExist() {
+            when()
+                .delete(BOB_LABELS_PATH + "/nonexistentlabelid")
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteLabelReturns404WhenUserDoesNotExist() throws Exception {
+            when(usersRepository.contains(Username.of("unknown@linagora.com"))).thenReturn(false);
+
+            when()
+                .delete("/users/unknown@linagora.com/labels/someid")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webadmin API endpoints to create, list, update, and delete user labels with support for display name, color, description, and keyword.

* **Documentation**
  * Added detailed documentation for the JMAP label endpoints including examples, payloads, and status codes.

* **Tests**
  * Added end-to-end API tests covering label lifecycle, validation, error cases, and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->