### PR TITLE
ISSUE-1180 Ability to apply tiering per user

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1353,6 +1353,38 @@ Return codes:
 - `200` Successfully returned the aggregated data
 - `400` Missing the `hasSpecificQuota` query parameter
 
+== User Data Tiering
+
+This endpoint allows administrators to free up Cassandra storage for a given user by clearing
+derived or cached data that predates a given retention period.
+
+The following data is cleared:
+
+- JMAP `/changes` projection (`email_change` and `mailbox_change` tables) — fully deleted for the user
+- Thread guessing table (`thread_2`) — fully deleted for the user
+- For each message older than the tiering period:
+  - Fast view projection (subject, preview)
+  - Header blob store cache entry
+
+The operation is synchronous and returns once all deletions are complete. All errors on individual
+messages are silently ignored so that the operation is best-effort.
+
+=== Tier a user's data
+
+....
+curl -XPOST http://ip:port/users/{username}/data?tiering={duration}
+....
+
+Query parameters:
+
+- `tiering` (required): retention period expressed as an ISO-8601 duration or a shorthand such as
+  `30d`, `12h`, `1w`. Messages older than this period have their cached data evicted.
+
+Return codes:
+
+- `204` Operation completed successfully
+- `400` Invalid username or missing / unparseable `tiering` parameter
+
 == User Mails Search
 
 This route allows administrators to search through a user's mailbox for debugging purposes

--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1365,9 +1365,9 @@ The following data is cleared:
 - For each message older than the tiering period:
   - Fast view projection (subject, preview)
   - Header blob store cache entry
+  - Attachments projection (attachment are still parseable via the raw Mime message as a fallback)
 
-The operation is synchronous and returns once all deletions are complete. All errors on individual
-messages are silently ignored so that the operation is best-effort.
+The operation is synchronous and returns once all deletions are complete. 
 
 === Tier a user's data
 

--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1361,11 +1361,11 @@ derived or cached data that predates a given retention period.
 The following data is cleared:
 
 - JMAP `/changes` projection (`email_change` and `mailbox_change` tables) — fully deleted for the user
-- Thread guessing table (`thread_2`) — fully deleted for the user
 - For each message older than the tiering period:
   - Fast view projection (subject, preview)
   - Header blob store cache entry
   - Attachments projection (attachment are still parseable via the raw Mime message as a fallback)
+  - Thread guessing table (`thread_2`) — deleted for this message
 
 The operation is synchronous and returns once all deletions are complete. 
 

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -211,6 +211,7 @@ import com.linagora.tmail.listener.FilteringRuleReferenceUpdaterListenerModule;
 import com.linagora.tmail.mailbox.opensearch.TmailOpenSearchMailboxMappingModule;
 import com.linagora.tmail.mailbox.quota.cassandra.CassandraUserQuotaReporterModule;
 import com.linagora.tmail.modules.data.CassandraKeywordEmailQueryViewModule;
+import com.linagora.tmail.modules.data.CassandraUserDataTieringModule;
 import com.linagora.tmail.modules.data.TMailCassandraDelegationStoreModule;
 import com.linagora.tmail.modules.data.TMailCassandraDeletedMessageVaultModule;
 import com.linagora.tmail.modules.data.TMailCassandraDomainListModule;
@@ -226,12 +227,11 @@ import com.linagora.tmail.webadmin.TeamMailboxVaultRoutesModule;
 import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
+import com.linagora.tmail.webadmin.data.UserDataTieringRoutesModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
-import com.linagora.tmail.webadmin.data.UserDataTieringRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
-import com.linagora.tmail.modules.data.CassandraUserDataTieringModule;
 
 import reactor.core.publisher.Mono;
 

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -228,8 +228,10 @@ import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
+import com.linagora.tmail.webadmin.data.UserDataTieringRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
+import com.linagora.tmail.modules.data.CassandraUserDataTieringModule;
 
 import reactor.core.publisher.Mono;
 
@@ -288,7 +290,8 @@ public class DistributedServer {
         new InboxArchivalTaskModule(),
         new VacationRoutesModule(),
         new ContactIndexingModule(),
-        new PopulateKeywordEmailQueryViewTaskModule());
+        new PopulateKeywordEmailQueryViewTaskModule(),
+        new UserDataTieringRoutesModule());
 
     public static final Module JMAP = Modules.override(
         new TMailJMAPModule(),
@@ -392,7 +395,8 @@ public class DistributedServer {
             new TMailMailboxSortOrderProviderModule(),
             new TMailIMAPModule(),
             new CollectTrustedContactsListenerModule(),
-            new FilteringRuleReferenceUpdaterListenerModule());
+            new FilteringRuleReferenceUpdaterListenerModule(),
+            new CassandraUserDataTieringModule());
 
     public static void main(String[] args) throws Exception {
         DistributedJamesConfiguration configuration = DistributedJamesConfiguration.builder()

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/UserDataTieringIT.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/UserDataTieringIT.java
@@ -36,6 +36,8 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
+import org.apache.james.backends.redis.RedisExtension;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.JmapGuiceProbe;
 import org.apache.james.jmap.JmapRFCCommonRequests;
 import org.apache.james.mailbox.DefaultMailboxes;
@@ -43,7 +45,6 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.apache.james.modules.MailboxProbeImpl;
-import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.WebAdminGuiceProbe;
@@ -56,7 +57,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
@@ -67,7 +67,6 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 
 class UserDataTieringIT {
-
     static class CassandraTieringProbe implements GuiceProbe {
         private final CqlSession session;
 
@@ -76,59 +75,28 @@ class UserDataTieringIT {
             this.session = session;
         }
 
-        boolean hasEmailChanges(String accountId) {
-            return !session.execute(
-                session.prepare("SELECT account_id FROM email_change WHERE account_id = ?")
-                    .bind().set(0, accountId, TypeCodecs.TEXT))
-                .all().isEmpty();
-        }
-
-        boolean hasMailboxChanges(String accountId) {
-            return !session.execute(
-                session.prepare("SELECT account_id FROM mailbox_change WHERE account_id = ?")
-                    .bind().set(0, accountId, TypeCodecs.TEXT))
-                .all().isEmpty();
-        }
-
-        boolean hasFastViewEntry(String messageId) {
-            return !session.execute(
-                session.prepare("SELECT \"messageId\" FROM message_fast_view_projection WHERE \"messageId\" = ?")
-                    .bind(java.util.UUID.fromString(messageId)))
-                .all().isEmpty();
-        }
-
-        long countEmailChanges(String accountId) {
-            return session.execute(
-                session.prepare("SELECT COUNT(*) FROM email_change WHERE account_id = ?")
-                    .bind().set(0, accountId, TypeCodecs.TEXT))
+        long countEmailChanges() {
+            return session.execute("SELECT COUNT(*) FROM email_change")
                 .one().getLong(0);
         }
 
-        long countMailboxChanges(String accountId) {
-            return session.execute(
-                session.prepare("SELECT COUNT(*) FROM mailbox_change WHERE account_id = ?")
-                    .bind().set(0, accountId, TypeCodecs.TEXT))
+        long countMailboxChanges() {
+            return session.execute("SELECT COUNT(*) FROM mailbox_change")
                 .one().getLong(0);
         }
 
-        long countThread2(String username) {
-            return session.execute(
-                session.prepare("SELECT COUNT(*) FROM thread_2 WHERE username = ?")
-                    .bind().set(0, username, TypeCodecs.TEXT))
+        long countThread2() {
+            return session.execute("SELECT COUNT(*) FROM thread_2 ")
                 .one().getLong(0);
         }
 
         long countFastViewEntries() {
-            return session.execute(
-                session.prepare("SELECT COUNT(*) FROM message_fast_view_projection")
-                    .bind())
+            return session.execute("SELECT COUNT(*) FROM message_fast_view_projection")
                 .one().getLong(0);
         }
 
         long countAttachmentV2() {
-            return session.execute(
-                session.prepare("SELECT COUNT(*) FROM \"attachmentV2\"")
-                    .bind())
+            return session.execute("SELECT COUNT(*) FROM attachmentV2")
                 .one().getLong(0);
         }
     }
@@ -163,15 +131,16 @@ class UserDataTieringIT {
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
             .configurationFromClasspath()
+            .jmapEnabled(true)
             .blobStore(BlobStoreConfiguration.builder()
                 .s3()
                 .noSecondaryS3BlobStore()
-                .disableCache()
+                .enableCache()
                 .deduplication()
                 .noCryptoConfig()
                 .enableSingleSave())
             .searchConfiguration(SearchConfiguration.openSearch())
-            .eventBusKeysChoice(EventBusKeysChoice.RABBITMQ)
+            .eventBusKeysChoice(EventBusKeysChoice.REDIS)
             .build())
         .server(configuration -> DistributedServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule())
@@ -180,6 +149,7 @@ class UserDataTieringIT {
         .extension(new DockerOpenSearchExtension())
         .extension(new CassandraExtension())
         .extension(new RabbitMQExtension())
+        .extension(new RedisExtension())
         .extension(new AwsS3BlobStoreExtension())
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
@@ -195,10 +165,10 @@ class UserDataTieringIT {
             .addUser(BOB, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
-        mailboxProbe.createMailbox(MailboxPath.forUser(org.apache.james.core.Username.of(BOB), DefaultMailboxes.INBOX));
+        mailboxProbe.createMailbox(MailboxPath.forUser(Username.of(BOB), DefaultMailboxes.INBOX));
 
         InputStream multipartEml = new ByteArrayInputStream(MULTIPART_WITH_ATTACHMENT.getBytes(StandardCharsets.US_ASCII));
-        messageId = mailboxProbe.appendMessage(BOB, MailboxPath.inbox(org.apache.james.core.Username.of(BOB)),
+        messageId = mailboxProbe.appendMessage(BOB, MailboxPath.inbox(Username.of(BOB)),
             multipartEml, OLD_INTERNAL_DATE, false, new Flags()).getMessageId();
 
         WebAdminGuiceProbe webAdminProbe = server.getProbe(WebAdminGuiceProbe.class);
@@ -216,9 +186,9 @@ class UserDataTieringIT {
         bobCredential = JmapRFCCommonRequests.getUserCredential(BOB, PASSWORD);
 
         CassandraTieringProbe probe = server.getProbe(CassandraTieringProbe.class);
-        CALMLY_AWAIT.until(() -> probe.hasEmailChanges(bobCredential.accountId()));
-        CALMLY_AWAIT.until(() -> probe.hasMailboxChanges(bobCredential.accountId()));
-        CALMLY_AWAIT.until(() -> probe.hasFastViewEntry(messageId.serialize()));
+        CALMLY_AWAIT.until(() -> probe.countEmailChanges() > 0);
+        CALMLY_AWAIT.until(() -> probe.countMailboxChanges() > 0);
+        CALMLY_AWAIT.until(() -> probe.countFastViewEntries() > 0);
     }
 
     @Test
@@ -269,9 +239,9 @@ class UserDataTieringIT {
 
         // All tiered tables are empty
         CassandraTieringProbe probe = server.getProbe(CassandraTieringProbe.class);
-        assertThat(probe.countEmailChanges(bobCredential.accountId())).isZero();
-        assertThat(probe.countMailboxChanges(bobCredential.accountId())).isZero();
-        assertThat(probe.countThread2(BOB)).isZero();
+        assertThat(probe.countEmailChanges()).isZero();
+        assertThat(probe.countMailboxChanges()).isZero();
+        assertThat(probe.countThread2()).isZero();
         assertThat(probe.countFastViewEntries()).isZero();
         assertThat(probe.countAttachmentV2()).isZero();
     }

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/UserDataTieringIT.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/UserDataTieringIT.java
@@ -1,0 +1,278 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.app;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import jakarta.inject.Inject;
+import jakarta.mail.Flags;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.jmap.JmapGuiceProbe;
+import org.apache.james.jmap.JmapRFCCommonRequests;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.modules.AwsS3BlobStoreExtension;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.modules.RabbitMQExtension;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+class UserDataTieringIT {
+
+    static class CassandraTieringProbe implements GuiceProbe {
+        private final CqlSession session;
+
+        @Inject
+        CassandraTieringProbe(CqlSession session) {
+            this.session = session;
+        }
+
+        boolean hasEmailChanges(String accountId) {
+            return !session.execute(
+                session.prepare("SELECT account_id FROM email_change WHERE account_id = ?")
+                    .bind().set(0, accountId, TypeCodecs.TEXT))
+                .all().isEmpty();
+        }
+
+        boolean hasMailboxChanges(String accountId) {
+            return !session.execute(
+                session.prepare("SELECT account_id FROM mailbox_change WHERE account_id = ?")
+                    .bind().set(0, accountId, TypeCodecs.TEXT))
+                .all().isEmpty();
+        }
+
+        boolean hasFastViewEntry(String messageId) {
+            return !session.execute(
+                session.prepare("SELECT \"messageId\" FROM message_fast_view_projection WHERE \"messageId\" = ?")
+                    .bind(java.util.UUID.fromString(messageId)))
+                .all().isEmpty();
+        }
+
+        long countEmailChanges(String accountId) {
+            return session.execute(
+                session.prepare("SELECT COUNT(*) FROM email_change WHERE account_id = ?")
+                    .bind().set(0, accountId, TypeCodecs.TEXT))
+                .one().getLong(0);
+        }
+
+        long countMailboxChanges(String accountId) {
+            return session.execute(
+                session.prepare("SELECT COUNT(*) FROM mailbox_change WHERE account_id = ?")
+                    .bind().set(0, accountId, TypeCodecs.TEXT))
+                .one().getLong(0);
+        }
+
+        long countThread2(String username) {
+            return session.execute(
+                session.prepare("SELECT COUNT(*) FROM thread_2 WHERE username = ?")
+                    .bind().set(0, username, TypeCodecs.TEXT))
+                .one().getLong(0);
+        }
+
+        long countFastViewEntries() {
+            return session.execute(
+                session.prepare("SELECT COUNT(*) FROM message_fast_view_projection")
+                    .bind())
+                .one().getLong(0);
+        }
+
+        long countAttachmentV2() {
+            return session.execute(
+                session.prepare("SELECT COUNT(*) FROM \"attachmentV2\"")
+                    .bind())
+                .one().getLong(0);
+        }
+    }
+
+    private static final String DOMAIN = "tmail.org";
+    private static final String BOB = "bob@" + DOMAIN;
+    private static final String PASSWORD = "secret";
+    private static final Date OLD_INTERNAL_DATE = Date.from(Instant.now().minus(60, ChronoUnit.DAYS));
+    private static final String MULTIPART_WITH_ATTACHMENT = "From: sender@tmail.org\r\n"
+        + "To: bob@tmail.org\r\n"
+        + "Subject: Test tiering\r\n"
+        + "MIME-Version: 1.0\r\n"
+        + "Content-Type: multipart/mixed; boundary=\"boundary\"\r\n"
+        + "\r\n"
+        + "--boundary\r\n"
+        + "Content-Type: text/plain\r\n"
+        + "\r\n"
+        + "Body content\r\n"
+        + "--boundary\r\n"
+        + "Content-Type: text/plain; name=\"attachment.txt\"\r\n"
+        + "Content-Disposition: attachment; filename=\"attachment.txt\"\r\n"
+        + "\r\n"
+        + "Attachment content\r\n"
+        + "--boundary--\r\n";
+    private static final ConditionFactory CALMLY_AWAIT = Awaitility
+        .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
+        .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
+        .await();
+
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
+        DistributedJamesConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .blobStore(BlobStoreConfiguration.builder()
+                .s3()
+                .noSecondaryS3BlobStore()
+                .disableCache()
+                .deduplication()
+                .noCryptoConfig()
+                .enableSingleSave())
+            .searchConfiguration(SearchConfiguration.openSearch())
+            .eventBusKeysChoice(EventBusKeysChoice.RABBITMQ)
+            .build())
+        .server(configuration -> DistributedServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(CassandraTieringProbe.class)))
+        .extension(new DockerOpenSearchExtension())
+        .extension(new CassandraExtension())
+        .extension(new RabbitMQExtension())
+        .extension(new AwsS3BlobStoreExtension())
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+
+    private MessageId messageId;
+    private JmapRFCCommonRequests.UserCredential bobCredential;
+    private RequestSpecification webadminSpec;
+
+    @BeforeEach
+    void setUp(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(BOB, PASSWORD);
+
+        MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
+        mailboxProbe.createMailbox(MailboxPath.forUser(org.apache.james.core.Username.of(BOB), DefaultMailboxes.INBOX));
+
+        InputStream multipartEml = new ByteArrayInputStream(MULTIPART_WITH_ATTACHMENT.getBytes(StandardCharsets.US_ASCII));
+        messageId = mailboxProbe.appendMessage(BOB, MailboxPath.inbox(org.apache.james.core.Username.of(BOB)),
+            multipartEml, OLD_INTERNAL_DATE, false, new Flags()).getMessageId();
+
+        WebAdminGuiceProbe webAdminProbe = server.getProbe(WebAdminGuiceProbe.class);
+        webadminSpec = WebAdminUtils.buildRequestSpecification(webAdminProbe.getWebAdminPort()).build();
+
+        int jmapPort = server.getProbe(JmapGuiceProbe.class).getJmapPort().getValue();
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setPort(jmapPort)
+            .addHeader("accept", "application/json; jmapVersion=rfc-8621")
+            .build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        bobCredential = JmapRFCCommonRequests.getUserCredential(BOB, PASSWORD);
+
+        CassandraTieringProbe probe = server.getProbe(CassandraTieringProbe.class);
+        CALMLY_AWAIT.until(() -> probe.hasEmailChanges(bobCredential.accountId()));
+        CALMLY_AWAIT.until(() -> probe.hasMailboxChanges(bobCredential.accountId()));
+        CALMLY_AWAIT.until(() -> probe.hasFastViewEntry(messageId.serialize()));
+    }
+
+    @Test
+    void tieringShouldClearProjectionsWhileMessageRemainsReadable(GuiceJamesServer server) {
+        // Apply tiering via webadmin
+        given()
+            .spec(webadminSpec)
+            .queryParam("tiering", "30d")
+        .when()
+            .post("/users/" + BOB + "/data")
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+
+        // Message can still be retrieved via JMAP Email/get
+        String attachmentBlobId = given()
+            .auth().basic(BOB, PASSWORD)
+            .header("accept", "application/json; jmapVersion=rfc-8621")
+            .body("""
+                {
+                  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+                  "methodCalls": [[
+                    "Email/get",
+                    {
+                      "accountId": "%s",
+                      "ids": ["%s"],
+                      "properties": ["id", "subject", "attachments"]
+                    },
+                    "c1"
+                  ]]
+                }""".formatted(bobCredential.accountId(), messageId.serialize()))
+        .when()
+            .post("/jmap")
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("methodResponses[0][1].list", org.hamcrest.Matchers.hasSize(1))
+            .extract()
+            .jsonPath()
+            .getString("methodResponses[0][1].list[0].attachments[0].blobId");
+
+        // Attachment can still be downloaded using the blobId from Email/get
+        given()
+            .auth().basic(BOB, PASSWORD)
+            .header("accept", "application/json; jmapVersion=rfc-8621")
+        .when()
+            .get("/download/" + bobCredential.accountId() + "/" + attachmentBlobId)
+        .then()
+            .statusCode(HttpStatus.OK_200);
+
+        // All tiered tables are empty
+        CassandraTieringProbe probe = server.getProbe(CassandraTieringProbe.class);
+        assertThat(probe.countEmailChanges(bobCredential.accountId())).isZero();
+        assertThat(probe.countMailboxChanges(bobCredential.accountId())).isZero();
+        assertThat(probe.countThread2(BOB)).isZero();
+        assertThat(probe.countFastViewEntries()).isZero();
+        assertThat(probe.countAttachmentV2()).isZero();
+    }
+}

--- a/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringService.java
+++ b/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringService.java
@@ -1,0 +1,37 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.tiering;
+
+import java.time.Duration;
+
+import org.apache.james.core.Username;
+
+import reactor.core.publisher.Mono;
+
+public interface UserDataTieringService {
+    /**
+     * Tiers user data by:
+     * - Clearing the JMAP /changes projection (email and mailbox changes)
+     * - Clearing the thread-guessing table for the user
+     * - For messages older than {@code tiering}, clearing their fast-view projection,
+     *   clearing their attachments
+     *   and evicting their header blobs from the blob-store cache
+     */
+    Mono<Void> tierUserData(Username username, Duration tiering);
+}

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreCacheCleaner.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreCacheCleaner.java
@@ -1,0 +1,26 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import org.apache.james.blob.api.BlobId;
+import org.reactivestreams.Publisher;
+
+public interface BlobStoreCacheCleaner {
+    Publisher<Void> removeFromCache(BlobId blobId);
+}

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreCacheModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreCacheModulesChooser.java
@@ -65,6 +65,11 @@ public class BlobStoreCacheModulesChooser {
     private static final Logger LOGGER = LoggerFactory.getLogger(BlobStoreCacheModulesChooser.class);
 
     static class CacheDisabledModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(BlobStoreCacheCleaner.class).to(NoopBlobStoreCacheCleaner.class);
+        }
+
         @Provides
         @Named(MetricableBlobStore.BLOB_STORE_IMPLEMENTATION)
         @Singleton
@@ -78,6 +83,7 @@ public class BlobStoreCacheModulesChooser {
         protected void configure() {
             bind(CassandraBlobStoreCache.class).in(Scopes.SINGLETON);
             bind(BlobStoreCache.class).to(CassandraBlobStoreCache.class);
+            bind(BlobStoreCacheCleaner.class).to(CassandraBlobStoreCacheCleaner.class);
 
             Multibinder.newSetBinder(binder(), CassandraDataDefinition.class, Names.named(InjectionNames.CACHE))
                 .addBinding()

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/CassandraBlobStoreCacheCleaner.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/CassandraBlobStoreCacheCleaner.java
@@ -1,0 +1,39 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.cassandra.cache.BlobStoreCache;
+import org.reactivestreams.Publisher;
+
+public class CassandraBlobStoreCacheCleaner implements BlobStoreCacheCleaner {
+    private final BlobStoreCache blobStoreCache;
+
+    @Inject
+    public CassandraBlobStoreCacheCleaner(BlobStoreCache blobStoreCache) {
+        this.blobStoreCache = blobStoreCache;
+    }
+
+    @Override
+    public Publisher<Void> removeFromCache(BlobId blobId) {
+        return blobStoreCache.remove(blobId);
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/NoopBlobStoreCacheCleaner.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/NoopBlobStoreCacheCleaner.java
@@ -1,0 +1,31 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import org.apache.james.blob.api.BlobId;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+
+public class NoopBlobStoreCacheCleaner implements BlobStoreCacheCleaner {
+    @Override
+    public Publisher<Void> removeFromCache(BlobId blobId) {
+        return Mono.empty();
+    }
+}

--- a/tmail-backend/guice/data-cassandra/pom.xml
+++ b/tmail-backend/guice/data-cassandra/pom.xml
@@ -36,6 +36,14 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>blob-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-jmap-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-deleted-messages-vault-cassandra</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/guice/data-cassandra/pom.xml
+++ b/tmail-backend/guice/data-cassandra/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>blob-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-guice-common</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringModule.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringModule.java
@@ -1,0 +1,29 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.modules.data;
+
+import com.google.inject.AbstractModule;
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+public class CassandraUserDataTieringModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(UserDataTieringService.class).to(CassandraUserDataTieringService.class);
+    }
+}

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -148,7 +148,7 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
             .filter(metadata -> metadata.getInternalDate()
                 .map(d -> d.before(tieringDate))
                 .orElse(false))
-            .flatMap(metadata -> applyTiering(username, metadata))
+            .flatMap(metadata -> applyTiering(username, metadata), LOW_CONCURRENCY)
             .then();
     }
 

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -1,0 +1,157 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.modules.data;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
+import static org.apache.james.jmap.cassandra.change.tables.CassandraEmailChangeTable.ACCOUNT_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraThreadTable.USERNAME;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.blob.cassandra.cache.BlobStoreCache;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.jmap.api.projections.MessageFastViewProjection;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageMetadata;
+import org.apache.james.mailbox.cassandra.table.CassandraThreadTable;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.util.streams.Limit;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Singleton
+public class CassandraUserDataTieringService implements UserDataTieringService {
+
+    private static final String EMAIL_CHANGE_TABLE = "email_change";
+    private static final String MAILBOX_CHANGE_TABLE = "mailbox_change";
+    private static final int LOW_CONCURRENCY = 2;
+
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement deleteEmailChanges;
+    private final PreparedStatement deleteMailboxChanges;
+    private final PreparedStatement deleteThreadByUser;
+    private final MailboxManager mailboxManager;
+    private final CassandraMessageIdDAO cassandraMessageIdDAO;
+    private final CassandraMessageDAOV3 cassandraMessageDAOV3;
+    private final CassandraAttachmentDAOV2 cassandraAttachmentDAOV2;
+    private final MessageFastViewProjection messageFastViewProjection;
+    private final BlobStoreCache blobStoreCache;
+
+    @Inject
+    public CassandraUserDataTieringService(CqlSession session,
+                                           MailboxManager mailboxManager,
+                                           CassandraMessageIdDAO cassandraMessageIdDAO,
+                                           CassandraMessageDAOV3 cassandraMessageDAOV3,
+                                           CassandraAttachmentDAOV2 cassandraAttachmentDAOV2,
+                                           MessageFastViewProjection messageFastViewProjection,
+                                           BlobStoreCache blobStoreCache) {
+        this.executor = new CassandraAsyncExecutor(session);
+        this.mailboxManager = mailboxManager;
+        this.cassandraMessageIdDAO = cassandraMessageIdDAO;
+        this.cassandraMessageDAOV3 = cassandraMessageDAOV3;
+        this.cassandraAttachmentDAOV2 = cassandraAttachmentDAOV2;
+        this.messageFastViewProjection = messageFastViewProjection;
+        this.blobStoreCache = blobStoreCache;
+
+        this.deleteEmailChanges = session.prepare(deleteFrom(EMAIL_CHANGE_TABLE)
+            .whereColumn(ACCOUNT_ID).isEqualTo(bindMarker(ACCOUNT_ID))
+            .build());
+
+        this.deleteMailboxChanges = session.prepare(deleteFrom(MAILBOX_CHANGE_TABLE)
+            .whereColumn(ACCOUNT_ID).isEqualTo(bindMarker(ACCOUNT_ID))
+            .build());
+
+        this.deleteThreadByUser = session.prepare(deleteFrom(CassandraThreadTable.TABLE_NAME)
+            .whereColumn(USERNAME).isEqualTo(bindMarker(USERNAME))
+            .build());
+    }
+
+    @Override
+    public Mono<Void> tierUserData(Username username, Duration tiering) {
+        Date tieringDate = Date.from(Instant.now().minus(tiering));
+        AccountId accountId = AccountId.fromUsername(username);
+        MailboxSession session = mailboxManager.createSystemSession(username);
+
+        return clearChanges(accountId)
+            .then(clearThreadGuessing(username))
+            .then(clearOldMessageProjections(tieringDate, session));
+    }
+
+    private Mono<Void> clearChanges(AccountId accountId) {
+        return executor.executeVoid(deleteEmailChanges.bind()
+                .set(ACCOUNT_ID, accountId.getIdentifier(), TypeCodecs.TEXT))
+            .then(executor.executeVoid(deleteMailboxChanges.bind()
+                .set(ACCOUNT_ID, accountId.getIdentifier(), TypeCodecs.TEXT)));
+    }
+
+    private Mono<Void> clearThreadGuessing(Username username) {
+        return executor.executeVoid(deleteThreadByUser.bind()
+            .set(USERNAME, username.asString(), TypeCodecs.TEXT));
+    }
+
+    private Mono<Void> clearOldMessageProjections(Date tieringDate, MailboxSession session) {
+        return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), session)
+            .map(metaData -> (CassandraId) metaData.getId())
+            .flatMap(mailboxId -> cassandraMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()), LOW_CONCURRENCY)
+            .filter(metadata -> metadata.getInternalDate()
+                .map(d -> d.before(tieringDate))
+                .orElse(false))
+            .flatMap(this::applyTiering)
+            .then();
+    }
+
+    private Mono<Void> applyTiering(CassandraMessageMetadata metadata) {
+        CassandraMessageId messageId = (CassandraMessageId) metadata.getComposedMessageId().getComposedMessageId().getMessageId();
+
+        Mono<Void> clearFastView = Mono.from(messageFastViewProjection.delete(messageId));
+
+        Mono<Void> clearHeaderBlob = metadata.getHeaderContent()
+            .map(blobId -> Mono.from(blobStoreCache.remove(blobId)))
+            .orElse(Mono.empty());
+
+        Mono<Void> clearAttachments = cassandraMessageDAOV3.retrieveMessage(messageId, FetchType.METADATA)
+            .flatMapMany(representation ->  Flux.fromIterable(representation.getAttachments()))
+            .flatMap(attachment -> cassandraAttachmentDAOV2.delete(attachment.getAttachmentId()))
+            .then();
+
+        return Mono.when(clearFastView, clearHeaderBlob, clearAttachments);
+    }
+}

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -158,9 +158,9 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
         Mono<Void> clearFastView = Mono.from(messageFastViewProjection.delete(messageId));
 
         Mono<Void> clearThreadAndHeaderCache = metadata.getHeaderContent()
-            .map(blobId -> Mono.from(blobStore.readBytes(blobStore.getDefaultBucketName(), blobId))
+            .<Mono<Void>>map(blobId -> Mono.from(blobStore.readBytes(blobStore.getDefaultBucketName(), blobId))
                 .flatMap(headerBytes -> clearThreadEntries(username, headerBytes))
-                .then(Mono.from(blobStoreCacheCleaner.removeFromCache(blobId))))
+                .then(Mono.<Void>from(blobStoreCacheCleaner.removeFromCache(blobId))))
             .orElse(Mono.empty());
 
         Mono<Void> clearAttachments = cassandraMessageDAOV3.retrieveMessage(messageId, FetchType.METADATA)

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -21,17 +21,25 @@ package com.linagora.tmail.modules.data;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
 import static org.apache.james.jmap.cassandra.change.tables.CassandraEmailChangeTable.ACCOUNT_ID;
-import static org.apache.james.mailbox.cassandra.table.CassandraThreadTable.USERNAME;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
-import org.apache.james.blob.cassandra.cache.BlobStoreCache;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.jmap.api.projections.MessageFastViewProjection;
@@ -43,15 +51,25 @@ import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageMetadata;
-import org.apache.james.mailbox.cassandra.table.CassandraThreadTable;
+import org.apache.james.mailbox.cassandra.mail.CassandraThreadDAO;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.mailbox.store.mail.model.MimeMessageId;
+import org.apache.james.mailbox.store.mail.utils.MimeMessageHeadersUtil;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.james.util.streams.Limit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.google.common.hash.Hashing;
+import com.linagora.tmail.blob.guice.BlobStoreCacheCleaner;
 import com.linagora.tmail.tiering.UserDataTieringService;
 
 import reactor.core.publisher.Flux;
@@ -60,6 +78,7 @@ import reactor.core.publisher.Mono;
 @Singleton
 public class CassandraUserDataTieringService implements UserDataTieringService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraUserDataTieringService.class);
     private static final String EMAIL_CHANGE_TABLE = "email_change";
     private static final String MAILBOX_CHANGE_TABLE = "mailbox_change";
     private static final int LOW_CONCURRENCY = 2;
@@ -67,13 +86,14 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
     private final CassandraAsyncExecutor executor;
     private final PreparedStatement deleteEmailChanges;
     private final PreparedStatement deleteMailboxChanges;
-    private final PreparedStatement deleteThreadByUser;
     private final MailboxManager mailboxManager;
     private final CassandraMessageIdDAO cassandraMessageIdDAO;
     private final CassandraMessageDAOV3 cassandraMessageDAOV3;
     private final CassandraAttachmentDAOV2 cassandraAttachmentDAOV2;
+    private final CassandraThreadDAO cassandraThreadDAO;
     private final MessageFastViewProjection messageFastViewProjection;
-    private final BlobStoreCache blobStoreCache;
+    private final BlobStoreCacheCleaner blobStoreCacheCleaner;
+    private final BlobStore blobStore;
 
     @Inject
     public CassandraUserDataTieringService(CqlSession session,
@@ -81,15 +101,19 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
                                            CassandraMessageIdDAO cassandraMessageIdDAO,
                                            CassandraMessageDAOV3 cassandraMessageDAOV3,
                                            CassandraAttachmentDAOV2 cassandraAttachmentDAOV2,
+                                           CassandraThreadDAO cassandraThreadDAO,
                                            MessageFastViewProjection messageFastViewProjection,
-                                           BlobStoreCache blobStoreCache) {
+                                           BlobStoreCacheCleaner blobStoreCacheCleaner,
+                                           @Named(MetricableBlobStore.BLOB_STORE_IMPLEMENTATION) BlobStore blobStore) {
         this.executor = new CassandraAsyncExecutor(session);
         this.mailboxManager = mailboxManager;
         this.cassandraMessageIdDAO = cassandraMessageIdDAO;
         this.cassandraMessageDAOV3 = cassandraMessageDAOV3;
         this.cassandraAttachmentDAOV2 = cassandraAttachmentDAOV2;
+        this.cassandraThreadDAO = cassandraThreadDAO;
         this.messageFastViewProjection = messageFastViewProjection;
-        this.blobStoreCache = blobStoreCache;
+        this.blobStoreCacheCleaner = blobStoreCacheCleaner;
+        this.blobStore = blobStore;
 
         this.deleteEmailChanges = session.prepare(deleteFrom(EMAIL_CHANGE_TABLE)
             .whereColumn(ACCOUNT_ID).isEqualTo(bindMarker(ACCOUNT_ID))
@@ -97,10 +121,6 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
 
         this.deleteMailboxChanges = session.prepare(deleteFrom(MAILBOX_CHANGE_TABLE)
             .whereColumn(ACCOUNT_ID).isEqualTo(bindMarker(ACCOUNT_ID))
-            .build());
-
-        this.deleteThreadByUser = session.prepare(deleteFrom(CassandraThreadTable.TABLE_NAME)
-            .whereColumn(USERNAME).isEqualTo(bindMarker(USERNAME))
             .build());
     }
 
@@ -111,8 +131,7 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
         MailboxSession session = mailboxManager.createSystemSession(username);
 
         return clearChanges(accountId)
-            .then(clearThreadGuessing(username))
-            .then(clearOldMessageProjections(tieringDate, session));
+            .then(clearOldMessageProjections(username, tieringDate, session));
     }
 
     private Mono<Void> clearChanges(AccountId accountId) {
@@ -122,36 +141,66 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
                 .set(ACCOUNT_ID, accountId.getIdentifier(), TypeCodecs.TEXT)));
     }
 
-    private Mono<Void> clearThreadGuessing(Username username) {
-        return executor.executeVoid(deleteThreadByUser.bind()
-            .set(USERNAME, username.asString(), TypeCodecs.TEXT));
-    }
-
-    private Mono<Void> clearOldMessageProjections(Date tieringDate, MailboxSession session) {
+    private Mono<Void> clearOldMessageProjections(Username username, Date tieringDate, MailboxSession session) {
         return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), session)
             .map(metaData -> (CassandraId) metaData.getId())
             .flatMap(mailboxId -> cassandraMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()), LOW_CONCURRENCY)
             .filter(metadata -> metadata.getInternalDate()
                 .map(d -> d.before(tieringDate))
                 .orElse(false))
-            .flatMap(this::applyTiering)
+            .flatMap(metadata -> applyTiering(username, metadata))
             .then();
     }
 
-    private Mono<Void> applyTiering(CassandraMessageMetadata metadata) {
+    private Mono<Void> applyTiering(Username username, CassandraMessageMetadata metadata) {
         CassandraMessageId messageId = (CassandraMessageId) metadata.getComposedMessageId().getComposedMessageId().getMessageId();
 
         Mono<Void> clearFastView = Mono.from(messageFastViewProjection.delete(messageId));
 
-        Mono<Void> clearHeaderBlob = metadata.getHeaderContent()
-            .map(blobId -> Mono.from(blobStoreCache.remove(blobId)))
+        Mono<Void> clearThreadAndHeaderCache = metadata.getHeaderContent()
+            .map(blobId -> Mono.from(blobStore.readBytes(blobStore.getDefaultBucketName(), blobId))
+                .flatMap(headerBytes -> clearThreadEntries(username, headerBytes))
+                .then(Mono.from(blobStoreCacheCleaner.removeFromCache(blobId))))
             .orElse(Mono.empty());
 
         Mono<Void> clearAttachments = cassandraMessageDAOV3.retrieveMessage(messageId, FetchType.METADATA)
-            .flatMapMany(representation ->  Flux.fromIterable(representation.getAttachments()))
+            .flatMapMany(representation -> Flux.fromIterable(representation.getAttachments()))
             .flatMap(attachment -> cassandraAttachmentDAOV2.delete(attachment.getAttachmentId()))
             .then();
 
-        return Mono.when(clearFastView, clearHeaderBlob, clearAttachments);
+        return Mono.when(clearFastView, clearThreadAndHeaderCache, clearAttachments);
+    }
+
+    private Mono<Void> clearThreadEntries(Username username, byte[] headerBytes) {
+        Set<Integer> hashMimeMessageIds = extractHashedMimeMessageIds(headerBytes);
+        if (hashMimeMessageIds.isEmpty()) {
+            return Mono.empty();
+        }
+        return cassandraThreadDAO.deleteSome(username, hashMimeMessageIds).then();
+    }
+
+    private Set<Integer> extractHashedMimeMessageIds(byte[] headerBytes) {
+        try {
+            DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
+            messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
+            messageBuilder.setDecodeMonitor(DecodeMonitor.SILENT);
+            Message message = messageBuilder.parseMessage(new ByteArrayInputStream(headerBytes));
+
+            Optional<MimeMessageId> mimeMessageId = MimeMessageHeadersUtil.parseMimeMessageId(message.getHeader());
+            Optional<MimeMessageId> inReplyTo = MimeMessageHeadersUtil.parseInReplyTo(message.getHeader());
+            Optional<List<MimeMessageId>> references = MimeMessageHeadersUtil.parseReferences(message.getHeader());
+
+            Set<MimeMessageId> allMimeMessageIds = new HashSet<>();
+            mimeMessageId.ifPresent(allMimeMessageIds::add);
+            inReplyTo.ifPresent(allMimeMessageIds::add);
+            references.ifPresent(allMimeMessageIds::addAll);
+
+            return allMimeMessageIds.stream()
+                .map(id -> Hashing.murmur3_32_fixed().hashBytes(id.getValue().getBytes()).asInt())
+                .collect(Collectors.toSet());
+        } catch (IOException e) {
+            LOGGER.warn("Failed to parse message headers for thread cleanup", e);
+            return Set.of();
+        }
     }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
@@ -1,0 +1,101 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.util.DurationParser;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+import spark.Service;
+
+public class UserDataTieringRoutes implements Routes {
+
+    private static final String BASE_PATH = "/users";
+    private static final String USERNAME_PARAM = ":username";
+    private static final String DATA_PATH = BASE_PATH + "/" + USERNAME_PARAM + "/data";
+    private static final String TIERING_PARAM = "tiering";
+
+    private final UserDataTieringService tieringService;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public UserDataTieringRoutes(UserDataTieringService tieringService, JsonTransformer jsonTransformer) {
+        this.tieringService = tieringService;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.post(DATA_PATH, (request, response) -> {
+            Username username = parseUsername(request.params(USERNAME_PARAM));
+            Duration tiering = parseTiering(request.queryParams(TIERING_PARAM));
+
+            tieringService.tierUserData(username, tiering).block();
+
+            response.status(HttpStatus.NO_CONTENT_204);
+            return "";
+        }, jsonTransformer);
+    }
+
+    private Username parseUsername(String rawUsername) {
+        try {
+            return Username.of(rawUsername);
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid username: " + rawUsername)
+                .haltError();
+        }
+    }
+
+    private Duration parseTiering(String rawTiering) {
+        if (rawTiering == null || rawTiering.isBlank()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("'tiering' query parameter is required (e.g. tiering=30d)")
+                .haltError();
+        }
+        try {
+            return DurationParser.parse(rawTiering, ChronoUnit.DAYS);
+        } catch (NumberFormatException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid tiering value '" + rawTiering + "'. Expected a duration like '30d', '7d', '24h'.")
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesModule.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesModule.java
@@ -1,0 +1,32 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import org.apache.james.webadmin.Routes;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class UserDataTieringRoutesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Routes.class)
+            .addBinding().to(UserDataTieringRoutes.class);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
@@ -1,0 +1,140 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.apache.james.core.Username;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+import io.restassured.RestAssured;
+import reactor.core.publisher.Mono;
+
+class UserDataTieringRoutesTest {
+
+    private static final Username BOB = Username.of("bob@example.com");
+
+    private WebAdminServer webAdminServer;
+    private UserDataTieringService tieringService;
+
+    @BeforeEach
+    void setUp() {
+        tieringService = mock(UserDataTieringService.class);
+        when(tieringService.tierUserData(any(), any())).thenReturn(Mono.empty());
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new UserDataTieringRoutes(tieringService, new JsonTransformer()))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Test
+    void postShouldReturn204OnSuccess() {
+        given()
+            .queryParam("tiering", "30d")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+    }
+
+    @Test
+    void postShouldDelegateToService() {
+        given()
+            .queryParam("tiering", "30d")
+        .when()
+            .post("/users/bob@example.com/data");
+
+        verify(tieringService).tierUserData(eq(BOB), eq(Duration.ofDays(30)));
+    }
+
+    @Test
+    void postShouldAcceptHourDuration() {
+        given()
+            .queryParam("tiering", "24h")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+
+        verify(tieringService).tierUserData(eq(BOB), eq(Duration.ofHours(24)));
+    }
+
+    @Test
+    void postShouldReturn400WhenTieringParamMissing() {
+        when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", containsString("tiering"));
+
+        verifyNoInteractions(tieringService);
+    }
+
+    @Test
+    void postShouldReturn400WhenTieringParamBlank() {
+        given()
+            .queryParam("tiering", "")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", containsString("tiering"));
+
+        verifyNoInteractions(tieringService);
+    }
+
+    @Test
+    void postShouldReturn400WhenTieringParamInvalid() {
+        given()
+            .queryParam("tiering", "notaduration")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", containsString("notaduration"));
+
+        verifyNoInteractions(tieringService);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAdmin POST /users/{username}/data to tier user data: clears derived projections and relevant caches for items older than a specified duration while keeping messages and attachments retrievable.

* **Documentation**
  * Added User Data Tiering docs describing the endpoint, tiering parameter formats, and responses (204 on success, 400 on invalid input).

* **Tests**
  * Added route and integration tests covering parsing, validation, 204/400 responses, and end-to-end projection clearing with continued retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->