### PR TITLE
[ENHANCEMENT] Push docker images for each PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
           steps {
             script {
               if (env.CHANGE_FORK) {
-                def forkOwner = env.CHANGE_FORK
+                def forkOwner = env.CHANGE_FORK.split('/')[0]
                 def memberStatus = sh(
                   script: """curl -s -o /dev/null -w "%{http_code}" \
                     -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
@@ -70,7 +70,7 @@ pipeline {
                       "https://api.github.com/repos/linagora/tmail-backend/issues/\${CHANGE_ID}/comments" """,
                     returnStdout: true
                   ).trim()
-                  def comments = readJSON text: commentsJson
+                  def comments = new groovy.json.JsonSlurper().parseText(commentsJson)
                   for (comment in comments) {
                     if (comment.body.trim().toLowerCase() == 'build this please') {
                       def commenter = comment.user.login

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                   ).trim()
                   def comments = readJSON text: commentsJson
                   for (comment in comments) {
-                    if (comment.body.trim() == 'Build this please') {
+                    if (comment.body.trim().toLowerCase() == 'build this please') {
                       def commenter = comment.user.login
                       def commenterStatus = sh(
                         script: """curl -s -o /dev/null -w "%{http_code}" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
 
     environment {
         DOCKER_HUB_CREDENTIAL = credentials('dockerHub')
+        GITHUB_CREDENTIAL = credentials('github')
     }
 
     options {
@@ -42,6 +43,77 @@ pipeline {
                     archiveArtifacts artifacts: '**/surefire-reports/*' , fingerprint: true
                 }
             }
+        }
+        stage('Deliver Docker images for PR') {
+          when {
+            changeRequest()
+          }
+          steps {
+            script {
+              if (env.CHANGE_FORK) {
+                def forkOwner = env.CHANGE_FORK
+                def memberStatus = sh(
+                  script: """curl -s -o /dev/null -w "%{http_code}" \
+                    -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                    "https://api.github.com/orgs/linagora/members/${forkOwner}" """,
+                  returnStdout: true
+                ).trim()
+                echo "GitHub org membership check returned HTTP ${memberStatus} for '${forkOwner}'"
+                if (memberStatus == '204') {
+                  echo "Fork owner '${forkOwner}' is a linagora org member, proceeding."
+                } else if (memberStatus == '404') {
+                  echo "Fork owner '${forkOwner}' is not a member of the linagora organization."
+                  def approvedByMember = false
+                  def commentsJson = sh(
+                    script: """curl -s \
+                      -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                      "https://api.github.com/repos/linagora/tmail-backend/issues/\${CHANGE_ID}/comments" """,
+                    returnStdout: true
+                  ).trim()
+                  def comments = readJSON text: commentsJson
+                  for (comment in comments) {
+                    if (comment.body.trim() == 'Build this please') {
+                      def commenter = comment.user.login
+                      def commenterStatus = sh(
+                        script: """curl -s -o /dev/null -w "%{http_code}" \
+                          -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                          "https://api.github.com/orgs/linagora/members/${commenter}" """,
+                        returnStdout: true
+                      ).trim()
+                      if (commenterStatus == '204') {
+                        echo "Build approved by linagora member '${commenter}', proceeding."
+                        approvedByMember = true
+                        break
+                      }
+                    }
+                  }
+                  if (!approvedByMember) {
+                    echo "No linagora member approval found. Skipping PR image delivery."
+                    return
+                  }
+                } else if (memberStatus == '401' || memberStatus == '403') {
+                  error("Authentication/permission error validating fork owner: ${memberStatus}")
+                } else {
+                  error("GitHub API error ${memberStatus} while checking membership for '${forkOwner}'")
+                }
+              }
+
+              dir("tmail-backend") {
+                sh 'mvn -Pci jib:build -Djib.to.image=linagora/tmail-backend-pr -Djib.to.tags=$CHANGE_ID -Djib.to.auth.username=$DOCKER_HUB_CREDENTIAL_USR -Djib.to.auth.password=$DOCKER_HUB_CREDENTIAL_PSW -pl apps/distributed'
+              }
+              sh """
+                HTTP_STATUS=\$(curl -s -o /tmp/gh_comment_response.json -w "%{http_code}" -X POST \\
+                  -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \\
+                  -H "Content-Type: application/json" \\
+                  -d "{\\"body\\": \\"Docker image published for this PR: linagora/tmail-backend-pr:\${CHANGE_ID}\\"}" \\
+                  "https://api.github.com/repos/linagora/tmail-backend/issues/\${CHANGE_ID}/comments")
+                if [ "\$HTTP_STATUS" -lt 200 ] || [ "\$HTTP_STATUS" -ge 300 ]; then
+                  echo "WARNING: GitHub API comment failed with HTTP \$HTTP_STATUS"
+                  cat /tmp/gh_comment_response.json
+                fi
+              """
+            }
+          }
         }
         stage('Deliver Docker images') {
           when {


### PR DESCRIPTION
Idea is easy access for built PR docker images in order to ease performance testing (and quick QA)

Inspired from `linagora/twake-calendar-frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated Docker image builds for pull requests with authorization checks.
  * Added automatic GitHub notifications to announce PR-specific Docker images upon successful builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->