### PR TITLE
ISSUE-2341 Leverage task for Data User Tiering

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1409,7 +1409,7 @@ The following data is cleared:
   - Attachments projection (attachment are still parseable via the raw Mime message as a fallback)
   - Thread guessing table (`thread_2`) — deleted for this message
 
-The operation is synchronous and returns once all deletions are complete. 
+The operation is asynchronous and returns a task identifier that can be polled for completion.
 
 === Tier a user's data
 
@@ -1421,11 +1421,15 @@ Query parameters:
 
 - `tiering` (required): retention period expressed as an ISO-8601 duration or a shorthand such as
   `30d`, `12h`, `1w`. Messages older than this period have their cached data evicted.
+- `messagesPerSecond` (optional, default: 50): maximum number of messages processed per second.
+  Lower values reduce pressure on Cassandra and the blob store during large accounts.
 
 Return codes:
 
-- `204` Operation completed successfully
-- `400` Invalid username or missing / unparseable `tiering` parameter
+- `201` Task created — response body contains `{"taskId": "<id>"}`.
+  Use `GET /tasks/{taskId}/await` to wait for completion and inspect metrics
+  (`tieredMessageCount`, `failedMessageCount`) in the task's `additionalInformation`.
+- `400` Invalid username, missing / unparseable `tiering`, or invalid `messagesPerSecond`
 
 == User Mails Search
 

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -229,6 +229,7 @@ import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
 import com.linagora.tmail.webadmin.data.DomainTasksModule;
 import com.linagora.tmail.webadmin.data.UserDataTieringRoutesModule;
+import com.linagora.tmail.webadmin.data.UserDataTieringTaskModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
@@ -293,7 +294,8 @@ public class DistributedServer {
         new VacationRoutesModule(),
         new ContactIndexingModule(),
         new PopulateKeywordEmailQueryViewTaskModule(),
-        new UserDataTieringRoutesModule());
+        new UserDataTieringRoutesModule(),
+        new UserDataTieringTaskModule());
 
     public static final Module JMAP = Modules.override(
         new TMailJMAPModule(),

--- a/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringContext.java
+++ b/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringContext.java
@@ -18,22 +18,24 @@
 
 package com.linagora.tmail.tiering;
 
-import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.james.core.Username;
+public class UserDataTieringContext {
 
-import reactor.core.publisher.Mono;
+    public record Snapshot(long tieredMessageCount, long failedMessageCount) {}
 
-public interface UserDataTieringService {
-    /**
-     * Tiers user data by:
-     * - Clearing the JMAP /changes projection (email and mailbox changes)
-     * - Clearing the thread-guessing table for the user
-     * - For messages older than {@code tiering}, clearing their fast-view projection,
-     *   clearing their attachments
-     *   and evicting their header blobs from the blob-store cache
-     *
-     * Per-message successes and failures are reported to {@code context}.
-     */
-    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context);
+    private final AtomicLong tieredMessageCount = new AtomicLong();
+    private final AtomicLong failedMessageCount = new AtomicLong();
+
+    public void incrementTiered() {
+        tieredMessageCount.incrementAndGet();
+    }
+
+    public void incrementFailed() {
+        failedMessageCount.incrementAndGet();
+    }
+
+    public Snapshot snapshot() {
+        return new Snapshot(tieredMessageCount.get(), failedMessageCount.get());
+    }
 }

--- a/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringService.java
+++ b/tmail-backend/data/data-extra-api/src/main/java/com/linagora/tmail/tiering/UserDataTieringService.java
@@ -35,5 +35,5 @@ public interface UserDataTieringService {
      *
      * Per-message successes and failures are reported to {@code context}.
      */
-    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context);
+    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context, int messagesPerSecond);
 }

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -81,7 +81,7 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraUserDataTieringService.class);
     private static final String EMAIL_CHANGE_TABLE = "email_change";
     private static final String MAILBOX_CHANGE_TABLE = "mailbox_change";
-    private static final int LOW_CONCURRENCY = 2;
+    private static final int LOW_CONCURRENCY = 8;
 
     private final CassandraAsyncExecutor executor;
     private final PreparedStatement deleteEmailChanges;

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -70,6 +70,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.google.common.hash.Hashing;
 import com.linagora.tmail.blob.guice.BlobStoreCacheCleaner;
+import com.linagora.tmail.tiering.UserDataTieringContext;
 import com.linagora.tmail.tiering.UserDataTieringService;
 
 import reactor.core.publisher.Flux;
@@ -125,13 +126,14 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
     }
 
     @Override
-    public Mono<Void> tierUserData(Username username, Duration tiering) {
+    public Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context) {
         Date tieringDate = Date.from(Instant.now().minus(tiering));
         AccountId accountId = AccountId.fromUsername(username);
         MailboxSession session = mailboxManager.createSystemSession(username);
 
-        return clearChanges(accountId)
-            .then(clearOldMessageProjections(username, tieringDate, session));
+        return Mono.when(
+            clearChanges(accountId),
+            clearOldMessageProjections(username, tieringDate, session, context));
     }
 
     private Mono<Void> clearChanges(AccountId accountId) {
@@ -141,18 +143,18 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
                 .set(ACCOUNT_ID, accountId.getIdentifier(), TypeCodecs.TEXT)));
     }
 
-    private Mono<Void> clearOldMessageProjections(Username username, Date tieringDate, MailboxSession session) {
+    private Mono<Void> clearOldMessageProjections(Username username, Date tieringDate, MailboxSession session, UserDataTieringContext context) {
         return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), session)
             .map(metaData -> (CassandraId) metaData.getId())
             .flatMap(mailboxId -> cassandraMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()), LOW_CONCURRENCY)
             .filter(metadata -> metadata.getInternalDate()
                 .map(d -> d.before(tieringDate))
                 .orElse(false))
-            .flatMap(metadata -> applyTiering(username, metadata), LOW_CONCURRENCY)
+            .flatMap(metadata -> applyTiering(username, metadata, context), LOW_CONCURRENCY)
             .then();
     }
 
-    private Mono<Void> applyTiering(Username username, CassandraMessageMetadata metadata) {
+    private Mono<Void> applyTiering(Username username, CassandraMessageMetadata metadata, UserDataTieringContext context) {
         CassandraMessageId messageId = (CassandraMessageId) metadata.getComposedMessageId().getComposedMessageId().getMessageId();
 
         Mono<Void> clearFastView = Mono.from(messageFastViewProjection.delete(messageId));
@@ -168,7 +170,13 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
             .flatMap(attachment -> cassandraAttachmentDAOV2.delete(attachment.getAttachmentId()))
             .then();
 
-        return Mono.when(clearFastView, clearThreadAndHeaderCache, clearAttachments);
+        return Mono.when(clearFastView, clearThreadAndHeaderCache, clearAttachments)
+            .doOnSuccess(__ -> context.incrementTiered())
+            .onErrorResume(e -> {
+                LOGGER.warn("Failed to apply tiering for message {}", messageId, e);
+                context.incrementFailed();
+                return Mono.empty();
+            });
     }
 
     private Mono<Void> clearThreadEntries(Username username, byte[] headerBytes) {

--- a/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
+++ b/tmail-backend/guice/data-cassandra/src/main/java/com/linagora/tmail/modules/data/CassandraUserDataTieringService.java
@@ -61,6 +61,7 @@ import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.util.ReactorUtils;
 import org.apache.james.util.streams.Limit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,8 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraUserDataTieringService.class);
     private static final String EMAIL_CHANGE_TABLE = "email_change";
     private static final String MAILBOX_CHANGE_TABLE = "mailbox_change";
-    private static final int LOW_CONCURRENCY = 8;
+    private static final Duration PERIOD = Duration.ofSeconds(1);
+    private static final int MAILBOX_CONCURRENCY = 4;
 
     private final CassandraAsyncExecutor executor;
     private final PreparedStatement deleteEmailChanges;
@@ -126,14 +128,14 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
     }
 
     @Override
-    public Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context) {
+    public Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context, int messagesPerSecond) {
         Date tieringDate = Date.from(Instant.now().minus(tiering));
         AccountId accountId = AccountId.fromUsername(username);
         MailboxSession session = mailboxManager.createSystemSession(username);
 
         return Mono.when(
             clearChanges(accountId),
-            clearOldMessageProjections(username, tieringDate, session, context));
+            clearOldMessageProjections(username, tieringDate, session, context, messagesPerSecond));
     }
 
     private Mono<Void> clearChanges(AccountId accountId) {
@@ -143,14 +145,18 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
                 .set(ACCOUNT_ID, accountId.getIdentifier(), TypeCodecs.TEXT)));
     }
 
-    private Mono<Void> clearOldMessageProjections(Username username, Date tieringDate, MailboxSession session, UserDataTieringContext context) {
+    private Mono<Void> clearOldMessageProjections(Username username, Date tieringDate, MailboxSession session,
+                                                    UserDataTieringContext context, int messagesPerSecond) {
         return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), session)
             .map(metaData -> (CassandraId) metaData.getId())
-            .flatMap(mailboxId -> cassandraMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()), LOW_CONCURRENCY)
+            .flatMap(mailboxId -> cassandraMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()), MAILBOX_CONCURRENCY)
             .filter(metadata -> metadata.getInternalDate()
                 .map(d -> d.before(tieringDate))
                 .orElse(false))
-            .flatMap(metadata -> applyTiering(username, metadata, context), LOW_CONCURRENCY)
+            .transform(ReactorUtils.<CassandraMessageMetadata, Void>throttle()
+                .elements(messagesPerSecond)
+                .per(PERIOD)
+                .forOperation(metadata -> applyTiering(username, metadata, context)))
             .then();
     }
 
@@ -171,7 +177,7 @@ public class CassandraUserDataTieringService implements UserDataTieringService {
             .then();
 
         return Mono.when(clearFastView, clearThreadAndHeaderCache, clearAttachments)
-            .doOnSuccess(__ -> context.incrementTiered())
+            .doOnSuccess(any -> context.incrementTiered())
             .onErrorResume(e -> {
                 LOGGER.warn("Failed to apply tiering for message {}", messageId, e);
                 context.incrementFailed();

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/RunningOptions.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/RunningOptions.java
@@ -18,35 +18,13 @@
 
 package com.linagora.tmail.webadmin.data;
 
-import java.time.Instant;
+import com.google.common.base.Preconditions;
 
-import org.apache.james.JsonSerializationVerifier;
-import org.junit.jupiter.api.Test;
+public record RunningOptions(int messagesPerSecond) {
 
-class UserDataTieringTaskAdditionalInformationDTOTest {
+    public static final RunningOptions DEFAULT = new RunningOptions(50);
 
-    @Test
-    void beanTest() throws Exception {
-        JsonSerializationVerifier.dtoModule(UserDataTieringTaskAdditionalInformationDTO.module())
-            .bean(new UserDataTieringTask.AdditionalInformation(
-                Instant.parse("2007-12-03T10:15:30.00Z"),
-                "bob@domain.tld",
-                2592000L,
-                RunningOptions.DEFAULT,
-                42L,
-                3L))
-            .json("""
-                {
-                  "type": "UserDataTieringTask",
-                  "timestamp": "2007-12-03T10:15:30Z",
-                  "username": "bob@domain.tld",
-                  "tieringSeconds": 2592000,
-                  "runningOptions": {
-                    "messagesPerSecond": 50
-                  },
-                  "tieredMessageCount": 42,
-                  "failedMessageCount": 3
-                }""")
-            .verify();
+    public RunningOptions {
+        Preconditions.checkArgument(messagesPerSecond > 0, "'messagesPerSecond' must be strictly positive");
     }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
@@ -43,6 +43,7 @@ public class UserDataTieringRoutes implements Routes {
     private static final String USERNAME_PARAM = ":username";
     private static final String DATA_PATH = BASE_PATH + "/" + USERNAME_PARAM + "/data";
     private static final String TIERING_PARAM = "tiering";
+    private static final String MESSAGES_PER_SECOND_PARAM = "messagesPerSecond";
 
     private final UserDataTieringService tieringService;
     private final TaskManager taskManager;
@@ -69,7 +70,23 @@ public class UserDataTieringRoutes implements Routes {
     private UserDataTieringTask createTask(Request request) {
         Username username = parseUsername(request.params(USERNAME_PARAM));
         Duration tiering = parseTiering(request.queryParams(TIERING_PARAM));
-        return new UserDataTieringTask(tieringService, username, tiering);
+        RunningOptions runningOptions = parseMessagesPerSecond(request.queryParams(MESSAGES_PER_SECOND_PARAM));
+        return new UserDataTieringTask(tieringService, username, tiering, runningOptions);
+    }
+
+    private RunningOptions parseMessagesPerSecond(String rawMessagesPerSecond) {
+        if (rawMessagesPerSecond == null) {
+            return RunningOptions.DEFAULT;
+        }
+        try {
+            return new RunningOptions(Integer.parseInt(rawMessagesPerSecond));
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid messagesPerSecond value '" + rawMessagesPerSecond + "'. Expected a strictly positive integer.")
+                .haltError();
+        }
     }
 
     private Username parseUsername(String rawUsername) {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutes.java
@@ -24,14 +24,17 @@ import java.time.temporal.ChronoUnit;
 import jakarta.inject.Inject;
 
 import org.apache.james.core.Username;
+import org.apache.james.task.TaskManager;
 import org.apache.james.util.DurationParser;
 import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.tasks.TaskFromRequest;
 import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
 import com.linagora.tmail.tiering.UserDataTieringService;
 
+import spark.Request;
 import spark.Service;
 
 public class UserDataTieringRoutes implements Routes {
@@ -42,11 +45,13 @@ public class UserDataTieringRoutes implements Routes {
     private static final String TIERING_PARAM = "tiering";
 
     private final UserDataTieringService tieringService;
+    private final TaskManager taskManager;
     private final JsonTransformer jsonTransformer;
 
     @Inject
-    public UserDataTieringRoutes(UserDataTieringService tieringService, JsonTransformer jsonTransformer) {
+    public UserDataTieringRoutes(UserDataTieringService tieringService, TaskManager taskManager, JsonTransformer jsonTransformer) {
         this.tieringService = tieringService;
+        this.taskManager = taskManager;
         this.jsonTransformer = jsonTransformer;
     }
 
@@ -57,15 +62,14 @@ public class UserDataTieringRoutes implements Routes {
 
     @Override
     public void define(Service service) {
-        service.post(DATA_PATH, (request, response) -> {
-            Username username = parseUsername(request.params(USERNAME_PARAM));
-            Duration tiering = parseTiering(request.queryParams(TIERING_PARAM));
+        TaskFromRequest taskFromRequest = this::createTask;
+        service.post(DATA_PATH, taskFromRequest.asRoute(taskManager), jsonTransformer);
+    }
 
-            tieringService.tierUserData(username, tiering).block();
-
-            response.status(HttpStatus.NO_CONTENT_204);
-            return "";
-        }, jsonTransformer);
+    private UserDataTieringTask createTask(Request request) {
+        Username username = parseUsername(request.params(USERNAME_PARAM));
+        Duration tiering = parseTiering(request.queryParams(TIERING_PARAM));
+        return new UserDataTieringTask(tieringService, username, tiering);
     }
 
     private Username parseUsername(String rawUsername) {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTask.java
@@ -1,0 +1,99 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.linagora.tmail.tiering.UserDataTieringContext;
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+public class UserDataTieringTask implements Task {
+
+    public static final TaskType TASK_TYPE = TaskType.of("UserDataTieringTask");
+
+    public record AdditionalInformation(
+        Instant timestamp,
+        String username,
+        long tieringSeconds,
+        long tieredMessageCount,
+        long failedMessageCount
+    ) implements TaskExecutionDetails.AdditionalInformation {
+
+        static AdditionalInformation from(UserDataTieringTask task) {
+            UserDataTieringContext.Snapshot snapshot = task.context.snapshot();
+            return new AdditionalInformation(
+                Clock.systemUTC().instant(),
+                task.username.asString(),
+                task.tiering.getSeconds(),
+                snapshot.tieredMessageCount(),
+                snapshot.failedMessageCount());
+        }
+    }
+
+    private final UserDataTieringService tieringService;
+    private final Username username;
+    private final Duration tiering;
+    private final UserDataTieringContext context;
+
+    public UserDataTieringTask(UserDataTieringService tieringService, Username username, Duration tiering) {
+        this.tieringService = tieringService;
+        this.username = username;
+        this.tiering = tiering;
+        this.context = new UserDataTieringContext();
+    }
+
+    @Override
+    public Result run() {
+        return tieringService.tierUserData(username, tiering, context)
+            .thenReturn(context.snapshot().failedMessageCount() > 0 ? Result.PARTIAL : Result.COMPLETED)
+            .block();
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(AdditionalInformation.from(this));
+    }
+
+    public Username getUsername() {
+        return username;
+    }
+
+    public Duration getTiering() {
+        return tiering;
+    }
+
+    @VisibleForTesting
+    public UserDataTieringContext.Snapshot snapshot() {
+        return context.snapshot();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTask.java
@@ -32,6 +32,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linagora.tmail.tiering.UserDataTieringContext;
 import com.linagora.tmail.tiering.UserDataTieringService;
 
+import reactor.core.publisher.Mono;
+
 public class UserDataTieringTask implements Task {
 
     public static final TaskType TASK_TYPE = TaskType.of("UserDataTieringTask");
@@ -40,6 +42,7 @@ public class UserDataTieringTask implements Task {
         Instant timestamp,
         String username,
         long tieringSeconds,
+        RunningOptions runningOptions,
         long tieredMessageCount,
         long failedMessageCount
     ) implements TaskExecutionDetails.AdditionalInformation {
@@ -50,6 +53,7 @@ public class UserDataTieringTask implements Task {
                 Clock.systemUTC().instant(),
                 task.username.asString(),
                 task.tiering.getSeconds(),
+                task.runningOptions,
                 snapshot.tieredMessageCount(),
                 snapshot.failedMessageCount());
         }
@@ -58,19 +62,21 @@ public class UserDataTieringTask implements Task {
     private final UserDataTieringService tieringService;
     private final Username username;
     private final Duration tiering;
+    private final RunningOptions runningOptions;
     private final UserDataTieringContext context;
 
-    public UserDataTieringTask(UserDataTieringService tieringService, Username username, Duration tiering) {
+    public UserDataTieringTask(UserDataTieringService tieringService, Username username, Duration tiering, RunningOptions runningOptions) {
         this.tieringService = tieringService;
         this.username = username;
         this.tiering = tiering;
+        this.runningOptions = runningOptions;
         this.context = new UserDataTieringContext();
     }
 
     @Override
     public Result run() {
-        return tieringService.tierUserData(username, tiering, context)
-            .thenReturn(context.snapshot().failedMessageCount() > 0 ? Result.PARTIAL : Result.COMPLETED)
+        return tieringService.tierUserData(username, tiering, context, runningOptions.messagesPerSecond())
+            .then(Mono.fromSupplier(() -> context.snapshot().failedMessageCount() > 0 ? Result.PARTIAL : Result.COMPLETED))
             .block();
     }
 
@@ -90,6 +96,10 @@ public class UserDataTieringTask implements Task {
 
     public Duration getTiering() {
         return tiering;
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
     }
 
     @VisibleForTesting

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTO.java
@@ -1,0 +1,75 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserDataTieringTaskAdditionalInformationDTO(
+    @JsonProperty("type") String type,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("username") String username,
+    @JsonProperty("tieringSeconds") long tieringSeconds,
+    @JsonProperty("tieredMessageCount") long tieredMessageCount,
+    @JsonProperty("failedMessageCount") long failedMessageCount
+) implements AdditionalInformationDTO {
+
+    public static AdditionalInformationDTOModule<UserDataTieringTask.AdditionalInformation, UserDataTieringTaskAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(UserDataTieringTask.AdditionalInformation.class)
+            .convertToDTO(UserDataTieringTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(UserDataTieringTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(UserDataTieringTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(UserDataTieringTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static UserDataTieringTaskAdditionalInformationDTO fromDomainObject(UserDataTieringTask.AdditionalInformation info, String type) {
+        return new UserDataTieringTaskAdditionalInformationDTO(
+            type,
+            info.timestamp(),
+            info.username(),
+            info.tieringSeconds(),
+            info.tieredMessageCount(),
+            info.failedMessageCount());
+    }
+
+    private UserDataTieringTask.AdditionalInformation toDomainObject() {
+        return new UserDataTieringTask.AdditionalInformation(
+            timestamp,
+            username,
+            tieringSeconds,
+            tieredMessageCount,
+            failedMessageCount);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTO.java
@@ -19,18 +19,21 @@
 package com.linagora.tmail.webadmin.data;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.apache.james.json.DTOModule;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.webadmin.data.UserDataTieringTaskDTO.RunningOptionsDTO;
 
 public record UserDataTieringTaskAdditionalInformationDTO(
     @JsonProperty("type") String type,
     @JsonProperty("timestamp") Instant timestamp,
     @JsonProperty("username") String username,
     @JsonProperty("tieringSeconds") long tieringSeconds,
+    @JsonProperty("runningOptions") Optional<RunningOptionsDTO> runningOptions,
     @JsonProperty("tieredMessageCount") long tieredMessageCount,
     @JsonProperty("failedMessageCount") long failedMessageCount
 ) implements AdditionalInformationDTO {
@@ -50,6 +53,7 @@ public record UserDataTieringTaskAdditionalInformationDTO(
             info.timestamp(),
             info.username(),
             info.tieringSeconds(),
+            Optional.of(RunningOptionsDTO.of(info.runningOptions())),
             info.tieredMessageCount(),
             info.failedMessageCount());
     }
@@ -59,6 +63,7 @@ public record UserDataTieringTaskAdditionalInformationDTO(
             timestamp,
             username,
             tieringSeconds,
+            runningOptions.map(RunningOptionsDTO::asDomainObject).orElse(RunningOptions.DEFAULT),
             tieredMessageCount,
             failedMessageCount);
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskDTO.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.webadmin.data;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.apache.james.json.DTOModule;
@@ -31,14 +32,33 @@ import com.linagora.tmail.tiering.UserDataTieringService;
 public record UserDataTieringTaskDTO(
     @JsonProperty("type") String type,
     @JsonProperty("username") String username,
-    @JsonProperty("tieringSeconds") long tieringSeconds
+    @JsonProperty("tieringSeconds") long tieringSeconds,
+    @JsonProperty("runningOptions") Optional<RunningOptionsDTO> runningOptions
 ) implements TaskDTO {
+
+    public record RunningOptionsDTO(@JsonProperty("messagesPerSecond") int messagesPerSecond) {
+        public static RunningOptionsDTO of(RunningOptions options) {
+            return new RunningOptionsDTO(options.messagesPerSecond());
+        }
+
+        public RunningOptions asDomainObject() {
+            return new RunningOptions(messagesPerSecond);
+        }
+    }
 
     public static TaskDTOModule<UserDataTieringTask, UserDataTieringTaskDTO> module(UserDataTieringService service) {
         return DTOModule.forDomainObject(UserDataTieringTask.class)
             .convertToDTO(UserDataTieringTaskDTO.class)
-            .toDomainObjectConverter(dto -> new UserDataTieringTask(service, Username.of(dto.username()), Duration.ofSeconds(dto.tieringSeconds())))
-            .toDTOConverter((task, type) -> new UserDataTieringTaskDTO(type, task.getUsername().asString(), task.getTiering().getSeconds()))
+            .toDomainObjectConverter(dto -> new UserDataTieringTask(
+                service,
+                Username.of(dto.username()),
+                Duration.ofSeconds(dto.tieringSeconds()),
+                dto.runningOptions().map(RunningOptionsDTO::asDomainObject).orElse(RunningOptions.DEFAULT)))
+            .toDTOConverter((task, type) -> new UserDataTieringTaskDTO(
+                type,
+                task.getUsername().asString(),
+                task.getTiering().getSeconds(),
+                Optional.of(RunningOptionsDTO.of(task.getRunningOptions()))))
             .typeName(UserDataTieringTask.TASK_TYPE.asString())
             .withFactory(TaskDTOModule::new);
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskDTO.java
@@ -16,24 +16,35 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.tmail.tiering;
+package com.linagora.tmail.webadmin.data;
 
 import java.time.Duration;
 
 import org.apache.james.core.Username;
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
 
-import reactor.core.publisher.Mono;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.tiering.UserDataTieringService;
 
-public interface UserDataTieringService {
-    /**
-     * Tiers user data by:
-     * - Clearing the JMAP /changes projection (email and mailbox changes)
-     * - Clearing the thread-guessing table for the user
-     * - For messages older than {@code tiering}, clearing their fast-view projection,
-     *   clearing their attachments
-     *   and evicting their header blobs from the blob-store cache
-     *
-     * Per-message successes and failures are reported to {@code context}.
-     */
-    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context);
+public record UserDataTieringTaskDTO(
+    @JsonProperty("type") String type,
+    @JsonProperty("username") String username,
+    @JsonProperty("tieringSeconds") long tieringSeconds
+) implements TaskDTO {
+
+    public static TaskDTOModule<UserDataTieringTask, UserDataTieringTaskDTO> module(UserDataTieringService service) {
+        return DTOModule.forDomainObject(UserDataTieringTask.class)
+            .convertToDTO(UserDataTieringTaskDTO.class)
+            .toDomainObjectConverter(dto -> new UserDataTieringTask(service, Username.of(dto.username()), Duration.ofSeconds(dto.tieringSeconds())))
+            .toDTOConverter((task, type) -> new UserDataTieringTaskDTO(type, task.getUsername().asString(), task.getTiering().getSeconds()))
+            .typeName(UserDataTieringTask.TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskModule.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskModule.java
@@ -1,0 +1,51 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.data;
+
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.webadmin.dto.DTOModuleInjections;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.google.inject.name.Named;
+import com.linagora.tmail.tiering.UserDataTieringService;
+
+public class UserDataTieringTaskModule extends AbstractModule {
+
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> userDataTieringTaskDTO(UserDataTieringService service) {
+        return UserDataTieringTaskDTO.module(service);
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> userDataTieringAdditionalInformation() {
+        return UserDataTieringTaskAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> webAdminUserDataTieringAdditionalInformation() {
+        return UserDataTieringTaskAdditionalInformationDTO.module();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
@@ -54,7 +54,7 @@ class UserDataTieringRoutesTest {
     @BeforeEach
     void setUp() {
         tieringService = mock(UserDataTieringService.class);
-        org.mockito.Mockito.when(tieringService.tierUserData(any(), any(), any())).thenReturn(Mono.empty());
+        org.mockito.Mockito.when(tieringService.tierUserData(any(), any(), any(), org.mockito.ArgumentMatchers.anyInt())).thenReturn(Mono.empty());
 
         taskManager = new MemoryTaskManager(new Hostname("foo"));
 
@@ -109,6 +109,33 @@ class UserDataTieringRoutesTest {
         .then()
             .body("status", Matchers.is("completed"))
             .body("type", Matchers.is(UserDataTieringTask.TASK_TYPE.asString()));
+    }
+
+    @Test
+    void postShouldAcceptCustomMessagesPerSecond() {
+        String taskId = given()
+            .queryParam("tiering", "30d")
+            .queryParam("messagesPerSecond", "100")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getString("taskId");
+
+        assertThat(taskId).isNotEmpty();
+    }
+
+    @Test
+    void postShouldReturn400WhenMessagesPerSecondIsInvalid() {
+        given()
+            .queryParam("tiering", "30d")
+            .queryParam("messagesPerSecond", "0")
+        .when()
+            .post("/users/bob@example.com/data")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
     }
 
     @Test

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
@@ -27,7 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import org.apache.james.server.task.json.dto.DTOConverter;
+import org.apache.james.json.DTOConverter;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.webadmin.WebAdminServer;

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringRoutesTest.java
@@ -20,21 +20,22 @@ package com.linagora.tmail.webadmin.data;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
-import java.time.Duration;
-
-import org.apache.james.core.Username;
+import org.apache.james.server.task.json.dto.DTOConverter;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,18 +47,21 @@ import reactor.core.publisher.Mono;
 
 class UserDataTieringRoutesTest {
 
-    private static final Username BOB = Username.of("bob@example.com");
-
     private WebAdminServer webAdminServer;
     private UserDataTieringService tieringService;
+    private MemoryTaskManager taskManager;
 
     @BeforeEach
     void setUp() {
         tieringService = mock(UserDataTieringService.class);
-        when(tieringService.tierUserData(any(), any())).thenReturn(Mono.empty());
+        org.mockito.Mockito.when(tieringService.tierUserData(any(), any(), any())).thenReturn(Mono.empty());
+
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
 
         webAdminServer = WebAdminUtils.createWebAdminServer(
-                new UserDataTieringRoutes(tieringService, new JsonTransformer()))
+                new UserDataTieringRoutes(tieringService, taskManager, new JsonTransformer()),
+                new TasksRoutes(taskManager, new JsonTransformer(),
+                    DTOConverter.of(UserDataTieringTaskAdditionalInformationDTO.module())))
             .start();
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
@@ -67,38 +71,44 @@ class UserDataTieringRoutesTest {
     @AfterEach
     void tearDown() {
         webAdminServer.destroy();
+        taskManager.stop();
     }
 
     @Test
-    void postShouldReturn204OnSuccess() {
-        given()
+    void postShouldReturn201WithTaskId() {
+        String taskId = given()
             .queryParam("tiering", "30d")
         .when()
             .post("/users/bob@example.com/data")
         .then()
-            .statusCode(HttpStatus.NO_CONTENT_204);
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue())
+            .extract()
+            .jsonPath()
+            .getString("taskId");
+
+        assertThat(taskId).isNotEmpty();
     }
 
     @Test
-    void postShouldDelegateToService() {
-        given()
+    void taskShouldCompleteSuccessfully() {
+        String taskId = given()
             .queryParam("tiering", "30d")
-        .when()
-            .post("/users/bob@example.com/data");
-
-        verify(tieringService).tierUserData(eq(BOB), eq(Duration.ofDays(30)));
-    }
-
-    @Test
-    void postShouldAcceptHourDuration() {
-        given()
-            .queryParam("tiering", "24h")
         .when()
             .post("/users/bob@example.com/data")
         .then()
-            .statusCode(HttpStatus.NO_CONTENT_204);
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getString("taskId");
 
-        verify(tieringService).tierUserData(eq(BOB), eq(Duration.ofHours(24)));
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", Matchers.is("completed"))
+            .body("type", Matchers.is(UserDataTieringTask.TASK_TYPE.asString()));
     }
 
     @Test

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTOTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskAdditionalInformationDTOTest.java
@@ -16,24 +16,33 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.tmail.tiering;
+package com.linagora.tmail.webadmin.data;
 
-import java.time.Duration;
+import java.time.Instant;
 
-import org.apache.james.core.Username;
+import org.apache.james.JsonSerializationVerifier;
+import org.junit.jupiter.api.Test;
 
-import reactor.core.publisher.Mono;
+class UserDataTieringTaskAdditionalInformationDTOTest {
 
-public interface UserDataTieringService {
-    /**
-     * Tiers user data by:
-     * - Clearing the JMAP /changes projection (email and mailbox changes)
-     * - Clearing the thread-guessing table for the user
-     * - For messages older than {@code tiering}, clearing their fast-view projection,
-     *   clearing their attachments
-     *   and evicting their header blobs from the blob-store cache
-     *
-     * Per-message successes and failures are reported to {@code context}.
-     */
-    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context);
+    @Test
+    void beanTest() throws Exception {
+        JsonSerializationVerifier.dtoModule(UserDataTieringTaskAdditionalInformationDTO.module())
+            .bean(new UserDataTieringTask.AdditionalInformation(
+                Instant.parse("2007-12-03T10:15:30.00Z"),
+                "bob@domain.tld",
+                2592000L,
+                42L,
+                3L))
+            .json("""
+                {
+                  "type": "UserDataTieringTask",
+                  "timestamp": "2007-12-03T10:15:30Z",
+                  "username": "bob@domain.tld",
+                  "tieringSeconds": 2592000,
+                  "tieredMessageCount": 42,
+                  "failedMessageCount": 3
+                }""")
+            .verify();
+    }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskSerializationTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskSerializationTest.java
@@ -38,12 +38,15 @@ class UserDataTieringTaskSerializationTest {
     @Test
     void taskShouldBeSerializable() throws Exception {
         JsonSerializationVerifier.dtoModule(UserDataTieringTaskDTO.module(tieringService))
-            .bean(new UserDataTieringTask(tieringService, BOB, TIERING))
+            .bean(new UserDataTieringTask(tieringService, BOB, TIERING, RunningOptions.DEFAULT))
             .json("""
                 {
                   "type": "UserDataTieringTask",
                   "username": "bob@domain.tld",
-                  "tieringSeconds": 2592000
+                  "tieringSeconds": 2592000,
+                  "runningOptions": {
+                    "messagesPerSecond": 50
+                  }
                 }""")
             .verify();
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskSerializationTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/data/UserDataTieringTaskSerializationTest.java
@@ -16,24 +16,35 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.tmail.tiering;
+package com.linagora.tmail.webadmin.data;
+
+import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 
+import org.apache.james.JsonSerializationVerifier;
 import org.apache.james.core.Username;
+import org.junit.jupiter.api.Test;
 
-import reactor.core.publisher.Mono;
+import com.linagora.tmail.tiering.UserDataTieringService;
 
-public interface UserDataTieringService {
-    /**
-     * Tiers user data by:
-     * - Clearing the JMAP /changes projection (email and mailbox changes)
-     * - Clearing the thread-guessing table for the user
-     * - For messages older than {@code tiering}, clearing their fast-view projection,
-     *   clearing their attachments
-     *   and evicting their header blobs from the blob-store cache
-     *
-     * Per-message successes and failures are reported to {@code context}.
-     */
-    Mono<Void> tierUserData(Username username, Duration tiering, UserDataTieringContext context);
+class UserDataTieringTaskSerializationTest {
+
+    private static final Username BOB = Username.of("bob@domain.tld");
+    private static final Duration TIERING = Duration.ofDays(30);
+
+    private final UserDataTieringService tieringService = mock(UserDataTieringService.class);
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(UserDataTieringTaskDTO.module(tieringService))
+            .bean(new UserDataTieringTask(tieringService, BOB, TIERING))
+            .json("""
+                {
+                  "type": "UserDataTieringTask",
+                  "username": "bob@domain.tld",
+                  "tieringSeconds": 2592000
+                }""")
+            .verify();
+    }
 }


### PR DESCRIPTION
CF https://github.com/linagora/tmail-backend/issues/2341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User Data Tiering endpoint is now asynchronous: returns 201 with a taskId; use GET /tasks/{taskId}/await to wait for completion.
  * Response includes task metrics: tieredMessageCount and failedMessageCount.
  * Optional messagesPerSecond parameter to cap throughput (default 50).

* **Bug Fixes**
  * requests with invalid messagesPerSecond now return 400 Bad Request.

* **Documentation**
  * Updated webadmin docs to reflect these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->