### PR TITLE
[FIX] CalendarEvent/parse shall be lenient on malformed addresses

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventParse.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/model/CalendarEventParse.scala
@@ -288,7 +288,7 @@ object CalendarOrganizerField {
           .map(_.getValue),
           mailto = Option(organizer.getCalAddress)
             .map(_.getSchemeSpecificPart)
-            .map(new MailAddress(_))))
+            .flatMap(address => Try(new MailAddress(address)).toOption)))
 }
 case class CalendarOrganizerField(name: Option[String], mailto: Option[MailAddress]) {
   def asMailAddressString(): Option[String] = mailto.map(_.asString())
@@ -339,7 +339,7 @@ object CalendarAttendeeMailTo {
   def from(attendee: Attendee): Option[CalendarAttendeeMailTo] =
     Option(attendee.getCalAddress)
       .map(_.getSchemeSpecificPart)
-      .map(new MailAddress(_))
+      .flatMap(address => Try(new MailAddress(address)).toOption)
       .map(CalendarAttendeeMailTo(_))
 }
 case class CalendarAttendeeMailTo(value: MailAddress) extends AnyVal {

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventParsedTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventParsedTest.scala
@@ -614,6 +614,35 @@ class CalendarEventParsedTest {
   }
 
   @Test
+  def parseShouldSucceedWhenAttendeeHasMalformedMailto(): Unit = {
+    val icsPayload =
+      """BEGIN:VCALENDAR
+        |VERSION:2.0
+        |PRODID:-//Sabre//Sabre VObject 4.5.7//EN
+        |CALSCALE:GREGORIAN
+        |METHOD:REQUEST
+        |BEGIN:VEVENT
+        |UID:e315dff9-8eeb-416f-a315-aef24d3af06b
+        |DTSTART;TZID=Europe/Paris:20260520T123000
+        |DTEND;TZID=Europe/Paris:20260520T133000
+        |SUMMARY:Test event
+        |ORGANIZER;CN=Alice:mailto:alice@example.com
+        |ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=Bob:mailto:bob@example.com
+        |ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CUTYPE=INDIVIDUAL:mailto:Radia%20OUBRAHAM%20%3Croubraham@example.com%3E
+        |DTSTAMP:20260423T070116Z
+        |END:VEVENT
+        |END:VCALENDAR
+        |""".stripMargin
+
+    val result = CalendarEventParsed.from(new ByteArrayInputStream(icsPayload.getBytes()))
+
+    assertThat(result).hasSize(1)
+    assertThat(result.head.participants.list).hasSize(2)
+    assertThat(result.head.participants.list.head.mailto.map(_.serialize()).get).isEqualTo("bob@example.com")
+    assertThat(result.head.participants.list(1).mailto.isEmpty).isTrue
+  }
+
+  @Test
   def parseCounterEventShouldSucceed(): Unit = {
     val icsPayload =
       """BEGIN:VCALENDAR

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventParsedTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventParsedTest.scala
@@ -636,8 +636,8 @@ class CalendarEventParsedTest {
 
     val result = CalendarEventParsed.from(new ByteArrayInputStream(icsPayload.getBytes()))
 
-    assertThat(result).hasSize(1)
-    assertThat(result.head.participants.list).hasSize(2)
+    assertThat(result.asJava).hasSize(1)
+    assertThat(result.head.participants.list.asJava).hasSize(2)
     assertThat(result.head.participants.list.head.mailto.map(_.serialize()).get).isEqualTo("bob@example.com")
     assertThat(result.head.participants.list(1).mailto.isEmpty).isTrue
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar event parsing robustness to gracefully handle malformed attendee email addresses without causing parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->