### PR TITLE
ISSUE-2285 CalendarEventCounter/accept should be idempotent

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/CalendarEventCounterAcceptMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/CalendarEventCounterAcceptMethodContract.scala
@@ -128,6 +128,77 @@ trait CalendarEventCounterAcceptMethodContract {
   }
 
   @Test
+  def shouldBeIdempotent(server: GuiceJamesServer): Unit = {
+    // Given: An original calendar event created and pushed to the server
+    val eventUid: String = UUID.randomUUID().toString
+    val originalStartDate: ZonedDateTime = ZonedDateTime.parse("2025-03-14T14:00:00Z")
+    val originalEndDate: ZonedDateTime = originalStartDate.plusHours(2)
+    val (_, originalCalendar: CalendarEventHelper) = createAndPushOriginalCalendarEvent(server, eventUid, originalStartDate, originalEndDate)
+
+    // And: A counter event proposing a new schedule
+    val counterEvent: Calendar = originalCalendar.generateCounterEvent(originalStartDate.minusDays(1), originalEndDate.minusDays(1))
+    val counterEventBlobId: String = createNewEmailWithCalendarAttachment(server, eventUid, counterEvent)
+
+    `given`
+      .body(
+        s"""{
+           |  "using": [
+           |    "urn:ietf:params:jmap:core",
+           |    "com:linagora:params:calendar:event"],
+           |  "methodCalls": [[
+           |    "CalendarEventCounter/accept",
+           |    {
+           |      "accountId": "$bobAccountId",
+           |      "blobIds": [ "$counterEventBlobId" ]
+           |    },
+           |    "c1"]]
+           |}""".stripMargin)
+      .when
+      .post
+      .`then`
+      .statusCode(SC_OK)
+
+    // When: The counter event is accepted
+    val response: String =
+      `given`
+        .body(
+          s"""{
+             |  "using": [
+             |    "urn:ietf:params:jmap:core",
+             |    "com:linagora:params:calendar:event"],
+             |  "methodCalls": [[
+             |    "CalendarEventCounter/accept",
+             |    {
+             |      "accountId": "$bobAccountId",
+             |      "blobIds": [ "$counterEventBlobId" ]
+             |    },
+             |    "c1"]]
+             |}""".stripMargin)
+      .when
+        .post
+      .`then`
+        .statusCode(SC_OK)
+        .contentType(JSON)
+        .extract
+        .body
+        .asString
+
+    // Then: The response should indicate the event was successfully accepted
+    assertThatJson(response)
+      .withOptions(IGNORING_ARRAY_ORDER)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |  "CalendarEventCounter/accept",
+           |  {
+           |    "accountId": "$bobAccountId",
+           |    "accepted": [ "$counterEventBlobId" ]
+           |  },
+           |  "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
   def shouldUpdateCalendarOnDavServerWhenAccepted(server: GuiceJamesServer): Unit = {
     // Given: An original calendar event created and pushed to the server
     val eventUid: String = UUID.randomUUID().toString

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventCounterPerformer.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CalendarEventCounterPerformer.scala
@@ -18,7 +18,7 @@
 
 package com.linagora.tmail.james.jmap.method
 
-import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.ImplicitCalendar
+import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.{ImplicitCalendar, NoUpdateRequiredException}
 import com.linagora.tmail.james.jmap.calendar._
 import com.linagora.tmail.james.jmap.model._
 import com.linagora.tmail.james.jmap.{CalendarEventNotFoundException, CalendarEventRepository}
@@ -92,6 +92,7 @@ class CalendarEventCounterPerformer @Inject()(calendarEventRepository: CalendarE
       .switchIfEmpty(SMono.just(EventCounterAcceptedResults.notFound(blobId)))
       .onErrorResume({
         case _: BlobNotFoundException => SMono.just(EventCounterAcceptedResults.notFound(blobId))
+        case _: NoUpdateRequiredException => SMono.just(EventCounterAcceptedResults.done(blobId))
         case error => SMono.just(EventCounterAcceptedResults.notDone(blobId, error, mailboxSession.getUser.asString()))
       })
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for calendar event counter acceptance to validate idempotent behavior with consistent responses across repeated requests.

* **Bug Fixes**
  * Enhanced error handling in calendar event counter acceptance to properly treat specific exception scenarios as successful operation completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->