### PR TITLE
Adapt content-transfer-encoding -> content-encoding header

### DIFF
--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedWithEncryptedAndZstdBlobStoreTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedWithEncryptedAndZstdBlobStoreTest.java
@@ -20,7 +20,7 @@ package com.linagora.tmail.james.app;
 
 import static com.linagora.tmail.blob.guice.BlobStoreModulesChooser.INITIAL_BLOBSTORE_DAO;
 import static com.linagora.tmail.blob.guice.BlobStoreModulesChooser.MAYBE_ENCRYPTION_BLOBSTORE;
-import static org.apache.james.blob.api.BlobStoreDAO.ContentTransferEncoding.ZSTD;
+import static org.apache.james.blob.api.BlobStoreDAO.ContentEncoding.ZSTD;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.nio.charset.StandardCharsets;
@@ -133,14 +133,14 @@ class DistributedWithEncryptedAndZstdBlobStoreTest {
             // The intermediate encryption layer returns bytes that were zstd-compressed:
             // they differ from the original payload, keep zstd metadata, and round-trip through zstd decompression back to the original payload.
             softly.assertThat(blobSnapshot.encryptionLayerBlob().payload()).isNotEqualTo(blobSnapshot.originalPayload());
-            softly.assertThat(blobSnapshot.encryptionLayerBlob().metadata().contentTransferEncoding()).contains(ZSTD);
+            softly.assertThat(blobSnapshot.encryptionLayerBlob().metadata().contentEncoding()).contains(ZSTD);
             softly.assertThat(Zstd.decompress(blobSnapshot.encryptionLayerBlob().payload(), blobSnapshot.originalPayload().length))
                 .isEqualTo(blobSnapshot.originalPayload());
 
             // Raw storage must therefore be the encrypted form of those compressed bytes.
             softly.assertThat(blobSnapshot.rawStoredBlob().payload()).isNotEqualTo(blobSnapshot.originalPayload());
             softly.assertThat(blobSnapshot.rawStoredBlob().payload()).isNotEqualTo(blobSnapshot.encryptionLayerBlob().payload());
-            softly.assertThat(blobSnapshot.rawStoredBlob().metadata().contentTransferEncoding()).contains(ZSTD);
+            softly.assertThat(blobSnapshot.rawStoredBlob().metadata().contentEncoding()).contains(ZSTD);
             softly.assertThat(blobSnapshot.rawStoredBlob().metadata().get(ZstdBlobStoreDAO.CONTENT_ORIGINAL_SIZE))
                 .contains(new BlobStoreDAO.BlobMetadataValue(String.valueOf(blobSnapshot.originalPayload().length)));
         });

--- a/tmail-backend/apps/postgres/src/test/java/com/linagora/tmail/james/app/PostgresWithEncryptedAndZstdBlobStoreTest.java
+++ b/tmail-backend/apps/postgres/src/test/java/com/linagora/tmail/james/app/PostgresWithEncryptedAndZstdBlobStoreTest.java
@@ -21,7 +21,7 @@ package com.linagora.tmail.james.app;
 import static com.linagora.tmail.blob.guice.BlobStoreModulesChooser.INITIAL_BLOBSTORE_DAO;
 import static com.linagora.tmail.blob.guice.BlobStoreModulesChooser.MAYBE_ENCRYPTION_BLOBSTORE;
 import static com.linagora.tmail.james.app.PostgresTmailConfiguration.EventBusImpl.IN_MEMORY;
-import static org.apache.james.blob.api.BlobStoreDAO.ContentTransferEncoding.ZSTD;
+import static org.apache.james.blob.api.BlobStoreDAO.ContentEncoding.ZSTD;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.nio.charset.StandardCharsets;
@@ -135,14 +135,14 @@ class PostgresWithEncryptedAndZstdBlobStoreTest {
             // The intermediate encryption layer returns bytes that were zstd-compressed:
             // they differ from the original payload, keep zstd metadata, and round-trip through zstd decompression back to the original payload.
             softly.assertThat(blobSnapshot.encryptionLayerBlob().payload()).isNotEqualTo(blobSnapshot.originalPayload());
-            softly.assertThat(blobSnapshot.encryptionLayerBlob().metadata().contentTransferEncoding()).contains(ZSTD);
+            softly.assertThat(blobSnapshot.encryptionLayerBlob().metadata().contentEncoding()).contains(ZSTD);
             softly.assertThat(Zstd.decompress(blobSnapshot.encryptionLayerBlob().payload(), blobSnapshot.originalPayload().length))
                 .isEqualTo(blobSnapshot.originalPayload());
 
             // Raw storage must therefore be the encrypted form of those compressed bytes.
             softly.assertThat(blobSnapshot.rawStoredBlob().payload()).isNotEqualTo(blobSnapshot.originalPayload());
             softly.assertThat(blobSnapshot.rawStoredBlob().payload()).isNotEqualTo(blobSnapshot.encryptionLayerBlob().payload());
-            softly.assertThat(blobSnapshot.rawStoredBlob().metadata().contentTransferEncoding()).contains(ZSTD);
+            softly.assertThat(blobSnapshot.rawStoredBlob().metadata().contentEncoding()).contains(ZSTD);
             softly.assertThat(blobSnapshot.rawStoredBlob().metadata().get(ZstdBlobStoreDAO.CONTENT_ORIGINAL_SIZE))
                 .contains(new BlobStoreDAO.BlobMetadataValue(String.valueOf(blobSnapshot.originalPayload().length)));
         });

--- a/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/distributed/DistributedRspamdScannerIntegrationTest.java
+++ b/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/distributed/DistributedRspamdScannerIntegrationTest.java
@@ -18,10 +18,14 @@
 
 package com.linagora.tmail.integration.distributed;
 
+import java.io.IOException;
+
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.backends.redis.RedisExtension;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
@@ -60,4 +64,10 @@ public class DistributedRspamdScannerIntegrationTest extends RspamdScannerIntegr
         .server(configuration -> DistributedServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule()))
         .build();
+
+    @Disabled("CF https://github.com/linagora/tmail-backend/issues/2367")
+    @Test
+    @Override
+    public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
+    }
 }

--- a/tmail-backend/integration-tests/rspamd/postgres-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/postgres/PostgresRspamdScannerIntegrationTest.java
+++ b/tmail-backend/integration-tests/rspamd/postgres-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/postgres/PostgresRspamdScannerIntegrationTest.java
@@ -18,10 +18,14 @@
 
 package com.linagora.tmail.integration.postgres;
 
+import java.io.IOException;
+
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
 import org.apache.james.backends.postgres.PostgresExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
@@ -53,4 +57,10 @@ public class PostgresRspamdScannerIntegrationTest extends RspamdScannerIntegrati
         .server(configuration -> PostgresTmailServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule()))
         .build();
+
+    @Disabled("CF https://github.com/linagora/tmail-backend/issues/2367")
+    @Test
+    @Override
+    public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
+    }
 }

--- a/tmail-backend/integration-tests/rspamd/rspamd-integration-tests-common/src/main/java/com/linagora/tmail/integration/RspamdScannerIntegrationContract.java
+++ b/tmail-backend/integration-tests/rspamd/rspamd-integration-tests-common/src/main/java/com/linagora/tmail/integration/RspamdScannerIntegrationContract.java
@@ -78,7 +78,7 @@ public abstract class RspamdScannerIntegrationContract {
     }
 
     @Test
-    void messageShouldMoveToInboxWhenNotSpam() throws IOException {
+    public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
         assertThatCode(() -> messageSender.authenticate(BOB.asString(), BOB_PASSWORD)
             .sendMessage(BOB.asString(), ALICE.asString()))
             .doesNotThrowAnyException();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined ZSTD encoding metadata checks in blob store tests to validate compression metadata correctly.
  * Added a disabled integration test placeholder for "message moves to inbox when not spam" (linked to issue).
  * Made the related integration contract test method public to allow test overriding.

* **Chores**
  * Updated a subproject reference to point to a newer upstream commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->