### PR TITLE
[FIX] CalendarEvent/reply needs to warn upon cancelled events

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/calendarEventReply.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/calendarEventReply.adoc
@@ -97,13 +97,47 @@ If the blob id has been found but is not generate & reply email, the server woul
 }, "c1" ]]
 ```
 
+When deployed with OpenPaaS CalDAV, if the event referenced by the blob does not exist in the user's CalDAV calendar (e.g. the organizer deleted the event without sending a CANCEL iTIP), the server would respond:
+
+```
+[[ "CalendarEvent/accept",
+{
+    "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+    "notAccepted": {
+        "0f9f65ab-dc7b-4146-850f-6e4881093965": {
+            "type": "eventNotFound",
+            "description": "The event you reply to does not exist on your calendar"
+        }
+    }
+}, "c1" ]]
+```
+
+When deployed with OpenPaaS CalDAV, if the event referenced by the blob exists in the user's CalDAV calendar but has `STATUS:CANCELLED` (e.g. the organizer deleted the event and OpenPaaS propagated the cancellation to the attendee's calendar), the server would respond:
+
+```
+[[ "CalendarEvent/accept",
+{
+    "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+    "notAccepted": {
+        "0f9f65ab-dc7b-4146-850f-6e4881093965": {
+            "type": "eventCancelled",
+            "description": "The event you reply to has been cancelled"
+        }
+    }
+}, "c1" ]]
+```
+
 == CalendarEvent/reject
 Similarly to CalendarEvent/accept, CalendarEvent/reject function in a similar manner.
 However, in the response properties, 'rejected' replace 'accepted', while 'notRejected' replace 'notAccepted'.
 
+All error cases described for `CalendarEvent/accept` (`notFound`, `invalidPatch`, `eventNotFound`, `eventCancelled`) apply identically to this method.
+
 == CalendarEvent/maybe
 Similarly to CalendarEvent/accept, CalendarEvent/maybe function in a similar manner.
 However, in the response properties, 'maybe' replace 'accepted', while 'notMaybe' replace 'notAccepted'.
+
+All error cases described for `CalendarEvent/accept` (`notFound`, `invalidPatch`, `eventNotFound`, `eventCancelled`) apply identically to this method.
 
 == CalendarEventAttendance/get
 This method allow clients to get the attendance status of a calendar event invitation.

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/CalendarEventCancelledException.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/CalendarEventCancelledException.java
@@ -1,0 +1,30 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap;
+
+import org.apache.james.core.Username;
+
+import com.linagora.tmail.james.jmap.model.CalendarUidField;
+
+public class CalendarEventCancelledException extends RuntimeException {
+
+    public CalendarEventCancelledException(Username username, CalendarUidField eventUid) {
+        super("Calendar event is cancelled for user " + username.asString() + " and eventUid " + eventUid.value());
+    }
+}

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -18,7 +18,7 @@
 
 package com.linagora.tmail.james.jmap.model
 
-import com.linagora.tmail.james.jmap.CalendarEventNotFoundException
+import com.linagora.tmail.james.jmap.{CalendarEventCancelledException, CalendarEventNotFoundException}
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.NoUpdateRequiredException
 import eu.timepit.refined.auto._
 import org.apache.james.jmap.core.SetError
@@ -60,6 +60,9 @@ object CalendarEventReplyResults {
     case _: CalendarEventNotFoundException =>
       LOGGER.info("Error when replying to event invitation for {}: {}", username, throwable.getMessage)
       SetError("eventNotFound", SetErrorDescription("The event you reply to does not exist on your calendar"), None)
+    case _: CalendarEventCancelledException =>
+      LOGGER.info("Error when replying to event invitation for {}: {}", username, throwable.getMessage)
+      SetError("eventCancelled", SetErrorDescription("The event you reply to has been cancelled"), None)
     case _ =>
       LOGGER.error("serverFail to reply event invitation for {}", username, throwable)
       SetError.serverFail(SetErrorDescription(throwable.getMessage))

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventReplyResults.scala
@@ -18,8 +18,8 @@
 
 package com.linagora.tmail.james.jmap.model
 
-import com.linagora.tmail.james.jmap.{CalendarEventCancelledException, CalendarEventNotFoundException}
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier.NoUpdateRequiredException
+import com.linagora.tmail.james.jmap.{CalendarEventCancelledException, CalendarEventNotFoundException}
 import eu.timepit.refined.auto._
 import org.apache.james.jmap.core.SetError
 import org.apache.james.jmap.core.SetError.SetErrorDescription

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
@@ -21,6 +21,7 @@ package com.linagora.tmail.dav;
 import static com.linagora.tmail.james.jmap.model.CalendarEventAttendanceResults.AttendanceResult;
 import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
+import java.time.temporal.Temporal;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -52,6 +53,7 @@ import com.linagora.tmail.james.jmap.model.RecurrenceIdField;
 
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.RecurrenceId;
 import net.fortuna.ical4j.model.property.Status;
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 import reactor.core.publisher.Flux;
@@ -156,7 +158,7 @@ public class CalDavEventRepository implements CalendarEventRepository {
         return davUserProvider.provide(username)
             .flatMap(davUser -> davClient.caldav(davUser.username()).getCalendarObjects(davUser, DavUid.fromCalendarUidField(eventUid))
                 .switchIfEmpty(Flux.error(new CalendarEventNotFoundException(username, eventUid)))
-                .flatMap(calendarObject -> doUpdateCalendarObject(davUser, calendarObject, username, eventUid, updateEventOperator))
+                .flatMap(calendarObject -> doUpdateCalendarObject(davUser, calendarObject, username, eventUid, updateEventOperator, eventModifier))
                 .next()
                 .switchIfEmpty(Mono.error(new CalendarEventNotFoundException(username, eventUid)))
                 .then());
@@ -164,8 +166,9 @@ public class CalDavEventRepository implements CalendarEventRepository {
 
     private Mono<Boolean> doUpdateCalendarObject(DavUser davUser, DavCalendarObject calendarObject,
                                                   Username username, CalendarUidField eventUid,
-                                                  UnaryOperator<DavCalendarObject> updateEventOperator) {
-        if (isCancelled(calendarObject)) {
+                                                  UnaryOperator<DavCalendarObject> updateEventOperator,
+                                                  CalendarEventModifier eventModifier) {
+        if (isCancelled(calendarObject, eventModifier)) {
             return Mono.error(new CalendarEventCancelledException(username, eventUid));
         }
         return davClient.caldav(davUser.username()).updateCalendarObject(calendarObject.uri(), updateEventOperator)
@@ -176,10 +179,14 @@ public class CalDavEventRepository implements CalendarEventRepository {
             });
     }
 
-    private boolean isCancelled(DavCalendarObject calendarObject) {
+    private boolean isCancelled(DavCalendarObject calendarObject, CalendarEventModifier eventModifier) {
+        Optional<RecurrenceId<Temporal>> recurrenceId = scala.jdk.javaapi.OptionConverters.toJava(eventModifier.recurrenceId());
         return calendarObject.calendarData().getComponents(Component.VEVENT).stream()
             .filter(c -> c instanceof VEvent)
             .map(c -> (VEvent) c)
+            .filter(vEvent -> recurrenceId
+                .map(rid -> rid.equals(vEvent.getRecurrenceId()))
+                .orElseGet(() -> vEvent.getRecurrenceId() == null))
             .findFirst()
             .map(VEvent::getStatus)
             .map(status -> Status.VALUE_CANCELLED.equals(status.getValue()))

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import com.linagora.tmail.dav.cal.FreeBusyRequest;
 import com.linagora.tmail.dav.cal.FreeBusyResponse;
 import com.linagora.tmail.james.jmap.AttendanceStatus;
+import com.linagora.tmail.james.jmap.CalendarEventCancelledException;
 import com.linagora.tmail.james.jmap.CalendarEventNotFoundException;
 import com.linagora.tmail.james.jmap.CalendarEventRepository;
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier;
@@ -49,6 +50,9 @@ import com.linagora.tmail.james.jmap.model.CalendarUidField;
 import com.linagora.tmail.james.jmap.model.EventAttendanceStatusEntry;
 import com.linagora.tmail.james.jmap.model.RecurrenceIdField;
 
+import net.fortuna.ical4j.model.Component;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.Status;
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -152,15 +156,34 @@ public class CalDavEventRepository implements CalendarEventRepository {
         return davUserProvider.provide(username)
             .flatMap(davUser -> davClient.caldav(davUser.username()).getCalendarObjects(davUser, DavUid.fromCalendarUidField(eventUid))
                 .switchIfEmpty(Flux.error(new CalendarEventNotFoundException(username, eventUid)))
-                .flatMap(calendarObject -> davClient.caldav(davUser.username()).updateCalendarObject(calendarObject.uri(), updateEventOperator)
-                    .thenReturn(Boolean.TRUE)
-                    .onErrorResume(DavClientException.PermissionDenied.class, e -> {
-                        LOGGER.debug("Skipping calendar object '{}': permission denied, likely a delegated calendar", calendarObject.uri());
-                        return Mono.empty();
-                    }))
+                .flatMap(calendarObject -> doUpdateCalendarObject(davUser, calendarObject, username, eventUid, updateEventOperator))
                 .next()
                 .switchIfEmpty(Mono.error(new CalendarEventNotFoundException(username, eventUid)))
                 .then());
+    }
+
+    private Mono<Boolean> doUpdateCalendarObject(DavUser davUser, DavCalendarObject calendarObject,
+                                                  Username username, CalendarUidField eventUid,
+                                                  UnaryOperator<DavCalendarObject> updateEventOperator) {
+        if (isCancelled(calendarObject)) {
+            return Mono.error(new CalendarEventCancelledException(username, eventUid));
+        }
+        return davClient.caldav(davUser.username()).updateCalendarObject(calendarObject.uri(), updateEventOperator)
+            .thenReturn(Boolean.TRUE)
+            .onErrorResume(DavClientException.PermissionDenied.class, e -> {
+                LOGGER.debug("Skipping calendar object '{}': permission denied, likely a delegated calendar", calendarObject.uri());
+                return Mono.empty();
+            });
+    }
+
+    private boolean isCancelled(DavCalendarObject calendarObject) {
+        return calendarObject.calendarData().getComponents(Component.VEVENT).stream()
+            .filter(c -> c instanceof VEvent)
+            .map(c -> (VEvent) c)
+            .findFirst()
+            .map(VEvent::getStatus)
+            .map(status -> Status.VALUE_CANCELLED.equals(status.getValue()))
+            .orElse(false);
     }
 
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CalDavEventRepository.java
@@ -168,14 +168,19 @@ public class CalDavEventRepository implements CalendarEventRepository {
                                                   Username username, CalendarUidField eventUid,
                                                   UnaryOperator<DavCalendarObject> updateEventOperator,
                                                   CalendarEventModifier eventModifier) {
-        if (isCancelled(calendarObject, eventModifier)) {
-            return Mono.error(new CalendarEventCancelledException(username, eventUid));
-        }
+        // Cancellation is checked after the write: PermissionDenied is the only reliable delegated-calendar guard.
+        // Writing PARTSTAT on a cancelled event is acceptable (invisible to the user); the error below prevents a false success.
         return davClient.caldav(davUser.username()).updateCalendarObject(calendarObject.uri(), updateEventOperator)
             .thenReturn(Boolean.TRUE)
             .onErrorResume(DavClientException.PermissionDenied.class, e -> {
                 LOGGER.debug("Skipping calendar object '{}': permission denied, likely a delegated calendar", calendarObject.uri());
                 return Mono.empty();
+            })
+            .flatMap(updated -> {
+                if (isCancelled(calendarObject, eventModifier)) {
+                    return Mono.<Boolean>error(new CalendarEventCancelledException(username, eventUid));
+                }
+                return Mono.just(Boolean.TRUE);
             });
     }
 

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavEventRepositoryTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavEventRepositoryTest.java
@@ -854,6 +854,82 @@ class CalDavEventRepositoryTest {
             .hasMessageContaining("Calendar event is cancelled");
     }
 
+    @Test
+    void setAttendanceStatusShouldThrowWhenTargetedRecurrenceOverrideIsCancelled() {
+        String eventUid = UUID.randomUUID().toString();
+        String calendarWithCancelledOverride = "BEGIN:VCALENDAR\n" +
+            "VERSION:2.0\n" +
+            "PRODID:-//Sabre//Sabre VObject 4.5.7//EN\n" +
+            "BEGIN:VEVENT\n" +
+            "UID:" + eventUid + "\n" +
+            "DTSTART;TZID=Europe/Paris:20250328T090000\n" +
+            "DTEND;TZID=Europe/Paris:20250328T100000\n" +
+            "RRULE:FREQ=WEEKLY;COUNT=4;BYDAY=WE\n" +
+            "ORGANIZER;CN=organizer:mailto:organizer@open-paas.org\n" +
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:" + openPaasUser.email().asString() + "\n" +
+            "END:VEVENT\n" +
+            "BEGIN:VEVENT\n" +
+            "UID:" + eventUid + "\n" +
+            "DTSTART;TZID=Europe/Paris:20250409T090000\n" +
+            "DTEND;TZID=Europe/Paris:20250409T100000\n" +
+            "RECURRENCE-ID;TZID=Europe/Paris:20250409T090000\n" +
+            "ORGANIZER;CN=organizer:mailto:organizer@open-paas.org\n" +
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:" + openPaasUser.email().asString() + "\n" +
+            "STATUS:CANCELLED\n" +
+            "DTSTAMP:20250401T000000Z\n" +
+            "END:VEVENT\n" +
+            "END:VCALENDAR\n";
+
+        davClient.caldav(openPaasUser.email()).createCalendar(
+                URI.create("/calendars/" + openPaasUser.id().value() + "/" + openPaasUser.id().value() + "/" + eventUid + ".ics"),
+                CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(calendarWithCancelledOverride.getBytes(StandardCharsets.UTF_8))))
+            .block();
+
+        BlobId blobId = setupCalendarResolver(eventUid, Optional.of("RECURRENCE-ID;TZID=Europe/Paris:20250409T090000"));
+
+        assertThatThrownBy(() -> testee.setAttendanceStatus(testUser, AttendanceStatus.Accepted, blobId).block())
+            .isInstanceOf(CalendarEventCancelledException.class)
+            .hasMessageContaining("Calendar event is cancelled");
+    }
+
+    @Test
+    void setAttendanceStatusShouldSucceedForMasterWhenOnlyOverrideIsCancelled() {
+        String eventUid = UUID.randomUUID().toString();
+        String calendarWithCancelledOverride = "BEGIN:VCALENDAR\n" +
+            "VERSION:2.0\n" +
+            "PRODID:-//Sabre//Sabre VObject 4.5.7//EN\n" +
+            "BEGIN:VEVENT\n" +
+            "UID:" + eventUid + "\n" +
+            "DTSTART;TZID=Europe/Paris:20250328T090000\n" +
+            "DTEND;TZID=Europe/Paris:20250328T100000\n" +
+            "RRULE:FREQ=WEEKLY;COUNT=4;BYDAY=WE\n" +
+            "ORGANIZER;CN=organizer:mailto:organizer@open-paas.org\n" +
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:" + openPaasUser.email().asString() + "\n" +
+            "END:VEVENT\n" +
+            "BEGIN:VEVENT\n" +
+            "UID:" + eventUid + "\n" +
+            "DTSTART;TZID=Europe/Paris:20250409T090000\n" +
+            "DTEND;TZID=Europe/Paris:20250409T100000\n" +
+            "RECURRENCE-ID;TZID=Europe/Paris:20250409T090000\n" +
+            "ORGANIZER;CN=organizer:mailto:organizer@open-paas.org\n" +
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:" + openPaasUser.email().asString() + "\n" +
+            "STATUS:CANCELLED\n" +
+            "DTSTAMP:20250401T000000Z\n" +
+            "END:VEVENT\n" +
+            "END:VCALENDAR\n";
+
+        davClient.caldav(openPaasUser.email()).createCalendar(
+                URI.create("/calendars/" + openPaasUser.id().value() + "/" + openPaasUser.id().value() + "/" + eventUid + ".ics"),
+                CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(calendarWithCancelledOverride.getBytes(StandardCharsets.UTF_8))))
+            .block();
+
+        // No RECURRENCE-ID in the resolver: targets the master event, which is not cancelled
+        BlobId blobId = setupCalendarResolver(eventUid);
+
+        assertThatCode(() -> testee.setAttendanceStatus(testUser, AttendanceStatus.Accepted, blobId).block())
+            .doesNotThrowAnyException();
+    }
+
     private Calendar stringAsCalendar(String input) {
         return CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
     }

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavEventRepositoryTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavEventRepositoryTest.java
@@ -57,6 +57,7 @@ import com.linagora.tmail.dav.DavUser;
 import com.linagora.tmail.dav.DavUid;
 import com.linagora.tmail.dav.OpenPaasDavUserProvider;
 import com.linagora.tmail.james.jmap.AttendanceStatus;
+import com.linagora.tmail.james.jmap.CalendarEventCancelledException;
 import com.linagora.tmail.james.jmap.CalendarEventNotFoundException;
 import com.linagora.tmail.james.jmap.calendar.CalendarEventHelper;
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier;
@@ -822,6 +823,35 @@ class CalDavEventRepositoryTest {
                 "ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=John2 Doe2;SCHEDULE-STATUS=1.2;PARTSTAT=ACCEPTED:mailto:" + openPaasUser.email().asString() +"\n" +
                 "END:VEVENT\n" +
                 "END:VCALENDAR\n".trim());
+    }
+
+    @Test
+    void setAttendanceStatusShouldThrowWhenEventIsCancelled() {
+        String eventUid = UUID.randomUUID().toString();
+        String cancelledCalendar = "BEGIN:VCALENDAR\n" +
+            "VERSION:2.0\n" +
+            "PRODID:-//Sabre//Sabre VObject 4.5.7//EN\n" +
+            "BEGIN:VEVENT\n" +
+            "UID:" + eventUid + "\n" +
+            "DTSTART;TZID=Europe/Paris:20260424T123000\n" +
+            "DTEND;TZID=Europe/Paris:20260424T133000\n" +
+            "ORGANIZER;CN=organizer:mailto:organizer@open-paas.org\n" +
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=John2 Doe2:mailto:" + openPaasUser.email().asString() + "\n" +
+            "STATUS:CANCELLED\n" +
+            "DTSTAMP:20260420T134701Z\n" +
+            "END:VEVENT\n" +
+            "END:VCALENDAR\n";
+
+        davClient.caldav(openPaasUser.email()).createCalendar(
+                URI.create("/calendars/" + openPaasUser.id().value() + "/" + openPaasUser.id().value() + "/" + eventUid + ".ics"),
+                CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(cancelledCalendar.getBytes(StandardCharsets.UTF_8))))
+            .block();
+
+        BlobId blobId = setupCalendarResolver(eventUid);
+
+        assertThatThrownBy(() -> testee.setAttendanceStatus(testUser, AttendanceStatus.Accepted, blobId).block())
+            .isInstanceOf(CalendarEventCancelledException.class)
+            .hasMessageContaining("Calendar event is cancelled");
     }
 
     private Calendar stringAsCalendar(String input) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reply operations now detect cancelled calendar events and return a dedicated "eventCancelled" error instead of generic failures.

* **Documentation**
  * API docs updated with `eventCancelled` examples and clarified that the same error cases apply to accept/reject/maybe responses.

* **Tests**
  * New tests added to validate error handling when replying to cancelled calendar events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->