### PR TITLE
[BUILD] EmailGetMethodContract can now run with one server per class

### DIFF
--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedEmailGetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedEmailGetMethodTest.java
@@ -28,13 +28,13 @@ package com.linagora.tmail.james;
 
 import static org.apache.james.MailsShouldBeWellReceived.CALMLY_AWAIT;
 import static org.apache.james.MailsShouldBeWellReceived.DOMAIN;
-import static org.apache.james.MailsShouldBeWellReceived.JAMES_USER;
 import static org.apache.james.MailsShouldBeWellReceived.PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
@@ -151,6 +151,7 @@ public class DistributedEmailGetMethodTest implements EmailGetMethodContract {
             .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
                 .addBinding()
                 .to(MessageIdManagerProbe.class)))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
 
     @Override
@@ -165,13 +166,14 @@ public class DistributedEmailGetMethodTest implements EmailGetMethodContract {
             .getTestingSession()
             .recordStatements();
 
+        String jamesUser = "james-user-" + UUID.randomUUID() + "@" + DOMAIN;
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(jamesUser, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
-        mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
-        MessageId messageId = mailboxProbe.appendMessage(JAMES_USER, MailboxPath.inbox(Username.of(JAMES_USER)),
+        mailboxProbe.createMailbox("#private", jamesUser, DefaultMailboxes.INBOX);
+        MessageId messageId = mailboxProbe.appendMessage(jamesUser, MailboxPath.inbox(Username.of(jamesUser)),
             MessageManager.AppendCommand.from(Message.Builder.of()
                 .setSubject("Subject")
                 .setBody("This is content of the message", StandardCharsets.UTF_8)
@@ -196,13 +198,14 @@ public class DistributedEmailGetMethodTest implements EmailGetMethodContract {
             .getTestingSession()
             .recordStatements();
 
+        String jamesUser = "james-user-" + UUID.randomUUID() + "@" + DOMAIN;
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(jamesUser, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
-        mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
-        MessageId messageId = mailboxProbe.appendMessage(JAMES_USER, MailboxPath.inbox(Username.of(JAMES_USER)),
+        mailboxProbe.createMailbox("#private", jamesUser, DefaultMailboxes.INBOX);
+        MessageId messageId = mailboxProbe.appendMessage(jamesUser, MailboxPath.inbox(Username.of(jamesUser)),
                 MessageManager.AppendCommand.from(Message.Builder.of()
                     .setSubject("Subject")
                     .setBody("This is content of the message", StandardCharsets.UTF_8)
@@ -215,7 +218,7 @@ public class DistributedEmailGetMethodTest implements EmailGetMethodContract {
                 .isPresent());
 
         server.getProbe(MessageIdManagerProbe.class)
-            .delete(Set.of(messageId), Username.of(JAMES_USER))
+            .delete(Set.of(messageId), Username.of(jamesUser))
             .block();
 
         CALMLY_AWAIT

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryEmailGetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryEmailGetMethodTest.java
@@ -55,6 +55,7 @@ public class MemoryEmailGetMethodTest implements EmailGetMethodContract {
         .server(configuration -> MemoryServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule())
             .overrideWith(new DelegationProbeModule()))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
 
     @Override

--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailGetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresEmailGetMethodTest.java
@@ -22,11 +22,11 @@ import static com.linagora.tmail.james.TmailJmapBase.MESSAGE_ID_FACTORY;
 import static com.linagora.tmail.james.app.PostgresTmailConfiguration.EventBusImpl.RABBITMQ;
 import static org.apache.james.MailsShouldBeWellReceived.CALMLY_AWAIT;
 import static org.apache.james.MailsShouldBeWellReceived.DOMAIN;
-import static org.apache.james.MailsShouldBeWellReceived.JAMES_USER;
 import static org.apache.james.MailsShouldBeWellReceived.PASSWORD;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.UUID;
 
 import org.apache.james.ClockExtension;
 import org.apache.james.GuiceJamesServer;
@@ -111,6 +111,7 @@ class PostgresEmailGetMethodTest implements EmailGetMethodContract {
         .extension(new DockerOpenSearchExtension())
         .extension(new RabbitMQExtension())
         .extension(new ClockExtension())
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
 
     @Override
@@ -121,13 +122,14 @@ class PostgresEmailGetMethodTest implements EmailGetMethodContract {
     @Tag(BasicFeature.TAG)
     @Test
     void jmapPreviewShouldBeWellPreComputed(GuiceJamesServer server) throws Exception {
+        String jamesUser = "james-user-" + UUID.randomUUID() + "@" + DOMAIN;
         server.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(JAMES_USER, PASSWORD);
+            .addUser(jamesUser, PASSWORD);
 
         MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
-        mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
-        MessageId messageId = mailboxProbe.appendMessage(JAMES_USER, MailboxPath.inbox(Username.of(JAMES_USER)),
+        mailboxProbe.createMailbox("#private", jamesUser, DefaultMailboxes.INBOX);
+        MessageId messageId = mailboxProbe.appendMessage(jamesUser, MailboxPath.inbox(Username.of(jamesUser)),
                 MessageManager.AppendCommand.from(Message.Builder.of()
                     .setSubject("Subject")
                     .setBody("This is content of the message", StandardCharsets.UTF_8)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test isolation by implementing dynamic user generation for test runs, replacing static identifiers.
  * Improved test server lifecycle management configuration across JMAP integration test suites to ensure proper resource handling between test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->