### PR TITLE
[UPGRADE] netty.tcnative 2.0.65.Final -> 2.0.77.Final

### DIFF
--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -113,7 +113,7 @@
         <firebase-admin-sdk.version>9.3.0</firebase-admin-sdk.version>
         <bouncycastle.version>1.82</bouncycastle.version>
         <mongodb.version>5.5.1</mongodb.version>
-        <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.77.Final</netty.tcnative.version>
         <scala.base>2.13</scala.base>
     </properties>
 


### PR DESCRIPTION
Fixes ECDHE handling:

```
$ bash ssl-test.sh 172.30.0.2 993
=== Testing 172.30.0.2:993 ===

--- Protocols ---
KO  -tls1
KO  -tls1_1
OK  -tls1_2: New, TLSv1.2, Cipher is ECDHE-ECDSA-AES256-GCM-SHA384
OK  -tls1_3: New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384

--- TLS 1.2 ciphers ---
OK: ECDHE-ECDSA-AES256-GCM-SHA384
OK: ECDHE-ECDSA-CHACHA20-POLY1305
OK: ECDHE-ECDSA-AES128-GCM-SHA256
OK: ECDHE-ECDSA-AES256-SHA
OK: ECDHE-ECDSA-AES128-SHA

--- TLS 1.3 ciphers ---
OK: TLS_AES_128_GCM_SHA256
OK: TLS_AES_256_GCM_SHA384
OK: TLS_CHACHA20_POLY1305_SHA256
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netty tcnative library dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->