### PR TITLE
ISSUE-2211 KeywordEmailQueryViewListener: should not call mailbox APIs if not concern keywords

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/KeywordEmailQueryViewListener.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/KeywordEmailQueryViewListener.java
@@ -128,6 +128,10 @@ public class KeywordEmailQueryViewListener implements ReactiveGroupEventListener
     }
 
     private Mono<Void> handleAdded(Added added) {
+        if (!hasConcernedKeywords(added)) {
+            return Mono.empty();
+        }
+
         return Mono.when(deleteKeywordViewIfNeeded(added), addKeywordView(added))
             .then();
     }
@@ -165,6 +169,10 @@ public class KeywordEmailQueryViewListener implements ReactiveGroupEventListener
     }
 
     private Mono<Void> handleFlagsUpdated(FlagsUpdated flagsUpdated) {
+        if (!hasConcernedKeywordChanges(flagsUpdated)) {
+            return Mono.empty();
+        }
+
         Username mailboxOwner = flagsUpdated.getMailboxPath().getUser();
         MailboxSession ownerSession = mailboxManager.createSystemSession(mailboxOwner);
 
@@ -353,6 +361,24 @@ public class KeywordEmailQueryViewListener implements ReactiveGroupEventListener
     private Mono<Boolean> hasReadRightReactive(Username owner, MailboxACL acl, Username username) {
         return Mono.fromCallable(() -> mailboxACLResolver.resolveRights(username, acl, owner).contains(MailboxACL.Right.Read))
             .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER);
+    }
+
+    private boolean hasConcernedKeywords(Added added) {
+        return added.getAdded().values()
+            .stream()
+            .map(MessageMetaData::getFlags)
+            .map(this::concernedKeywords)
+            .anyMatch(keywords -> !keywords.isEmpty());
+    }
+
+    private boolean hasConcernedKeywordChanges(FlagsUpdated flagsUpdated) {
+        return flagsUpdated.getUpdatedFlags()
+            .stream()
+            .anyMatch(this::hasConcernedKeywordChanges);
+    }
+
+    private boolean hasConcernedKeywordChanges(UpdatedFlags updatedFlags) {
+        return !concernedKeywords(updatedFlags.getOldFlags()).equals(concernedKeywords(updatedFlags.getNewFlags()));
     }
 
     private Set<Keyword> concernedKeywords(Flags flags) {


### PR DESCRIPTION
Before, it calls mailbox APIs to get the mailbox first, even if the event does not contain concern keywords.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized event processing to skip unnecessary updates when no relevant keywords are affected, improving system performance and reducing redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->