### PR TITLE
[FIX] Limit amount of collected contacts and improve //ism

### DIFF
--- a/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
+++ b/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
@@ -58,6 +58,7 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linagora.tmail.james.jmap.contact.ContactAddIndexingProcessor;
 import com.linagora.tmail.james.jmap.contact.ContactFields;
 
@@ -71,7 +72,8 @@ public class CollectTrustedContactsListener implements EventListener.ReactiveGro
 
     public static final String TO_BE_COLLECTED_FLAG = "$to_be_collected";
     public static final String CARDDAV_COLLECT_LIMIT_PROPERTY = "tmail.carddav.collect.limit";
-    private static final OptionalLong COLLECT_LIMIT = Optional.ofNullable(System.getProperty(CARDDAV_COLLECT_LIMIT_PROPERTY))
+    @VisibleForTesting
+    static OptionalLong COLLECT_LIMIT = Optional.ofNullable(System.getProperty(CARDDAV_COLLECT_LIMIT_PROPERTY))
         .stream()
         .mapToLong(Long::parseLong)
         .filter(l -> l > 0)

--- a/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
+++ b/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
@@ -54,7 +54,6 @@ import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
-import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
+++ b/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/CollectTrustedContactsListener.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
@@ -53,6 +54,7 @@ import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +71,12 @@ public class CollectTrustedContactsListener implements EventListener.ReactiveGro
     }
 
     public static final String TO_BE_COLLECTED_FLAG = "$to_be_collected";
+    public static final String CARDDAV_COLLECT_LIMIT_PROPERTY = "tmail.carddav.collect.limit";
+    private static final OptionalLong COLLECT_LIMIT = Optional.ofNullable(System.getProperty(CARDDAV_COLLECT_LIMIT_PROPERTY))
+        .stream()
+        .mapToLong(Long::parseLong)
+        .filter(l -> l > 0)
+        .findFirst();
     private static final Group GROUP = new CollectTrustedContactsListenerGroup();
     private static final Logger LOGGER = LoggerFactory.getLogger(CollectTrustedContactsListener.class);
 
@@ -130,11 +138,19 @@ public class CollectTrustedContactsListener implements EventListener.ReactiveGro
     private Mono<Void> collectContacts(Username username, List<MessageId> messageIds) {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
 
-        return Flux.from(messageIdManager.getMessagesReactive(messageIds, FetchGroup.HEADERS, mailboxSession))
-            .flatMap(messageResult -> extractContacts(messageResult, username))
+        Flux<ContactFields> contacts = Flux.from(messageIdManager.getMessagesReactive(messageIds, FetchGroup.HEADERS, mailboxSession))
+            .flatMap(messageResult -> extractContacts(messageResult, username));
+
+        return applyCollectLimit(contacts)
             .flatMap(contact -> Mono.from(contactAddIndexingProcessor.process(username, contact)), LOW_CONCURRENCY)
             .then();
     }
+
+    private <T> Flux<T> applyCollectLimit(Flux<T> flux) {
+        return COLLECT_LIMIT.isPresent() ? flux.take(COLLECT_LIMIT.getAsLong()) : flux;
+    }
+
+
 
     private boolean hasTrustedFlag(MailboxEvents.Added addedEvent) {
         return addedEvent.getAdded()
@@ -162,7 +178,7 @@ public class CollectTrustedContactsListener implements EventListener.ReactiveGro
     private Flux<ContactFields> extractContacts(MessageResult messageResult, Username username) {
         return parseMessage(messageResult)
             .flatMapMany(parsedMessage -> Flux.fromStream(allMailboxes(parsedMessage))
-                .flatMap(mailbox -> Mono.justOrEmpty(asContact(mailbox, username))))
+                .flatMap(mailbox -> Mono.justOrEmpty(asContact(mailbox, username)), LOW_CONCURRENCY))
             .filter(contact -> !isEventUser(contact, username));
     }
 

--- a/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/CollectTrustedContactsListenerTest.java
+++ b/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/CollectTrustedContactsListenerTest.java
@@ -18,7 +18,6 @@
 
 package com.linagora.tmail.listener;
 
-import static com.linagora.tmail.listener.CollectTrustedContactsListener.CARDDAV_COLLECT_LIMIT_PROPERTY;
 import static com.linagora.tmail.listener.CollectTrustedContactsListener.TO_BE_COLLECTED_FLAG;
 import static jakarta.mail.Flags.Flag.FLAGGED;
 import static jakarta.mail.Flags.Flag.SEEN;
@@ -29,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.OptionalLong;
 
 import jakarta.mail.Flags;
 
@@ -313,12 +313,12 @@ class CollectTrustedContactsListenerTest {
 
         @AfterEach
         void tearDown() {
-            System.clearProperty(CARDDAV_COLLECT_LIMIT_PROPERTY);
+            CollectTrustedContactsListener.COLLECT_LIMIT = OptionalLong.empty();
         }
 
         @Test
         void shouldIndexOnlyUpToLimitContactsWhenLimitIsSet() throws Exception {
-            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "2");
+            CollectTrustedContactsListener.COLLECT_LIMIT = OptionalLong.of(2);
 
             Message message = Message.Builder.of()
                 .setFrom("Alice <alice@domain.tld>")
@@ -333,7 +333,7 @@ class CollectTrustedContactsListenerTest {
 
         @Test
         void shouldIndexAllContactsWhenLimitExceedsContactCount() throws Exception {
-            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "100");
+            CollectTrustedContactsListener.COLLECT_LIMIT = OptionalLong.of(100);
 
             Message message = Message.Builder.of()
                 .setFrom("Alice <alice@domain.tld>")
@@ -349,7 +349,7 @@ class CollectTrustedContactsListenerTest {
 
         @Test
         void shouldIndexAllContactsWhenLimitIsZero() throws Exception {
-            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "0");
+            CollectTrustedContactsListener.COLLECT_LIMIT = OptionalLong.empty();
 
             Message message = Message.Builder.of()
                 .setFrom("Alice <alice@domain.tld>")
@@ -365,7 +365,7 @@ class CollectTrustedContactsListenerTest {
 
         @Test
         void shouldIndexAllContactsWhenLimitIsNegative() throws Exception {
-            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "-1");
+            CollectTrustedContactsListener.COLLECT_LIMIT = OptionalLong.empty();
 
             Message message = Message.Builder.of()
                 .setFrom("Alice <alice@domain.tld>")

--- a/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/CollectTrustedContactsListenerTest.java
+++ b/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/CollectTrustedContactsListenerTest.java
@@ -18,6 +18,7 @@
 
 package com.linagora.tmail.listener;
 
+import static com.linagora.tmail.listener.CollectTrustedContactsListener.CARDDAV_COLLECT_LIMIT_PROPERTY;
 import static com.linagora.tmail.listener.CollectTrustedContactsListener.TO_BE_COLLECTED_FLAG;
 import static jakarta.mail.Flags.Flag.FLAGGED;
 import static jakarta.mail.Flags.Flag.SEEN;
@@ -42,7 +43,9 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.field.address.DefaultAddressParser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
@@ -303,6 +306,92 @@ class CollectTrustedContactsListenerTest {
     private void addFlags(ComposedMessageId composedMessageId, Flags flags) throws Exception {
         mailboxManager.getMailbox(bobInboxId, bobMailboxSession)
             .setFlags(flags, MessageManager.FlagsUpdateMode.ADD, MessageRange.one(composedMessageId.getUid()), bobMailboxSession);
+    }
+
+    @Nested
+    class CollectLimitTest {
+
+        @AfterEach
+        void tearDown() {
+            System.clearProperty(CARDDAV_COLLECT_LIMIT_PROPERTY);
+        }
+
+        @Test
+        void shouldIndexOnlyUpToLimitContactsWhenLimitIsSet() throws Exception {
+            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "2");
+
+            Message message = Message.Builder.of()
+                .setFrom("Alice <alice@domain.tld>")
+                .setTo(BOB.asString(), "Carol <carol@domain.tld>")
+                .setCc(DefaultAddressParser.DEFAULT.parseMailbox("David <david@domain.tld>"))
+                .setBody("Body", StandardCharsets.UTF_8)
+                .build();
+            appendMessage(bobInboxId, message, new Flags(TO_BE_COLLECTED_FLAG));
+
+            assertThat(capturingContactAddIndexingProcessor.invocationCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldIndexAllContactsWhenLimitExceedsContactCount() throws Exception {
+            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "100");
+
+            Message message = Message.Builder.of()
+                .setFrom("Alice <alice@domain.tld>")
+                .setTo(BOB.asString(), "Carol <carol@domain.tld>")
+                .setCc(DefaultAddressParser.DEFAULT.parseMailbox("David <david@domain.tld>"))
+                .setBody("Body", StandardCharsets.UTF_8)
+                .build();
+            appendMessage(bobInboxId, message, new Flags(TO_BE_COLLECTED_FLAG));
+
+            assertThat(capturingContactAddIndexingProcessor.indexedAddresses())
+                .containsExactlyInAnyOrder(ALICE_ADDRESS, CAROL_ADDRESS, DAVID_ADDRESS);
+        }
+
+        @Test
+        void shouldIndexAllContactsWhenLimitIsZero() throws Exception {
+            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "0");
+
+            Message message = Message.Builder.of()
+                .setFrom("Alice <alice@domain.tld>")
+                .setTo(BOB.asString(), "Carol <carol@domain.tld>")
+                .setCc(DefaultAddressParser.DEFAULT.parseMailbox("David <david@domain.tld>"))
+                .setBody("Body", StandardCharsets.UTF_8)
+                .build();
+            appendMessage(bobInboxId, message, new Flags(TO_BE_COLLECTED_FLAG));
+
+            assertThat(capturingContactAddIndexingProcessor.indexedAddresses())
+                .containsExactlyInAnyOrder(ALICE_ADDRESS, CAROL_ADDRESS, DAVID_ADDRESS);
+        }
+
+        @Test
+        void shouldIndexAllContactsWhenLimitIsNegative() throws Exception {
+            System.setProperty(CARDDAV_COLLECT_LIMIT_PROPERTY, "-1");
+
+            Message message = Message.Builder.of()
+                .setFrom("Alice <alice@domain.tld>")
+                .setTo(BOB.asString(), "Carol <carol@domain.tld>")
+                .setCc(DefaultAddressParser.DEFAULT.parseMailbox("David <david@domain.tld>"))
+                .setBody("Body", StandardCharsets.UTF_8)
+                .build();
+            appendMessage(bobInboxId, message, new Flags(TO_BE_COLLECTED_FLAG));
+
+            assertThat(capturingContactAddIndexingProcessor.indexedAddresses())
+                .containsExactlyInAnyOrder(ALICE_ADDRESS, CAROL_ADDRESS, DAVID_ADDRESS);
+        }
+
+        @Test
+        void shouldIndexAllContactsWhenLimitPropertyIsNotSet() throws Exception {
+            Message message = Message.Builder.of()
+                .setFrom("Alice <alice@domain.tld>")
+                .setTo(BOB.asString(), "Carol <carol@domain.tld>")
+                .setCc(DefaultAddressParser.DEFAULT.parseMailbox("David <david@domain.tld>"))
+                .setBody("Body", StandardCharsets.UTF_8)
+                .build();
+            appendMessage(bobInboxId, message, new Flags(TO_BE_COLLECTED_FLAG));
+
+            assertThat(capturingContactAddIndexingProcessor.indexedAddresses())
+                .containsExactlyInAnyOrder(ALICE_ADDRESS, CAROL_ADDRESS, DAVID_ADDRESS);
+        }
     }
 
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CardDavCollectedContact.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CardDavCollectedContact.java
@@ -20,6 +20,7 @@ package com.linagora.tmail.mailet;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import jakarta.inject.Inject;
 import jakarta.mail.MessagingException;
@@ -27,6 +28,7 @@ import jakarta.mail.MessagingException;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.util.FunctionalUtils;
+import org.apache.james.util.ReactorUtils;
 import org.apache.mailet.AttributeUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
@@ -49,6 +51,12 @@ import reactor.core.publisher.Mono;
  */
 public class CardDavCollectedContact extends GenericMailet {
     private static final Logger LOGGER = LoggerFactory.getLogger(CardDavCollectedContact.class);
+    static final String CARDDAV_COLLECT_LIMIT_PROPERTY = "tmail.carddav.collect.limit";
+    private static final OptionalLong COLLECT_LIMIT = Optional.ofNullable(System.getProperty(CARDDAV_COLLECT_LIMIT_PROPERTY))
+        .stream()
+        .mapToLong(Long::parseLong)
+        .filter(l -> l > 0)
+        .findFirst();
 
     private final OpenPaasRestClient openPaasRestClient;
     private final DavClient davClient;
@@ -91,11 +99,16 @@ public class CardDavCollectedContact extends GenericMailet {
 
     private Mono<Void> collectedContactProcess(Username senderUsername, List<MailAddress> recipients) {
         return openPaasRestClient.searchOpenPaasUserId(senderUsername)
-            .flatMapMany(openPassUserId -> Flux.fromIterable(recipients)
+            .flatMapMany(openPassUserId -> applyCollectLimit(Flux.fromIterable(recipients))
                 .map(CardDavUtils::createObjectCreationRequest)
-                .flatMap(cardDavCreationObjectRequest -> createCollectedContactIfNotExists(senderUsername, openPassUserId, cardDavCreationObjectRequest)))
+                .flatMap(cardDavCreationObjectRequest -> createCollectedContactIfNotExists(senderUsername, openPassUserId, cardDavCreationObjectRequest), ReactorUtils.LOW_CONCURRENCY))
             .then();
     }
+
+    private <T> Flux<T> applyCollectLimit(Flux<T> flux) {
+        return COLLECT_LIMIT.isPresent() ? flux.take(COLLECT_LIMIT.getAsLong()) : flux;
+    }
+
 
     private Mono<Void> createCollectedContactIfNotExists(Username sender, OpenPaaSUserId openPassUserId, CardDavCreationObjectRequest cardDavCreationObjectRequest) {
         CardDavClient cardDavClient = davClient.carddav(sender);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limit for trusted contact collection via `tmail.carddav.collect.limit` property, allowing administrators to control the maximum number of contacts collected per mail.
  
* **Performance**
  * Improved contact collection pipeline with optimized concurrency handling for faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->