### PR TITLE
ISSUE-1227 Add allignement validation for CalDavCollect

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/openpaas.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/openpaas.adoc
@@ -53,9 +53,25 @@ This mailet synchronizes calendars in mails with dav server (create, update, del
 
 === Parameters
 
-The mailet configuration requires the following parameters:
+* `source`: name of the mail attribute containing the JSON-encoded iCal data. Must match the `destination` attribute of the upstream `ICALToJsonAttribute` mailet. Default: `icalendarJson`.
+* `alignmentMode`: controls how the mail `From` address is validated against the ITIP payload before the event is forwarded to the DAV server. Default: `strict`.
++
+[cols="1,3"]
+|===
+| Value | Behaviour
 
-* `source`: source for this mailet. the value must be same as the value of `destination` attribute in ICALToJsonAttribute mailet.
+| `strict` (default)
+| For `REQUEST`/`CANCEL`: the `From` address must exactly match the `ORGANIZER` in the iCal payload. +
+  For `REPLY`: the `From` address must exactly match at least one `ATTENDEE`.
+
+| `sameDomain`
+| Same checks as `strict`, but only the domain part of the address is compared (e.g. `alice@example.com` and `bob@example.com` are considered aligned).
+
+| `none`
+| No validation is performed — any `From` address is accepted. This is the most permissive setting.
+|===
++
+When the alignment check fails the ITIP is silently dropped and a warning is logged.
 
 === Example
 This configuration contains all mailets necessary to read ics attachments in mail and send them to dav server.
@@ -88,5 +104,57 @@ This configuration contains all mailets necessary to read ics attachments in mai
 </mailet>
 <mailet match="All" class="com.linagora.tmail.mailet.CalDavCollect">
     <source>icalendarAsJson2</source>
+    <alignmentMode>strict</alignmentMode>
+</mailet>
+----
+
+== RestrictiveCalDavCollect
+
+Like `CalDavCollect` but does **not** auto-import new events into a user's calendar.
+
+For `REQUEST`/`CANCEL` methods: the ITIP is forwarded to the DAV server only if the event already exists in the recipient's CalDAV calendar. Unknown events are silently ignored.
+
+For `REPLY`: behaves identically to `CalDavCollect` — the organizer's calendar is updated with the attendee's response regardless of whether the event was previously known.
+
+=== Parameters
+
+* `source`: same as `CalDavCollect`. Default: `icalendarJson`.
+* `alignmentMode`: same semantics as `CalDavCollect`. Default: `strict`.
++
+For `REQUEST`: the alignment check is applied *before* the event-existence check. A misaligned `REQUEST` is dropped even if the event already exists.
++
+`CANCEL` and `REPLY` follow the same validation rules as `CalDavCollect`.
+
+=== Example
+
+[source,xml]
+----
+<mailet match="All" class="StripAttachment">
+    <mimeType>text/calendar</mimeType>
+    <attribute>rawIcalendar2</attribute>
+    <onMailetException>ignore</onMailetException>
+</mailet>
+<mailet match="All" class="MimeDecodingMailet">
+    <attribute>rawIcalendar2</attribute>
+    <onMailetException>ignore</onMailetException>
+</mailet>
+<mailet match="All" class="ICalendarParser">
+    <sourceAttribute>rawIcalendar2</sourceAttribute>
+    <destinationAttribute>icalendar2</destinationAttribute>
+    <onMailetException>ignore</onMailetException>
+</mailet>
+<mailet match="All" class="ICALToHeader">
+    <attribute>icalendar2</attribute>
+    <onMailetException>ignore</onMailetException>
+</mailet>
+<mailet match="All" class="org.apache.james.transport.mailets.ICALToJsonAttribute">
+    <source>icalendar2</source>
+    <destination>icalendarAsJson2</destination>
+    <rawSource>rawIcalendar2</rawSource>
+    <onMailetException>ignore</onMailetException>
+</mailet>
+<mailet match="All" class="com.linagora.tmail.mailet.RestrictiveCalDavCollect">
+    <source>icalendarAsJson2</source>
+    <alignmentMode>strict</alignmentMode>
 </mailet>
 ----

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/AlignmentMode.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/AlignmentMode.java
@@ -1,0 +1,35 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+public enum AlignmentMode {
+    STRICT, SAME_DOMAIN, NONE;
+
+    public static final String PARAMETER_NAME = "alignmentMode";
+
+    public static AlignmentMode fromString(String value) {
+        return switch (value.toLowerCase()) {
+            case "strict" -> STRICT;
+            case "samedomain" -> SAME_DOMAIN;
+            case "none" -> NONE;
+            default -> throw new IllegalArgumentException(
+                "Unknown alignmentMode '" + value + "'. Valid values: strict, sameDomain, none");
+        };
+    }
+}

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
@@ -66,6 +66,7 @@ public class CalDavCollect extends GenericMailet {
     private final DavUserProvider davUserProvider;
 
     private AttributeName sourceAttributeName;
+    private AlignmentMode alignmentMode;
 
     @Inject
     public CalDavCollect(DavClient davClient, DavUserProvider davUserProvider) {
@@ -76,6 +77,12 @@ public class CalDavCollect extends GenericMailet {
     @Override
     public void init() throws MessagingException {
         sourceAttributeName = AttributeName.of(getInitParameter(SOURCE_ATTRIBUTE_NAME, DEFAULT_SOURCE_ATTRIBUTE_NAME));
+        String alignmentModeParam = getInitParameter(AlignmentMode.PARAMETER_NAME, "strict");
+        try {
+            alignmentMode = AlignmentMode.fromString(alignmentModeParam);
+        } catch (IllegalArgumentException e) {
+            throw new MessagingException("Invalid " + AlignmentMode.PARAMETER_NAME + ": " + alignmentModeParam, e);
+        }
     }
 
     @Override
@@ -97,11 +104,16 @@ public class CalDavCollect extends GenericMailet {
 
         String icalContent = jsonNode.path("ical").asText();
         String recipient = jsonNode.path("recipient").asText();
+        String senderAsString = jsonNode.path("sender").asText();
 
         if (!icalContent.isEmpty() && !recipient.isEmpty()) {
             try {
                 MailAddress mailAddress = new MailAddress(recipient);
                 Calendar calendar = parseICalString(icalContent);
+
+                if (!isSenderAlignmentSatisfied(senderAsString, calendar, mail.getName())) {
+                    return;
+                }
 
                 if (shouldSendItip(mailAddress, calendar)) {
                     davUserProvider.provide(Username.of(mailAddress.asString()))
@@ -112,6 +124,75 @@ public class CalDavCollect extends GenericMailet {
                 LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e);
             }
         }
+    }
+
+    private boolean isSenderAlignmentSatisfied(String senderAsString, Calendar calendar, String mailName) {
+        if (alignmentMode == AlignmentMode.NONE) {
+            return true;
+        }
+        if (senderAsString.isEmpty()) {
+            LOGGER.warn("Skipping ITIP for mail {}: sender field is missing and alignmentMode is {}", mailName, alignmentMode);
+            return false;
+        }
+        try {
+            MailAddress senderAddress = new MailAddress(senderAsString);
+            if (passesAlignmentCheck(senderAddress, calendar)) {
+                return true;
+            }
+            LOGGER.warn("Skipping ITIP for mail {}: sender {} does not match ITIP payload constraints (alignmentMode={})", mailName, senderAsString, alignmentMode);
+            return false;
+        } catch (Exception e) {
+            LOGGER.warn("Skipping ITIP for mail {}: invalid sender address {}", mailName, senderAsString);
+            return false;
+        }
+    }
+
+    private boolean passesAlignmentCheck(MailAddress sender, Calendar calendar) {
+        if (isReply(calendar)) {
+            return isSenderAlignedWithAnyAttendee(sender, calendar);
+        }
+        return isSenderAlignedWithOrganizer(sender, calendar);
+    }
+
+    private boolean isSenderAlignedWithOrganizer(MailAddress sender, Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .filter(VEvent.class::isInstance)
+            .map(VEvent.class::cast)
+            .anyMatch(event -> Optional.ofNullable(event.getOrganizer())
+                .map(Organizer::getCalAddress)
+                .map(URI::getSchemeSpecificPart)
+                .flatMap(CalDavCollect::toMailAddressSilently)
+                .map(organizer -> isSenderAlignedWith(sender, organizer))
+                .orElse(false));
+    }
+
+    private boolean isSenderAlignedWithAnyAttendee(MailAddress sender, Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .filter(VEvent.class::isInstance)
+            .map(VEvent.class::cast)
+            .anyMatch(event -> event.getProperties(Property.ATTENDEE).stream()
+                .map(attendee -> (Attendee) attendee)
+                .map(Attendee::getCalAddress)
+                .map(URI::getSchemeSpecificPart)
+                .flatMap(addr -> toMailAddressSilently(addr).stream())
+                .anyMatch(attendeeAddr -> isSenderAlignedWith(sender, attendeeAddr)));
+    }
+
+    private static Optional<MailAddress> toMailAddressSilently(String address) {
+        try {
+            return Optional.of(new MailAddress(address));
+        } catch (Exception e) {
+            LOGGER.info("Skipping invalid mail address in iCal payload: {}", address);
+            return Optional.empty();
+        }
+    }
+
+    private boolean isSenderAlignedWith(MailAddress sender, MailAddress address) {
+        return switch (alignmentMode) {
+            case STRICT -> sender.equals(address);
+            case SAME_DOMAIN -> sender.getDomain().equals(address.getDomain());
+            case NONE -> true;
+        };
     }
 
     private Mono<Void> synchronizeWithDavServer(byte[] json, DavUser davUser) {

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
@@ -65,6 +65,11 @@ import reactor.core.publisher.Mono;
  *   - If the event does not exist → do nothing.
  *
  * For REPLY: same behaviour as CalDavCollect (organizer receives attendee's response).
+ *
+ * The alignmentMode parameter controls sender validation against the ITIP payload:
+ *   - strict (default): the From address must exactly match the ORGANIZER (REQUEST/CANCEL) or an ATTENDEE (REPLY).
+ *   - sameDomain: the From address must share the same domain as the ORGANIZER or an ATTENDEE.
+ *   - none: no constraint.
  */
 public class RestrictiveCalDavCollect extends GenericMailet {
 
@@ -78,6 +83,7 @@ public class RestrictiveCalDavCollect extends GenericMailet {
     private final DavClient davClient;
     private final DavUserProvider davUserProvider;
     private AttributeName sourceAttributeName;
+    private AlignmentMode alignmentMode;
 
     @Inject
     public RestrictiveCalDavCollect(DavClient davClient, DavUserProvider davUserProvider) {
@@ -88,6 +94,12 @@ public class RestrictiveCalDavCollect extends GenericMailet {
     @Override
     public void init() throws MessagingException {
         sourceAttributeName = AttributeName.of(getInitParameter(SOURCE_ATTRIBUTE_NAME, DEFAULT_SOURCE_ATTRIBUTE_NAME));
+        String alignmentModeParam = getInitParameter(AlignmentMode.PARAMETER_NAME, "strict");
+        try {
+            alignmentMode = AlignmentMode.fromString(alignmentModeParam);
+        } catch (IllegalArgumentException e) {
+            throw new MessagingException("Invalid " + AlignmentMode.PARAMETER_NAME + ": " + alignmentModeParam, e);
+        }
     }
 
     @Override
@@ -108,11 +120,16 @@ public class RestrictiveCalDavCollect extends GenericMailet {
         JsonNode jsonNode = convertToJson(json, mail.getName());
         String icalContent = jsonNode.path("ical").asText();
         String recipient = jsonNode.path("recipient").asText();
+        String senderAsString = jsonNode.path("sender").asText();
 
         if (!icalContent.isEmpty() && !recipient.isEmpty()) {
             try {
                 MailAddress mailAddress = new MailAddress(recipient);
                 Calendar calendar = parseICalString(icalContent);
+
+                if (!isSenderAlignmentSatisfied(senderAsString, calendar, mail.getName())) {
+                    return;
+                }
 
                 if (isReply(calendar)) {
                     if (!isExplicitAttendee(mailAddress, calendar)) {
@@ -129,6 +146,75 @@ public class RestrictiveCalDavCollect extends GenericMailet {
                 LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e);
             }
         }
+    }
+
+    private boolean isSenderAlignmentSatisfied(String senderAsString, Calendar calendar, String mailName) {
+        if (alignmentMode == AlignmentMode.NONE) {
+            return true;
+        }
+        if (senderAsString.isEmpty()) {
+            LOGGER.warn("Skipping ITIP for mail {}: sender field is missing and alignmentMode is {}", mailName, alignmentMode);
+            return false;
+        }
+        try {
+            MailAddress senderAddress = new MailAddress(senderAsString);
+            if (passesAlignmentCheck(senderAddress, calendar)) {
+                return true;
+            }
+            LOGGER.warn("Skipping ITIP for mail {}: sender {} does not match ITIP payload constraints (alignmentMode={})", mailName, senderAsString, alignmentMode);
+            return false;
+        } catch (Exception e) {
+            LOGGER.warn("Skipping ITIP for mail {}: invalid sender address {}", mailName, senderAsString);
+            return false;
+        }
+    }
+
+    private boolean passesAlignmentCheck(MailAddress sender, Calendar calendar) {
+        if (isReply(calendar)) {
+            return isSenderAlignedWithAnyAttendee(sender, calendar);
+        }
+        return isSenderAlignedWithOrganizer(sender, calendar);
+    }
+
+    private boolean isSenderAlignedWithOrganizer(MailAddress sender, Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .filter(VEvent.class::isInstance)
+            .map(VEvent.class::cast)
+            .anyMatch(event -> Optional.ofNullable(event.getOrganizer())
+                .map(Organizer::getCalAddress)
+                .map(URI::getSchemeSpecificPart)
+                .flatMap(RestrictiveCalDavCollect::toMailAddressSilently)
+                .map(organizer -> isSenderAlignedWith(sender, organizer))
+                .orElse(false));
+    }
+
+    private boolean isSenderAlignedWithAnyAttendee(MailAddress sender, Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .filter(VEvent.class::isInstance)
+            .map(VEvent.class::cast)
+            .anyMatch(event -> event.getProperties(Property.ATTENDEE).stream()
+                .map(attendee -> (Attendee) attendee)
+                .map(Attendee::getCalAddress)
+                .map(URI::getSchemeSpecificPart)
+                .flatMap(addr -> toMailAddressSilently(addr).stream())
+                .anyMatch(attendeeAddr -> isSenderAlignedWith(sender, attendeeAddr)));
+    }
+
+    private static Optional<MailAddress> toMailAddressSilently(String address) {
+        try {
+            return Optional.of(new MailAddress(address));
+        } catch (Exception e) {
+            LOGGER.info("Skipping invalid mail address in iCal payload: {}", address);
+            return Optional.empty();
+        }
+    }
+
+    private boolean isSenderAlignedWith(MailAddress sender, MailAddress address) {
+        return switch (alignmentMode) {
+            case STRICT -> sender.equals(address);
+            case SAME_DOMAIN -> sender.getDomain().equals(address.getDomain());
+            case NONE -> true;
+        };
     }
 
     private Mono<Void> syncIfEventExists(byte[] json, Calendar calendar, DavUser davUser) {

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
@@ -131,17 +131,7 @@ public class RestrictiveCalDavCollect extends GenericMailet {
                     return;
                 }
 
-                if (isReply(calendar)) {
-                    if (!isExplicitAttendee(mailAddress, calendar)) {
-                        davUserProvider.provide(Username.of(mailAddress.asString()))
-                            .flatMap(davUser -> synchronizeWithDavServer(json, davUser))
-                            .block();
-                    }
-                } else if (concernsRecipient(mailAddress, calendar)) {
-                    davUserProvider.provide(Username.of(mailAddress.asString()))
-                        .flatMap(davUser -> syncIfEventExists(json, calendar, davUser))
-                        .block();
-                }
+                synchronizeIfEligible(mailAddress, calendar, json);
             } catch (Exception e) {
                 LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e);
             }
@@ -215,6 +205,20 @@ public class RestrictiveCalDavCollect extends GenericMailet {
             case SAME_DOMAIN -> sender.getDomain().equals(address.getDomain());
             case NONE -> true;
         };
+    }
+
+    private void synchronizeIfEligible(MailAddress mailAddress, Calendar calendar, byte[] json) {
+        if (isReply(calendar)) {
+            if (!isExplicitAttendee(mailAddress, calendar)) {
+                davUserProvider.provide(Username.of(mailAddress.asString()))
+                    .flatMap(davUser -> synchronizeWithDavServer(json, davUser))
+                    .block();
+            }
+        } else if (concernsRecipient(mailAddress, calendar)) {
+            davUserProvider.provide(Username.of(mailAddress.asString()))
+                .flatMap(davUser -> syncIfEventExists(json, calendar, davUser))
+                .block();
+        }
     }
 
     private Mono<Void> syncIfEventExists(byte[] json, Calendar calendar, DavUser davUser) {

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
@@ -101,7 +101,9 @@ public class CalDavCollectIntegrationTest {
                                      String dtStart,
                                      String dtEnd,
                                      String recurrenceId,
-                                     String lastModified) {
+                                     String lastModified,
+                                     EmailTemplateUser organizer,
+                                     EmailTemplateUser icsAttendee) {
         public Function<String, String> base64Encode() {
             return (obj) -> Base64.getEncoder().encodeToString(obj.getBytes(StandardCharsets.UTF_8));
         }
@@ -123,6 +125,8 @@ public class CalDavCollectIntegrationTest {
             private Optional<String> dtEnd = Optional.empty();
             private Optional<String> recurrenceId = Optional.empty();
             private Optional<String> lastModified = Optional.empty();
+            private Optional<EmailTemplateUser> organizer = Optional.empty();
+            private Optional<EmailTemplateUser> icsAttendee = Optional.empty();
 
             public Builder sender(EmailTemplateUser sender) {
                 this.sender = sender;
@@ -184,6 +188,16 @@ public class CalDavCollectIntegrationTest {
                 return this;
             }
 
+            public Builder organizer(EmailTemplateUser organizer) {
+                this.organizer = Optional.of(organizer);
+                return this;
+            }
+
+            public Builder icsAttendee(EmailTemplateUser icsAttendee) {
+                this.icsAttendee = Optional.of(icsAttendee);
+                return this;
+            }
+
             public EmailTemplateData build() {
                 Preconditions.checkNotNull(sender, "sender is required");
                 Preconditions.checkNotNull(receiver, "receiver is required");
@@ -201,7 +215,9 @@ public class CalDavCollectIntegrationTest {
                     dtStart.orElse("20170111T090000Z"),
                     dtEnd.orElse("20170111T100000Z"),
                     recurrenceId.orElse("20170112T090000Z"),
-                    lastModified.orElse("20170106T115036Z"));
+                    lastModified.orElse("20170106T115036Z"),
+                    organizer.orElse(sender),
+                    icsAttendee.orElse(sender));
             }
         }
     }
@@ -224,6 +240,10 @@ public class CalDavCollectIntegrationTest {
 
     @BeforeEach
     void setUpJamesServer(@TempDir File temporaryFolder) throws Exception {
+        startServer(temporaryFolder, "strict");
+    }
+
+    private void startServer(File dir, String alignmentMode) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
                 new OpenPaasModule()))
@@ -263,9 +283,10 @@ public class CalDavCollectIntegrationTest {
                             .addProperty(ICALToJsonAttribute.RAW_SOURCE_ATTRIBUTE_NAME, "rawIcalendar"))
                         .addMailet(MailetConfiguration.builder()
                             .matcher(All.class)
-                            .mailet(CalDavCollect.class))
+                            .mailet(CalDavCollect.class)
+                            .addProperty("alignmentMode", alignmentMode))
                         .addMailetsFrom(CommonProcessors.deliverOnlyTransport())))
-            .build(temporaryFolder);
+            .build(dir);
 
         jamesServer.start();
 
@@ -641,6 +662,174 @@ public class CalDavCollectIntegrationTest {
             .calendarUid(calendarUid)
             .build();
     }
+
+    // ---- alignmentMode tests ----
+
+    @Test
+    void alignmentModeStrictShouldSkipRequestWhenOrganizerDoesNotMatchSender() throws Exception {
+        String mimeMessageId = UUID.randomUUID().toString();
+        String calendarUid = UUID.randomUUID().toString();
+        // From=sender.email but ORGANIZER=some other address on same domain
+        EmailTemplateUser fakeOrganizer = new EmailTemplateUser("Fake Org", "fake-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getSender())
+                .receiver(getReceiver())
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .organizer(fakeOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void alignmentModeStrictShouldSkipCancelWhenOrganizerDoesNotMatchSender() throws Exception {
+        String mimeMessageId = UUID.randomUUID().toString();
+        String calendarUid = UUID.randomUUID().toString();
+        // First REQUEST with correct organizer — event is created
+        String requestMail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            generateEmailTemplateData(sender, receiver, mimeMessageId, calendarUid));
+        sendMessage(sender, receiver, requestMail, mimeMessageId);
+
+        // Then CANCEL with mismatched organizer — event must NOT be cancelled
+        String cancelMsgId = UUID.randomUUID().toString();
+        EmailTemplateUser fakeOrganizer = new EmailTemplateUser("Fake Org", "fake-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String cancelMail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getSender())
+                .receiver(getReceiver())
+                .mimeMessageId(cancelMsgId)
+                .calendarUid(calendarUid)
+                .method("CANCEL")
+                .organizer(fakeOrganizer)
+                .build());
+        sendMessage(sender, receiver, cancelMail, cancelMsgId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        // Event still exists and is NOT cancelled
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperty(Property.STATUS).get().getValue())
+            .isEqualTo("CONFIRMED");
+    }
+
+    @Test
+    void alignmentModeStrictShouldSkipReplyWhenSenderNotInAttendees() throws Exception {
+        String calendarUid = UUID.randomUUID().toString();
+        // Create the event in organizer's calendar first
+        String requestMsgId = UUID.randomUUID().toString();
+        String requestMail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            generateEmailTemplateData(sender, receiver, requestMsgId, calendarUid));
+        sendMessage(receiver, sender, requestMail, requestMsgId);
+
+        // REPLY where From=sender but ICS ATTENDEE is a different address
+        String replyMsgId = UUID.randomUUID().toString();
+        EmailTemplateUser differentAttendee = new EmailTemplateUser("Other", "other@" + OpenPaaSProvisioningService.DOMAIN);
+        String replyMail = generateMail("template/emailReplyWithoutOrganizer.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getReceiver())
+                .receiver(getSender())
+                .mimeMessageId(replyMsgId)
+                .calendarUid(calendarUid)
+                .icsAttendee(differentAttendee)
+                .build());
+        sendMessage(receiver, sender, replyMail, replyMsgId);
+
+        // Organizer's calendar should NOT be updated (alignment failed)
+        DavCalendarObject result = davClient.caldav(sender.email())
+            .getCalendarObject(new DavUser(sender.id(), sender.email()), new DavUid(calendarUid)).block();
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperties(Property.ATTENDEE).stream()
+            .map(p -> (Attendee) p)
+            .filter(a -> a.getCalAddress().getSchemeSpecificPart().equalsIgnoreCase(receiver.email().asString()))
+            .findFirst()
+            .flatMap(a -> a.getParameter("PARTSTAT"))
+            .map(parameter -> ((Parameter) parameter).getValue())
+            .orElse("NEEDS-ACTION"))
+            .isEqualTo("NEEDS-ACTION");
+    }
+
+    @Test
+    void alignmentModeSameDomainShouldAllowRequestWhenOrganizerHasSameDomain(@TempDir File altDir) throws Exception {
+        jamesServer.shutdown();
+        startServer(altDir, "sameDomain");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        String calendarUid = UUID.randomUUID().toString();
+        // From=sender@open-paas.org, ORGANIZER=other@open-paas.org — same domain, different user
+        EmailTemplateUser sameDomainOrganizer = new EmailTemplateUser("Same Domain Org", "same-domain-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getSender())
+                .receiver(getReceiver())
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .organizer(sameDomainOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void alignmentModeSameDomainShouldSkipRequestWhenOrganizerHasDifferentDomain(@TempDir File altDir) throws Exception {
+        jamesServer.shutdown();
+        startServer(altDir, "sameDomain");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        String calendarUid = UUID.randomUUID().toString();
+        // From=sender@open-paas.org, ORGANIZER=someone@external.tld — different domain
+        EmailTemplateUser externalOrganizer = new EmailTemplateUser("External Org", "organizer@external.tld");
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getSender())
+                .receiver(getReceiver())
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .organizer(externalOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void alignmentModeNoneShouldAllowRequestWithAnyOrganizer(@TempDir File altDir) throws Exception {
+        jamesServer.shutdown();
+        startServer(altDir, "none");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        String calendarUid = UUID.randomUUID().toString();
+        // From=sender@open-paas.org, ORGANIZER=anyone@external.tld — no constraint in none mode
+        EmailTemplateUser externalOrganizer = new EmailTemplateUser("External Org", "organizer@external.tld");
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(getSender())
+                .receiver(getReceiver())
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .organizer(externalOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result).isNotNull();
+    }
+
+    // ---- end alignmentMode tests ----
 
     private Optional<CalendarComponent> getVEventContainingRecurrenceId(Calendar calendar) {
         return calendar.getComponents().stream()

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/RestrictiveCalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/RestrictiveCalDavCollectIntegrationTest.java
@@ -103,7 +103,9 @@ public class RestrictiveCalDavCollectIntegrationTest {
                                      String dtStart,
                                      String dtEnd,
                                      String recurrenceId,
-                                     String lastModified) {
+                                     String lastModified,
+                                     EmailTemplateUser organizer,
+                                     EmailTemplateUser icsAttendee) {
         public Function<String, String> base64Encode() {
             return (obj) -> Base64.getEncoder().encodeToString(obj.getBytes(StandardCharsets.UTF_8));
         }
@@ -125,6 +127,8 @@ public class RestrictiveCalDavCollectIntegrationTest {
             private Optional<String> dtEnd = Optional.empty();
             private Optional<String> recurrenceId = Optional.empty();
             private Optional<String> lastModified = Optional.empty();
+            private Optional<EmailTemplateUser> organizer = Optional.empty();
+            private Optional<EmailTemplateUser> icsAttendee = Optional.empty();
 
             public Builder sender(EmailTemplateUser sender) { this.sender = sender; return this; }
             public Builder receiver(EmailTemplateUser receiver) { this.receiver = receiver; return this; }
@@ -133,6 +137,8 @@ public class RestrictiveCalDavCollectIntegrationTest {
             public Builder method(String method) { this.method = Optional.of(method); return this; }
             public Builder sequence(String sequence) { this.sequence = Optional.of(sequence); return this; }
             public Builder location(String location) { this.location = Optional.of(location); return this; }
+            public Builder organizer(EmailTemplateUser organizer) { this.organizer = Optional.of(organizer); return this; }
+            public Builder icsAttendee(EmailTemplateUser icsAttendee) { this.icsAttendee = Optional.of(icsAttendee); return this; }
 
             public EmailTemplateData build() {
                 Preconditions.checkNotNull(sender, "sender is required");
@@ -143,7 +149,8 @@ public class RestrictiveCalDavCollectIntegrationTest {
                     method.orElse("REQUEST"), sequence.orElse("0"),
                     dtStamp.orElse("20170106T115036Z"), location.orElse("office"),
                     dtStart.orElse("20170111T090000Z"), dtEnd.orElse("20170111T100000Z"),
-                    recurrenceId.orElse("20170112T090000Z"), lastModified.orElse("20170106T115036Z"));
+                    recurrenceId.orElse("20170112T090000Z"), lastModified.orElse("20170106T115036Z"),
+                    organizer.orElse(sender), icsAttendee.orElse(sender));
             }
         }
     }
@@ -165,6 +172,10 @@ public class RestrictiveCalDavCollectIntegrationTest {
 
     @BeforeEach
     void setUpJamesServer(@TempDir File temporaryFolder) throws Exception {
+        startServer(temporaryFolder, "strict");
+    }
+
+    private void startServer(File dir, String alignmentMode) throws Exception {
         jamesServer = TemporaryJamesServer.builder()
             .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
                 new OpenPaasModule()))
@@ -204,9 +215,10 @@ public class RestrictiveCalDavCollectIntegrationTest {
                             .addProperty(ICALToJsonAttribute.RAW_SOURCE_ATTRIBUTE_NAME, "rawIcalendar"))
                         .addMailet(MailetConfiguration.builder()
                             .matcher(All.class)
-                            .mailet(RestrictiveCalDavCollect.class))
+                            .mailet(RestrictiveCalDavCollect.class)
+                            .addProperty("alignmentMode", alignmentMode))
                         .addMailetsFrom(CommonProcessors.deliverOnlyTransport())))
-            .build(temporaryFolder);
+            .build(dir);
 
         jamesServer.start();
 
@@ -299,6 +311,159 @@ public class RestrictiveCalDavCollectIntegrationTest {
             .orElse(""))
             .isEqualTo("ACCEPTED");
     }
+
+    // ---- alignmentMode tests ----
+
+    @Test
+    void alignmentModeStrictShouldSkipRequestUpdateWhenOrganizerDoesNotMatchSender() throws Exception {
+        String calendarUid = UUID.randomUUID().toString();
+        pushCalendarToDav(receiver, calendarUid, "office");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        EmailTemplateUser fakeOrganizer = new EmailTemplateUser("Fake Org", "fake-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(toTemplateUser(sender))
+                .receiver(toTemplateUser(receiver))
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .sequence("1")
+                .location("office2")
+                .organizer(fakeOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        // Location must stay "office" — update was rejected
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperty(Property.LOCATION).get().getValue())
+            .isEqualTo("office");
+    }
+
+    @Test
+    void alignmentModeStrictShouldSkipCancelWhenOrganizerDoesNotMatchSender() throws Exception {
+        String calendarUid = UUID.randomUUID().toString();
+        pushCalendarToDav(receiver, calendarUid, "office");
+
+        String cancelMsgId = UUID.randomUUID().toString();
+        EmailTemplateUser fakeOrganizer = new EmailTemplateUser("Fake Org", "fake-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String cancelMail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(toTemplateUser(sender))
+                .receiver(toTemplateUser(receiver))
+                .mimeMessageId(cancelMsgId)
+                .calendarUid(calendarUid)
+                .method("CANCEL")
+                .organizer(fakeOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, cancelMail, cancelMsgId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        // Event must still exist (not null) and must NOT have been cancelled
+        assertThat(result).isNotNull();
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperty(Property.STATUS)
+            .map(Property::getValue)
+            .orElse("NONE"))
+            .isNotEqualTo("CANCELLED");
+    }
+
+    @Test
+    void alignmentModeStrictShouldSkipReplyWhenSenderNotInAttendees() throws Exception {
+        String calendarUid = UUID.randomUUID().toString();
+        pushCalendarToDav(sender, calendarUid, "office");
+
+        String replyMsgId = UUID.randomUUID().toString();
+        EmailTemplateUser differentAttendee = new EmailTemplateUser("Other", "other@" + OpenPaaSProvisioningService.DOMAIN);
+        String replyMail = generateMail("template/emailReplyWithoutOrganizer.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(toTemplateUser(receiver))
+                .receiver(toTemplateUser(sender))
+                .mimeMessageId(replyMsgId)
+                .calendarUid(calendarUid)
+                .icsAttendee(differentAttendee)
+                .build());
+
+        sendMessage(receiver, sender, replyMail, replyMsgId);
+
+        DavCalendarObject result = davClient.caldav(sender.email())
+            .getCalendarObject(new DavUser(sender.id(), sender.email()), new DavUid(calendarUid)).block();
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperties(Property.ATTENDEE).stream()
+            .map(p -> (Attendee) p)
+            .filter(a -> a.getCalAddress().getSchemeSpecificPart().equalsIgnoreCase(receiver.email().asString()))
+            .findFirst()
+            .flatMap(a -> a.getParameter("PARTSTAT"))
+            .map(parameter -> ((Parameter) parameter).getValue())
+            .orElse("NEEDS-ACTION"))
+            .isEqualTo("NEEDS-ACTION");
+    }
+
+    @Test
+    void alignmentModeSameDomainShouldAllowRequestUpdateWhenOrganizerHasSameDomain(@TempDir File altDir) throws Exception {
+        jamesServer.shutdown();
+        startServer(altDir, "sameDomain");
+
+        String calendarUid = UUID.randomUUID().toString();
+        pushCalendarToDav(receiver, calendarUid, "office");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        EmailTemplateUser sameDomainOrganizer = new EmailTemplateUser("Same Domain Org", "same-domain-org@" + OpenPaaSProvisioningService.DOMAIN);
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(toTemplateUser(sender))
+                .receiver(toTemplateUser(receiver))
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .sequence("1")
+                .location("office2")
+                .organizer(sameDomainOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperty(Property.LOCATION).get().getValue())
+            .isEqualTo("office2");
+    }
+
+    @Test
+    void alignmentModeNoneShouldAllowRequestUpdateWithAnyOrganizer(@TempDir File altDir) throws Exception {
+        jamesServer.shutdown();
+        startServer(altDir, "none");
+
+        String calendarUid = UUID.randomUUID().toString();
+        pushCalendarToDav(receiver, calendarUid, "office");
+
+        String mimeMessageId = UUID.randomUUID().toString();
+        EmailTemplateUser externalOrganizer = new EmailTemplateUser("External Org", "organizer@external.tld");
+        String mail = generateMail("template/emailWithAliceInviteBob.eml.mustache",
+            EmailTemplateData.builder()
+                .sender(toTemplateUser(sender))
+                .receiver(toTemplateUser(receiver))
+                .mimeMessageId(mimeMessageId)
+                .calendarUid(calendarUid)
+                .sequence("1")
+                .location("office2")
+                .organizer(externalOrganizer)
+                .build());
+
+        sendMessage(sender, receiver, mail, mimeMessageId);
+
+        DavCalendarObject result = davClient.caldav(receiver.email())
+            .getCalendarObject(new DavUser(receiver.id(), receiver.email()), new DavUid(calendarUid)).block();
+        assertThat(result.calendarData().getComponent(Component.VEVENT).get()
+            .getProperty(Property.LOCATION).get().getValue())
+            .isEqualTo("office2");
+    }
+
+    // ---- end alignmentMode tests ----
 
     private void pushCalendarToDav(OpenPaasUser user, String calendarUid, String location) {
         String ics = "BEGIN:VCALENDAR\r\n" +

--- a/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/aliceInviteBob.ics.mustache
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/aliceInviteBob.ics.mustache
@@ -18,7 +18,7 @@ SUMMARY:Sprint planning #23
 DESCRIPTION: description 123
 CLASS:PUBLIC
 PRIORITY:5
-ORGANIZER;X-OBM-ID=128;CN={{sender.name}}:MAILTO:{{sender.email}}
+ORGANIZER;X-OBM-ID=128;CN={{organizer.name}}:MAILTO:{{organizer.email}}
 X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.linagora.com/abcd
 LOCATION:{{location}}
 RRULE:FREQ=DAILY;COUNT=3

--- a/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/recurrenceId.ics.mustache
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/recurrenceId.ics.mustache
@@ -18,7 +18,7 @@ SUMMARY:Sprint planning #23
 DESCRIPTION: description 123
 CLASS:PUBLIC
 PRIORITY:5
-ORGANIZER;X-OBM-ID=128;CN={{sender.name}}:MAILTO:{{sender.email}}
+ORGANIZER;X-OBM-ID=128;CN={{organizer.name}}:MAILTO:{{organizer.email}}
 X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.linagora.com/abcd
 LOCATION:{{location}}
 RECURRENCE-ID:{{recurrenceId}}

--- a/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/replyWithoutOrganizer.ics.mustache
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/resources/template/ics/replyWithoutOrganizer.ics.mustache
@@ -9,6 +9,6 @@ DTSTART:{{dtStart}}
 DTEND:{{dtEnd}}
 SEQUENCE:{{sequence}}
 SUMMARY:Sprint planning #23
-ATTENDEE;PARTSTAT=ACCEPTED;CN={{sender.name}}:mailto:{{sender.email}}
+ATTENDEE;PARTSTAT=ACCEPTED;CN={{icsAttendee.name}}:mailto:{{icsAttendee.email}}
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `alignmentMode` parameter for calendar event synchronization, supporting three modes: `strict` (exact match), `sameDomain` (domain-only match), and `none` (no validation).
  * Events with misaligned sender addresses are now silently dropped with warning logs.

* **Documentation**
  * Updated CalDavCollect and RestrictiveCalDavCollect configuration documentation with alignment mode details and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->