### PR TITLE
Switch to JDK 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 pipeline {
     agent any
 
+    tools {
+        jdk 'jdk_25'
+    }
+
     environment {
         DOCKER_HUB_CREDENTIAL = credentials('dockerHub')
     }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <target.jdk>21</target.jdk>
+        <target.jdk>25</target.jdk>
         <jib.base.image>eclipse-temurin:26-jre-noble</jib.base.image>
     </properties>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Java compilation target from 21 to 25.
  * Build pipeline configured to use JDK 25 for compilation and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->