### PR TITLE
[FIX] Do not collect subadressing variations

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavUtils.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.user.api.UsersRepository;
 
 import com.google.common.hash.Hashing;
 import com.linagora.tmail.dav.request.CardDavCreationObjectRequest;
@@ -34,8 +35,9 @@ public class CardDavUtils {
     private static final EmailType DEFAULT_EMAIL_TYPE = EmailType.WORK;
 
     public static CardDavCreationObjectRequest createObjectCreationRequest(Optional<String> maybeFullName, MailAddress email) {
-        CardDavCreationObjectRequest.Email emailObject = new CardDavCreationObjectRequest.Email(List.of(DEFAULT_EMAIL_TYPE), email);
-        return new CardDavCreationObjectRequest(VERSION, createContactUid(email), maybeFullName, Optional.empty(), emailObject);
+        MailAddress normalizedEmail = email.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        CardDavCreationObjectRequest.Email emailObject = new CardDavCreationObjectRequest.Email(List.of(DEFAULT_EMAIL_TYPE), normalizedEmail);
+        return new CardDavCreationObjectRequest(VERSION, createContactUid(normalizedEmail), maybeFullName, Optional.empty(), emailObject);
     }
 
     public static CardDavCreationObjectRequest createObjectCreationRequest(MailAddress email) {

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/CardDavUtilsTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/CardDavUtilsTest.java
@@ -1,0 +1,71 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.dav;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.core.MailAddress;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.dav.request.CardDavCreationObjectRequest;
+
+public class CardDavUtilsTest {
+
+    @Test
+    void createObjectCreationRequestShouldNormalizeSubAddressedRecipient() throws Exception {
+        MailAddress subAddressed = new MailAddress("bob+folder@domain.tld");
+        MailAddress plain = new MailAddress("bob@domain.tld");
+
+        CardDavCreationObjectRequest requestFromSubAddressed = CardDavUtils.createObjectCreationRequest(subAddressed);
+        CardDavCreationObjectRequest requestFromPlain = CardDavUtils.createObjectCreationRequest(plain);
+
+        assertThat(requestFromSubAddressed.uid()).isEqualTo(requestFromPlain.uid());
+    }
+
+    @Test
+    void createObjectCreationRequestShouldStoreNormalizedEmailAddress() throws Exception {
+        MailAddress subAddressed = new MailAddress("bob+folder@domain.tld");
+
+        CardDavCreationObjectRequest request = CardDavUtils.createObjectCreationRequest(subAddressed);
+
+        assertThat(request.email().value().asString()).isEqualTo("bob@domain.tld");
+    }
+
+    @Test
+    void createObjectCreationRequestWithFullNameShouldNormalizeSubAddressedRecipient() throws Exception {
+        MailAddress subAddressed = new MailAddress("bob+project@domain.tld");
+        MailAddress plain = new MailAddress("bob@domain.tld");
+
+        CardDavCreationObjectRequest requestFromSubAddressed = CardDavUtils.createObjectCreationRequest(Optional.of("Bob"), subAddressed);
+        CardDavCreationObjectRequest requestFromPlain = CardDavUtils.createObjectCreationRequest(Optional.of("Bob"), plain);
+
+        assertThat(requestFromSubAddressed.uid()).isEqualTo(requestFromPlain.uid());
+    }
+
+    @Test
+    void createObjectCreationRequestShouldNotAlterPlainAddress() throws Exception {
+        MailAddress plain = new MailAddress("bob@domain.tld");
+
+        CardDavCreationObjectRequest request = CardDavUtils.createObjectCreationRequest(plain);
+
+        assertThat(request.email().value().asString()).isEqualTo("bob@domain.tld");
+    }
+}


### PR DESCRIPTION
<img width="443" height="484" alt="image" src="https://github.com/user-attachments/assets/3bc6382b-de0d-4c7e-a26f-3a3ff9191355" />

OUPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email addresses with sub-addressing (e.g., user+tag@domain.tld) are now normalized to base addresses during contact creation, ensuring consistent contact identification and deduplication.

* **Tests**
  * Added comprehensive test coverage for email address normalization across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->