### PR TITLE
ISSUE-2176 Team Mailbox identity should not have sort order 0

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListener.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListener.java
@@ -82,6 +82,7 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
     private static final IdentityProvisionerListenerGroup GROUP = new IdentityProvisionerListenerGroup();
     private static final Logger LOGGER = LoggerFactory.getLogger(IdentityProvisionListener.class);
     private static final int DEFAULT_IDENTITY_SORT_ORDER = 0;
+    private static final int TEAM_MAILBOX_IDENTITY_SORT_ORDER = 10;
     private static final String APPLY_WHEN_PATH = "defaultText.applyWhen";
 
     private final LDAPConnectionPool ldapConnectionPool;
@@ -269,7 +270,7 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
             .filter(Identity::mayDelete)
             .hasElements()
             .filter(FunctionalUtils.identityPredicate().negate())
-            .flatMap(noIdentity -> Mono.from(identityRepository.save(user, asIdentityRequest(teamMailboxAddress, identityName)))
+            .flatMap(noIdentity -> Mono.from(identityRepository.save(user, asTeamMailboxIdentityRequest(teamMailboxAddress, identityName)))
                 .doOnSuccess(identity -> LOGGER.info("Created team mailbox identity for user {} with email {}", user.asString(), teamMailboxAddress.asString())))
             .then();
     }
@@ -332,6 +333,17 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
             Optional.empty(),
             Optional.empty(),
             Optional.of(DEFAULT_IDENTITY_SORT_ORDER),
+            Optional.empty(),
+            Optional.empty());
+    }
+
+    private IdentityCreationRequest asTeamMailboxIdentityRequest(MailAddress mailAddress, String identityDisplayName) {
+        return IdentityCreationRequest.fromJava(
+            mailAddress,
+            Optional.of(identityDisplayName),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(TEAM_MAILBOX_IDENTITY_SORT_ORDER),
             Optional.empty(),
             Optional.empty());
     }

--- a/tmail-backend/jmap/extensions/src/test/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListenerTest.java
+++ b/tmail-backend/jmap/extensions/src/test/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListenerTest.java
@@ -320,6 +320,7 @@ public class IdentityProvisionListenerTest {
             softly.assertThat(identities).hasSize(1);
             softly.assertThat(identities.getFirst().name()).isEqualTo("marketing");
             softly.assertThat(identities.getFirst().email()).isEqualTo(teamMailbox.asMailAddress());
+            softly.assertThat(identities.getFirst().sortOrder()).isEqualTo(10);
             softly.assertThat(identities.getFirst().mayDelete()).isEqualTo(true);
         });
     }
@@ -345,6 +346,7 @@ public class IdentityProvisionListenerTest {
             softly.assertThat(identities).hasSize(1);
             softly.assertThat(identities.getFirst().name()).isEqualTo("marketing");
             softly.assertThat(identities.getFirst().email()).isEqualTo(teamMailbox.asMailAddress());
+            softly.assertThat(identities.getFirst().sortOrder()).isEqualTo(10);
             softly.assertThat(identities.getFirst().mayDelete()).isEqualTo(true);
         });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team mailbox identities are now provisioned with an improved sort order value, allowing for better organization and consistent presentation within the identity management system when managing team mailboxes.

* **Tests**
  * Enhanced test coverage to validate the correct sort order assignment for team mailbox identities during provisioning when members are added or extra senders are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->