### PR TITLE
ISSUE-2367 Adapt messageShouldMoveToInboxWhenNotSpam test

### DIFF
--- a/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/distributed/DistributedRspamdScannerIntegrationTest.java
+++ b/tmail-backend/integration-tests/rspamd/distributed-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/distributed/DistributedRspamdScannerIntegrationTest.java
@@ -18,14 +18,10 @@
 
 package com.linagora.tmail.integration.distributed;
 
-import java.io.IOException;
-
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.backends.redis.RedisExtension;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
@@ -65,9 +61,4 @@ public class DistributedRspamdScannerIntegrationTest extends RspamdScannerIntegr
             .overrideWith(new LinagoraTestJMAPServerModule()))
         .build();
 
-    @Disabled("CF https://github.com/linagora/tmail-backend/issues/2367")
-    @Test
-    @Override
-    public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
-    }
 }

--- a/tmail-backend/integration-tests/rspamd/postgres-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/postgres/PostgresRspamdScannerIntegrationTest.java
+++ b/tmail-backend/integration-tests/rspamd/postgres-rspamd-integration-tests/src/test/java/com/linagora/tmail/integration/postgres/PostgresRspamdScannerIntegrationTest.java
@@ -18,14 +18,10 @@
 
 package com.linagora.tmail.integration.postgres;
 
-import java.io.IOException;
-
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
 import org.apache.james.backends.postgres.PostgresExtension;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
@@ -57,10 +53,4 @@ public class PostgresRspamdScannerIntegrationTest extends RspamdScannerIntegrati
         .server(configuration -> PostgresTmailServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule()))
         .build();
-
-    @Disabled("CF https://github.com/linagora/tmail-backend/issues/2367")
-    @Test
-    @Override
-    public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
-    }
 }

--- a/tmail-backend/integration-tests/rspamd/rspamd-integration-tests-common/src/main/java/com/linagora/tmail/integration/RspamdScannerIntegrationContract.java
+++ b/tmail-backend/integration-tests/rspamd/rspamd-integration-tests-common/src/main/java/com/linagora/tmail/integration/RspamdScannerIntegrationContract.java
@@ -79,8 +79,19 @@ public abstract class RspamdScannerIntegrationContract {
 
     @Test
     public void messageShouldMoveToInboxWhenNotSpam() throws IOException {
+        String message = "From: " + BOB.asString() + "\r\n" +
+            "To: " + ALICE.asString() + "\r\n" +
+            "Subject: test\r\n" +
+            "Date: Mon, 4 May 2026 04:00:00 +0000\r\n" +
+            "Message-ID: <not-spam-message@example.com>\r\n" +
+            "MIME-Version: 1.0\r\n" +
+            "Content-Type: text/plain; charset=UTF-8\r\n" +
+            "\r\n" +
+            "content\r\n" +
+            ".\r\n";
+
         assertThatCode(() -> messageSender.authenticate(BOB.asString(), BOB_PASSWORD)
-            .sendMessage(BOB.asString(), ALICE.asString()))
+            .sendMessageWithHeaders(BOB.asString(), ALICE.asString(), message))
             .doesNotThrowAnyException();
 
         imapClient.login(ALICE, ALICE_PASSWORD)


### PR DESCRIPTION
Failing after Rspamd upgrade to 3.14.3.

Root cause: with `rspamd/rspamd:3.14.3`, Rspamd now scores the old “not spam” fixture as spam enough to hit `add_header = 6`.

Rspamd log for the original fixture showed:

```text
(default: T (add header): [6.00/10.00]
[MISSING_MID(2.50), MISSING_TO(2.00), MISSING_DATE(1.00), R_MISSING_CHARSET(0.50), ...])
```

So TMail moved it away from INBOX because `RspamdScanner` maps `ADD_HEADER` to spam headers. After making the test fixture a realistic ham message with `To`, `Date`, `Message-ID`, `MIME-Version`, and `Content-Type`, the test passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unused test methods from integration test suite.
  * Updated email message sending in integration tests to use explicit RFC 822 headers for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->