### PR TITLE
Adopt JRE 26-jre-noble

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <target.jdk>21</target.jdk>
-        <jib.base.image>eclipse-temurin:25-jre-jammy</jib.base.image>
+        <jib.base.image>eclipse-temurin:26-jre-noble</jib.base.image>
     </properties>
 
     <modules>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to use Java 26 and the latest Ubuntu LTS release, improving runtime performance and security posture for containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->