### PR TITLE
Update James SHA-1

### DIFF
--- a/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializer.java
+++ b/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializer.java
@@ -27,8 +27,10 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import org.apache.james.core.Username;
+import org.apache.james.events.DeserializationResult;
 import org.apache.james.events.Event;
 import org.apache.james.events.EventSerializer;
+import org.apache.james.events.SerializationResult;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,9 +49,9 @@ public class DisconnectionRequestedEventSerializer implements EventSerializer {
     }
 
     @Override
-    public String toJson(Event event) {
+    public SerializationResult toJson(Event event) {
         if (!(event instanceof DisconnectionRequested disconnectionRequested)) {
-            throw new IllegalArgumentException("Unsupported event: " + event);
+            return new SerializationResult.Failure("Unsupported event: " + event);
         }
 
         DisconnectionRequestedDTO dto = new DisconnectionRequestedDTO(
@@ -57,36 +59,36 @@ public class DisconnectionRequestedEventSerializer implements EventSerializer {
             disconnectionRequested.usernames().stream().map(Username::asString).toList());
 
         try {
-            return objectMapper.writeValueAsString(dto);
+            return new SerializationResult.Success(objectMapper.writeValueAsString(dto));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return new SerializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public String toJson(Collection<Event> event) {
+    public SerializationResult toJson(Collection<Event> event) {
         if (event.size() != 1) {
-            throw new IllegalArgumentException("Not supported for multiple events, please serialize separately");
+            return new SerializationResult.Failure("Not supported for multiple events, please serialize separately");
         }
         return toJson(event.iterator().next());
     }
 
     @Override
-    public Event asEvent(String serialized) {
+    public DeserializationResult asEvent(String serialized) {
         try {
             DisconnectionRequestedDTO dto = objectMapper.readValue(serialized, DisconnectionRequestedDTO.class);
             List<String> usernamesAsString = dto.usernames() == null ? ImmutableList.of() : dto.usernames();
             Set<Username> usernames = usernamesAsString.stream()
                 .map(Username::of)
                 .collect(Collectors.toSet());
-            return new DisconnectionRequested(Event.EventId.of(dto.eventId()), usernames);
+            return new DeserializationResult.Success(new DisconnectionRequested(Event.EventId.of(dto.eventId()), usernames));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return new DeserializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public List<Event> asEvents(String serialized) {
-        return List.of(asEvent(serialized));
+    public DeserializationResult asEvents(String serialized) {
+        return asEvent(serialized);
     }
 }

--- a/tmail-backend/data/data-extra-api/src/test/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializerTest.java
+++ b/tmail-backend/data/data-extra-api/src/test/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializerTest.java
@@ -34,7 +34,8 @@ class DisconnectionRequestedEventSerializerTest {
         Set<Username> usernames = Set.of(Username.of("bob@domain.tld"), Username.of("alice@domain.tld"));
         DisconnectionRequested event = new DisconnectionRequested(Event.EventId.random(), usernames);
 
-        Event deserialized = testee.asEvent(testee.toJson(event));
+        Event deserialized = testee.asEvent(testee.toJson(event).json())
+            .event();
 
         DisconnectionRequested deserializedDisconnectionRequested = (DisconnectionRequested) deserialized;
         assertThat(deserializedDisconnectionRequested.getEventId()).isEqualTo(event.getEventId());
@@ -46,7 +47,8 @@ class DisconnectionRequestedEventSerializerTest {
     void roundTripShouldPreserveEmptyUsernamesToRepresentAllUsers() {
         DisconnectionRequested event = new DisconnectionRequested(Event.EventId.random(), Set.of());
 
-        Event deserialized = testee.asEvent(testee.toJson(event));
+        Event deserialized = testee.asEvent(testee.toJson(event).json())
+            .event();
 
         DisconnectionRequested deserializedDisconnectionRequested = (DisconnectionRequested) deserialized;
         assertThat(deserializedDisconnectionRequested.usernames()).isEmpty();
@@ -64,7 +66,7 @@ class DisconnectionRequestedEventSerializerTest {
             }
             """.formatted(eventId.getId());
 
-        Event deserialized = testee.asEvent(json);
+        Event deserialized = testee.asEvent(json).event();
 
         DisconnectionRequested deserializedDisconnectionRequested = (DisconnectionRequested) deserialized;
         assertThat(deserializedDisconnectionRequested.usernames()).isEmpty();

--- a/tmail-backend/data/data-extra-api/src/test/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializerTest.java
+++ b/tmail-backend/data/data-extra-api/src/test/java/com/linagora/tmail/disconnector/DisconnectionRequestedEventSerializerTest.java
@@ -78,7 +78,7 @@ class DisconnectionRequestedEventSerializerTest {
         Event.EventId eventId = Event.EventId.random();
         DisconnectionRequested event = new DisconnectionRequested(eventId, Set.of());
 
-        assertThat(testee.toJson(event)).isEqualTo("""
+        assertThat(testee.toJson(event).json()).isEqualTo("""
             {"eventId":"%s","usernames":[]}""".formatted(eventId.getId()));
     }
 }

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/DefaultTmailGroupRegistrationHandler.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/DefaultTmailGroupRegistrationHandler.java
@@ -216,7 +216,7 @@ class DefaultTmailGroupRegistrationHandler implements TmailGroupRegistrationHand
     }
 
     private Mono<List<Event>> deserializeEvents(byte[] eventAsBytes) {
-        return Mono.fromCallable(() -> eventSerializer.asEventsFromBytes(eventAsBytes));
+        return Mono.fromCallable(() -> eventSerializer.asEventsFromBytes(eventAsBytes).events());
     }
 
     private GroupRegistration newGroupRegistration(EventListener.ReactiveEventListener listener, Group group) {

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
@@ -74,7 +74,7 @@ public class RedisKeyEventDispatcher {
     }
 
     private Mono<Void> dispatchToRemoteListeners(Event event, Set<RegistrationKey> keys) {
-        return Mono.fromCallable(() -> eventSerializer.toJson(event))
+        return Mono.fromCallable(() -> eventSerializer.toJson(event).json())
             .flatMap(serializedJson -> remoteKeysDispatch(serializedJson, keys))
             .then();
     }
@@ -88,7 +88,7 @@ public class RedisKeyEventDispatcher {
             .flatMap(e -> e.keys().stream())
             .collect(ImmutableSet.toImmutableSet());
 
-        return Mono.fromCallable(() -> eventSerializer.toJson(underlyingEvents))
+        return Mono.fromCallable(() -> eventSerializer.toJson(underlyingEvents).json())
             .flatMap(serializedJson -> remoteKeysDispatch(serializedJson, keys))
             .then();
     }

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyRegistrationHandler.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyRegistrationHandler.java
@@ -202,13 +202,14 @@ public class RedisKeyRegistrationHandler {
     public List<Event> toEvents(String eventAsJson) {
         // if the json is an array, we have multiple events
         if (StringUtils.trim(eventAsJson).startsWith("[")) {
-            return eventSerializer.asEvents(eventAsJson);
+            return eventSerializer.asEvents(eventAsJson)
+                .events();
         }
 
         try {
-            return List.of(eventSerializer.asEvent(eventAsJson));
+            return eventSerializer.asEvent(eventAsJson).events();
         } catch (RuntimeException exception) {
-            return eventSerializer.asEvents(eventAsJson);
+            return eventSerializer.asEvents(eventAsJson).events();
         }
     }
 

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/TMailEventDispatcher.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/TMailEventDispatcher.java
@@ -20,7 +20,6 @@ package org.apache.james.events;
 
 import static org.apache.james.events.GroupRegistration.DEFAULT_RETRY_COUNT;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -105,16 +104,16 @@ public class TMailEventDispatcher {
 
         return Mono.fromCallable(() -> eventSerializer.toJson(underlyingEvents))
             .flatMap(serializedEvent -> Mono.zipDelayError(
-                remoteGroupsDispatch(serializedEvent.getBytes(StandardCharsets.UTF_8), underlyingEvents),
-                keyEventDispatcher.remoteKeysDispatch(serializedEvent, keys)))
+                remoteGroupsDispatch(serializedEvent.jsonBytes(), underlyingEvents),
+                keyEventDispatcher.remoteKeysDispatch(serializedEvent.json(), keys)))
             .then();
     }
 
     private Mono<Void> dispatchToRemoteListeners(Event event, Set<RegistrationKey> keys) {
         return Mono.fromCallable(() -> eventSerializer.toJson(event))
             .flatMap(serializedEvent -> Mono.zipDelayError(
-                remoteGroupsDispatch(serializedEvent.getBytes(StandardCharsets.UTF_8), event),
-                keyEventDispatcher.remoteKeysDispatch(serializedEvent, keys)))
+                remoteGroupsDispatch(serializedEvent.jsonBytes(), event),
+                keyEventDispatcher.remoteKeysDispatch(serializedEvent.json(), keys)))
             .then();
     }
 

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusContractTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusContractTest.java
@@ -479,7 +479,7 @@ abstract class RabbitMQAndRedisEventBusContractTest implements GroupContract.Sin
                     .blockFirst()
                     .getBody();
 
-                return eventSerializer.asEvent(new String(eventInBytes, StandardCharsets.UTF_8));
+                return eventSerializer.asEvent(new String(eventInBytes, StandardCharsets.UTF_8)).event();
             }
         }
     }

--- a/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/event/TmailEventSerializer.java
+++ b/tmail-backend/guice/distributed/src/main/java/com/linagora/tmail/event/TmailEventSerializer.java
@@ -19,7 +19,7 @@
 package com.linagora.tmail.event;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 import jakarta.mail.internet.AddressException;
@@ -28,14 +28,16 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
+import org.apache.james.events.DeserializationResult;
 import org.apache.james.events.Event;
 import org.apache.james.events.EventSerializer;
+import org.apache.james.events.SerializationResult;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
+import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.blob.secondaryblobstore.FailedBlobEvents;
 import com.linagora.tmail.blob.secondaryblobstore.ObjectStorageIdentity;
 import com.linagora.tmail.james.jmap.contact.ContactFields;
@@ -97,38 +99,39 @@ public class TmailEventSerializer implements EventSerializer {
     }
 
     @Override
-    public String toJson(Event event) {
+    public SerializationResult toJson(Event event) {
+
         try {
-            EventDTO eventDTO = toDTO(event);
-            return objectMapper.writeValueAsString(eventDTO);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            Optional<String> maybeEventDTO = toDTO(event)
+                .map(Throwing.function(objectMapper::writeValueAsString).sneakyThrow());
+            return SerializationResult.of(maybeEventDTO, "Unexpected value: " + event);
+        } catch (Exception e) {
+            return new SerializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public String toJson(Collection<Event> event) {
+    public SerializationResult toJson(Collection<Event> event) {
         if (event.size() != 1) {
-            throw new IllegalArgumentException("Not supported for multiple events, please serialize separately");
+            return new SerializationResult.Failure("Not supported for multiple events, please serialize separately");
         }
         return toJson(event.iterator().next());
     }
 
     @Override
-    public Event asEvent(String serialized) {
+    public DeserializationResult asEvent(String serialized) {
         try {
             EventDTO eventDTO = objectMapper.readValue(serialized, EventDTO.class);
-            return fromDTO(eventDTO);
+            return DeserializationResult.of(fromDTO(eventDTO), "Unexpected value: " + eventDTO);
         } catch (JsonProcessingException | AddressException e) {
-            throw new RuntimeException(e);
+            return new DeserializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public List<Event> asEvents(String serialized) {
-        return ImmutableList.of(asEvent(serialized));
+    public DeserializationResult asEvents(String serialized) {
+        return asEvent(serialized);
     }
-
 
     private Label dtoToLabel(String keyword, String displayName, String color, String description, Boolean readOnly) {
         return new Label(
@@ -140,8 +143,8 @@ public class TmailEventSerializer implements EventSerializer {
             Boolean.TRUE.equals(readOnly));
     }
 
-    private EventDTO toDTO(Event event) {
-        return switch (event) {
+    private Optional<EventDTO> toDTO(Event event) {
+        return Optional.ofNullable(switch (event) {
             case FailedBlobEvents.BlobAddition e -> new BlobAdditionDTO(e.getEventId().getId().toString(), FailedBlobEvents.BlobEvent.USERNAME.asString(),
                 e.bucketName().asString(), e.blobId().asString(), e.getFailedObjectStorage().name());
             case FailedBlobEvents.BlobsDeletion e -> new BlobsDeletionDTO(e.getEventId().getId().toString(), FailedBlobEvents.BlobEvent.USERNAME.asString(),
@@ -163,12 +166,12 @@ public class TmailEventSerializer implements EventSerializer {
                 e.updatedLabel().readOnly());
             case LabelDestroyed e -> new LabelDestroyedDTO(e.getEventId().getId().toString(), e.username().asString(),
                 e.labelId().toKeyword());
-            default -> throw new IllegalStateException("Unexpected value: " + event);
-        };
+            default -> null;
+        });
     }
 
-    private Event fromDTO(EventDTO eventDTO) throws AddressException {
-        return switch (eventDTO) {
+    private Optional<Event> fromDTO(EventDTO eventDTO) throws AddressException {
+        return Optional.ofNullable(switch (eventDTO) {
             case BlobAdditionDTO dto -> new FailedBlobEvents.BlobAddition(Event.EventId.of(dto.eventId()),
                 BucketName.of(dto.bucketName()), blobIdFactory.parse(dto.blobId()), ObjectStorageIdentity.valueOf(dto.failedObjectStorage()));
             case BlobsDeletionDTO dto -> new FailedBlobEvents.BlobsDeletion(Event.EventId.of(dto.eventId()),
@@ -183,7 +186,7 @@ public class TmailEventSerializer implements EventSerializer {
             case LabelUpdatedDTO dto -> new LabelUpdated(Event.EventId.of(dto.eventId()),
                 Username.of(dto.username()), dtoToLabel(dto.keyword(), dto.displayName(), dto.color(), dto.description(), dto.readOnly()));
             case LabelDestroyedDTO dto -> new LabelDestroyed(Event.EventId.of(dto.eventId()), Username.of(dto.username()), LabelId.fromKeyword(dto.keyword));
-            default -> throw new IllegalStateException("Unexpected value: " + eventDTO);
-        };
+            default -> null;
+        });
     }
 }

--- a/tmail-backend/guice/distributed/src/test/java/com/linagora/tmail/event/BlobEventSerializationTest.java
+++ b/tmail-backend/guice/distributed/src/test/java/com/linagora/tmail/event/BlobEventSerializationTest.java
@@ -73,37 +73,37 @@ public class BlobEventSerializationTest {
 
     @Test
     void blobAdditionEventShouldBeWellSerialized() {
-        String json = tmailEventSerializer.toJson(BLOB_ADDTITION_EVENT);
+        String json = tmailEventSerializer.toJson(BLOB_ADDTITION_EVENT).json();
         assertThat(json).isEqualTo(BlOB_ADDITION_JSON);
     }
 
     @Test
     void blobAdditionEventShouldBeWellDeserialized() {
-        Event event = tmailEventSerializer.asEvent(BlOB_ADDITION_JSON);
+        Event event = tmailEventSerializer.asEvent(BlOB_ADDITION_JSON).event();
         assertThat(event).isEqualTo(BLOB_ADDTITION_EVENT);
     }
 
     @Test
     void blobsDeletionEventShouldBeWellSerialized() {
-        String json = tmailEventSerializer.toJson(BLOBS_DELETION_EVENT);
+        String json = tmailEventSerializer.toJson(BLOBS_DELETION_EVENT).json();
         assertThat(json).isEqualTo(BlOBS_DELETION_JSON);
     }
 
     @Test
     void blobsDeletionEventShouldBeWellDeserialized() {
-        Event event = tmailEventSerializer.asEvent(BlOBS_DELETION_JSON);
+        Event event = tmailEventSerializer.asEvent(BlOBS_DELETION_JSON).event();
         assertThat(event).isEqualTo(BLOBS_DELETION_EVENT);
     }
 
     @Test
     void bucketDeletionEventShouldBeWellSerialized() {
-        String json = tmailEventSerializer.toJson(BUCKET_DELETION_EVENT);
+        String json = tmailEventSerializer.toJson(BUCKET_DELETION_EVENT).json();
         assertThat(json).isEqualTo(BUCKET_DELETION_JSON);
     }
 
     @Test
     void bucketDeletionEventShouldBeWellDeserialized() {
-        Event event = tmailEventSerializer.asEvent(BUCKET_DELETION_JSON);
+        Event event = tmailEventSerializer.asEvent(BUCKET_DELETION_JSON).event();
         assertThat(event).isEqualTo(BUCKET_DELETION_EVENT);
     }
 }

--- a/tmail-backend/guice/distributed/src/test/java/com/linagora/tmail/event/LabelEventSerializationTest.java
+++ b/tmail-backend/guice/distributed/src/test/java/com/linagora/tmail/event/LabelEventSerializationTest.java
@@ -25,7 +25,6 @@ import java.time.Instant;
 import org.apache.james.blob.api.PlainBlobId;
 import org.apache.james.core.Username;
 import org.apache.james.events.Event;
-import org.apache.james.jmap.mail.Keyword;
 import org.apache.james.server.blob.deduplication.GenerationAwareBlobId;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.junit.jupiter.api.Test;
@@ -148,73 +147,73 @@ class LabelEventSerializationTest {
 
     @Test
     void labelCreatedShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR)))
+        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR)).json())
             .isEqualTo(LABEL_CREATED_JSON);
     }
 
     @Test
     void labelCreatedShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_CREATED_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_CREATED_JSON).event())
             .isEqualTo(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR));
     }
 
     @Test
     void labelCreatedWithDescriptionShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR_AND_DESCRIPTION)))
+        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR_AND_DESCRIPTION)).json())
             .isEqualTo(LABEL_CREATED_WITH_DESCRIPTION_JSON);
     }
 
     @Test
     void labelCreatedWithDescriptionShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_CREATED_WITH_DESCRIPTION_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_CREATED_WITH_DESCRIPTION_JSON).event())
             .isEqualTo(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR_AND_DESCRIPTION));
     }
 
     @Test
     void labelCreatedWithoutOptionalFieldsShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_MINIMAL)))
+        assertThat(SERIALIZER.toJson(new LabelCreated(EVENT_ID, ALICE, LABEL_MINIMAL)).json())
             .isEqualTo(LABEL_CREATED_MINIMAL_JSON);
     }
 
     @Test
     void labelCreatedWithoutOptionalFieldsShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_CREATED_MINIMAL_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_CREATED_MINIMAL_JSON).event())
             .isEqualTo(new LabelCreated(EVENT_ID, ALICE, LABEL_MINIMAL));
     }
 
     @Test
     void labelUpdatedShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR)))
+        assertThat(SERIALIZER.toJson(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR)).json())
             .isEqualTo(LABEL_UPDATED_JSON);
     }
 
     @Test
     void labelUpdatedShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_UPDATED_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_UPDATED_JSON).event())
             .isEqualTo(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR));
     }
 
     @Test
     void labelDestroyedShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelDestroyed(EVENT_ID, ALICE, LABEL_ID)))
+        assertThat(SERIALIZER.toJson(new LabelDestroyed(EVENT_ID, ALICE, LABEL_ID)).json())
             .isEqualTo(LABEL_DESTROYED_JSON);
     }
 
     @Test
     void labelDestroyedShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_DESTROYED_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_DESTROYED_JSON).event())
             .isEqualTo(new LabelDestroyed(EVENT_ID, ALICE, LABEL_ID));
     }
 
     @Test
     void labelUpdatedReadOnlyShouldBeWellSerialized() {
-        assertThat(SERIALIZER.toJson(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR_READONLY)))
+        assertThat(SERIALIZER.toJson(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR_READONLY)).json())
             .isEqualTo(LABEL_UPDATED_READONLY_JSON);
     }
 
     @Test
     void labelUpdatedReadOnlyShouldBeWellDeserialized() {
-        assertThat(SERIALIZER.asEvent(LABEL_UPDATED_READONLY_JSON))
+        assertThat(SERIALIZER.asEvent(LABEL_UPDATED_READONLY_JSON).event())
             .isEqualTo(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR_READONLY));
     }
 
@@ -229,7 +228,7 @@ class LabelEventSerializationTest {
             "\"color\":\"#FF0000\"," +
             "\"description\":null" +
             "}";
-        assertThat(SERIALIZER.asEvent(legacyJson))
+        assertThat(SERIALIZER.asEvent(legacyJson).event())
             .isEqualTo(new LabelUpdated(EVENT_ID, ALICE, LABEL_WITH_COLOR));
     }
 
@@ -244,7 +243,7 @@ class LabelEventSerializationTest {
             "\"color\":\"#FF0000\"," +
             "\"description\":null" +
             "}";
-        assertThat(SERIALIZER.asEvent(legacyJson))
+        assertThat(SERIALIZER.asEvent(legacyJson).event())
             .isEqualTo(new LabelCreated(EVENT_ID, ALICE, LABEL_WITH_COLOR));
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/listener/rag/event/AIAnalysisNeededEventSerializer.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/listener/rag/event/AIAnalysisNeededEventSerializer.java
@@ -19,19 +19,19 @@
 package com.linagora.tmail.listener.rag.event;
 
 import java.util.Collection;
-import java.util.List;
 
 import jakarta.inject.Inject;
 
 import org.apache.james.core.Username;
+import org.apache.james.events.DeserializationResult;
 import org.apache.james.events.Event;
 import org.apache.james.events.EventSerializer;
+import org.apache.james.events.SerializationResult;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 
 public class AIAnalysisNeededEventSerializer implements EventSerializer {
     private record AIAnalysisNeededDTO(String eventId, String username, String mailboxId, String messageId) {
@@ -49,9 +49,9 @@ public class AIAnalysisNeededEventSerializer implements EventSerializer {
     }
 
     @Override
-    public String toJson(Event event) {
+    public SerializationResult toJson(Event event) {
         if (!(event instanceof AIAnalysisNeeded aiAnalysisNeeded)) {
-            throw new IllegalArgumentException("Unsupported event type: " + event.getClass().getName());
+            return new SerializationResult.Failure("Unsupported event type: " + event.getClass().getName());
         }
 
         try {
@@ -59,33 +59,33 @@ public class AIAnalysisNeededEventSerializer implements EventSerializer {
                 aiAnalysisNeeded.getUsername().asString(),
                 aiAnalysisNeeded.mailboxId().serialize(),
                 aiAnalysisNeeded.messageId().serialize());
-            return objectMapper.writeValueAsString(dto);
+            return new SerializationResult.Success(objectMapper.writeValueAsString(dto));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return new SerializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public String toJson(Collection<Event> events) {
+    public SerializationResult toJson(Collection<Event> events) {
         if (events.size() != 1) {
-            throw new IllegalArgumentException("Not supported for multiple events, please serialize separately");
+            return new SerializationResult.Failure("Not supported for multiple events, please serialize separately");
         }
         return toJson(events.iterator().next());
     }
 
     @Override
-    public Event asEvent(String serialized) {
+    public DeserializationResult asEvent(String serialized) {
         try {
             AIAnalysisNeededDTO dto = objectMapper.readValue(serialized, AIAnalysisNeededDTO.class);
-            return new AIAnalysisNeeded(Event.EventId.of(dto.eventId()), Username.of(dto.username()),
-                mailboxIdFactory.fromString(dto.mailboxId()), messageIdFactory.fromString(dto.messageId()));
+            return new DeserializationResult.Success(new AIAnalysisNeeded(Event.EventId.of(dto.eventId()), Username.of(dto.username()),
+                mailboxIdFactory.fromString(dto.mailboxId()), messageIdFactory.fromString(dto.messageId())));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return new DeserializationResult.Failure(e.getMessage());
         }
     }
 
     @Override
-    public List<Event> asEvents(String serialized) {
-        return ImmutableList.of(asEvent(serialized));
+    public DeserializationResult asEvents(String serialized) {
+        return asEvent(serialized);
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/listener/rag/event/AIAnalysisNeededEventSerializerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/listener/rag/event/AIAnalysisNeededEventSerializerTest.java
@@ -36,8 +36,10 @@ public class AIAnalysisNeededEventSerializerTest {
         Username username = Username.of("bob@example.com");
         AIAnalysisNeeded event = new AIAnalysisNeeded(eventId, username, InMemoryId.of(42), InMemoryMessageId.of(100));
 
-        String serialized = serializer.toJson(event);
-        Event deserialized = serializer.asEvent(serialized);
+        String serialized = serializer.toJson(event)
+            .json();
+        Event deserialized = serializer.asEvent(serialized)
+            .event();
 
         assertThat(deserialized).isInstanceOf(AIAnalysisNeeded.class);
         AIAnalysisNeeded aiAnalysisNeeded = (AIAnalysisNeeded) deserialized;


### PR DESCRIPTION
Still failing on the postgres server app tests

This https://github.com/apache/james-project/pull/2996 is breaking the tests for me.

It does not auto adjust space storage, it seems the broker service is trying to claim 100gb disk space. Our CI has 82GB available? (I have less locally)

It breaks for me on james too, but maybe the tests were green because the apache ci is beefy..?

Need to think of a fix on james side

Thinking jvm properties or conf option in activemq properties conf file?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized event serialization/deserialization across the system: serializers now return structured success/failure results instead of throwing, improving error handling and consistency.
* **Tests**
  * Updated tests to unwrap and assert serializer result payloads via new accessors.
* **Chores**
  * Updated submodule reference to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->