### PR TITLE
ISSUE-2176 TMailWithMailingListValidRcptHandler should also handle su…

### DIFF
--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
@@ -90,7 +90,8 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
     }
 
     private boolean isATeamMailbox(MailAddress recipient) {
-        return TeamMailbox.asTeamMailbox(recipient)
+        MailAddress strippedRecipient = recipient.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        return TeamMailbox.asTeamMailbox(strippedRecipient)
             .map(tm -> Mono.from(teamMailboxRepository.exists(tm)).block())
             .getOrElse(() -> false);
     }

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
@@ -92,7 +92,8 @@ class TMailValidRcptHandlerTest {
         "bob-alias@linagora.com",
         "group@linagora.com",
         "address-alias@linagora.com",
-        "sales@linagora.com"
+        "sales@linagora.com",
+        "sales+detail@linagora.com"
     })
     void shouldHandeLocalResources(String address) throws Exception {
         assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
@@ -126,6 +126,7 @@ class TMailWithMailingListValidRcptHandlerTest {
         "group@linagora.com",
         "address-alias@linagora.com",
         "sales@linagora.com",
+        "sales+detail@linagora.com",
         "mygroup@lists.james.org"
     })
     void shouldHandeLocalResources(String address) throws Exception {


### PR DESCRIPTION
…badressing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email validation to properly handle addresses with detail suffixes (e.g., user+detail@domain.com). The validation now correctly normalizes these addresses before checking mailbox existence, ensuring accurate recipient validation in SMTP processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->