### PR TITLE
ISSUE-2325 Domain defined signature templates

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
@@ -95,10 +95,13 @@ Configuration keys:
 
 Signature provisioning is controlled by the optional `defaultText` block:
 
+- `defaultText.provider`: Optional. Selects the signature engine. When absent, static per-locale signatures defined in the configuration are used. Supported values:
+** `DomainBasedSignatureTemplateEngine` — reads signatures from the domain-level repository managed via WebAdmin (see xref:tmail-backend/webadmin.adoc#_domain_signature_templates[Domain Signature Templates]).
+** Any fully-qualified class name implementing `SignatureTextFactory`, instantiated via Guice.
 - `defaultText.applyWhen`: Optional FQDN of an `ApplyWhenFilter` implementation loaded via Guice. Defaults to always-eligible.
-- `defaultText.defaultLanguage`: Fallback language. Defaults to `en`.
-- `defaultText.<locale>.textSignature`: Plain-text signature for a locale.
-- `defaultText.<locale>.htmlSignature`: HTML signature for a locale.
+- `defaultText.defaultLanguage`: Fallback language when no per-locale match is found. Defaults to `en`. Only used by the static provider.
+- `defaultText.<locale>.textSignature`: Plain-text signature for a locale. Only used by the static provider.
+- `defaultText.<locale>.htmlSignature`: HTML signature for a locale. Only used by the static provider.
 
 Signature templates support LDAP attribute interpolation using `+{ldap:attributeName}+`.
 `givenName`, `sn`, and the username attribute are always fetched; additional attributes must be declared via `extraAttributes`.
@@ -127,6 +130,35 @@ If a placeholder references an unknown or empty attribute it is left as-is.
   </listener>
 </listeners>
 ----
+
+=== Domain-Based Signature Engine
+
+Instead of static per-locale blocks, signatures can be managed at the domain level via WebAdmin
+and resolved dynamically at provisioning time:
+
+[source,xml]
+----
+<listeners>
+  <listener>
+    <class>com.linagora.tmail.james.jmap.event.IdentityProvisionListener</class>
+    <configuration>
+      <defaultText>
+        <provider>DomainBasedSignatureTemplateEngine</provider>
+      </defaultText>
+    </configuration>
+  </listener>
+</listeners>
+----
+
+The user's JMAP `language` setting is checked first; English is used as the final fallback.
+Users whose domain has no stored template receive an identity with no signature.
+
+Template text supports `{ldap:attributeName}` placeholders (same syntax as the static provider):
+`givenName`, `sn`, and the LDAP username attribute are always available; additional attributes
+require `extraAttributes` to be configured on the listener.
+
+See xref:tmail-backend/webadmin.adoc#_domain_signature_templates[Domain Signature Templates] for
+the WebAdmin API to manage templates.
 
 === SaaS Signature Enrichment
 

--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1568,3 +1568,95 @@ Return codes:
 - `200` Successfully returned the list of matching mails
 - `400` Missing or blank `reason`, invalid `limit`/`offset`, unknown sort property, or malformed JSON body
 
+== Domain Signature Templates
+
+Administrators can manage per-language email signature templates at the domain level.
+These templates are used by the `IdentityProvisionListener` (with the
+`DomainBasedSignatureTemplateEngine` provider) to populate the default identity signature
+of newly provisioned users, based on their preferred language.
+
+Template text supports `{ldap:attributeName}` placeholders.
+When `IdentityProvisionListener` provisions a user, it fetches that user's LDAP entry and
+substitutes every `{ldap:xxx}` placeholder with the matching LDAP attribute value.
+Unknown or missing attributes are left as-is.
+
+=== Getting signature templates for a domain
+
+....
+curl -XGET http://ip:port/domains/domain.tld/signature-templates
+....
+
+Returns the stored signature templates for the given domain.
+
+Return codes:
+
+- `200` Templates found and returned
+- `404` Domain does not exist, or no templates stored for this domain
+
+Example response:
+
+....
+{
+  "signatures": [
+    {
+      "language": "en",
+      "textSignature": "Best regards",
+      "htmlSignature": "<p>Best regards</p>"
+    },
+    {
+      "language": "fr",
+      "textSignature": "Cordialement",
+      "htmlSignature": "<p>Cordialement</p>"
+    }
+  ]
+}
+....
+
+=== Storing signature templates for a domain
+
+....
+curl -XPUT http://ip:port/domains/domain.tld/signature-templates \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "signatures": [
+      {
+        "language": "en",
+        "textSignature": "Best regards,\n{ldap:givenName} {ldap:sn}\n{ldap:title}",
+        "htmlSignature": "<p>Best regards,<br/>{ldap:givenName} {ldap:sn}<br/>{ldap:title}</p>"
+      },
+      {
+        "language": "fr",
+        "textSignature": "Cordialement,\n{ldap:givenName} {ldap:sn}\n{ldap:title}",
+        "htmlSignature": "<p>Cordialement,<br/>{ldap:givenName} {ldap:sn}<br/>{ldap:title}</p>"
+      }
+    ]
+  }'
+....
+
+Creates or replaces the signature templates for the given domain.
+The `signatures` list must contain at least one entry.
+
+LDAP attributes available by default: `givenName`, `sn`, and the LDAP username attribute.
+Additional attributes can be exposed via `extraAttributes` in the `IdentityProvisionListener`
+configuration (e.g. `telephoneNumber`, `title`).
+
+Return codes:
+
+- `204` Templates stored successfully
+- `400` Request body is missing or `signatures` is empty
+- `404` Domain does not exist
+
+=== Deleting signature templates for a domain
+
+....
+curl -XDELETE http://ip:port/domains/domain.tld/signature-templates
+....
+
+Removes all signature templates for the given domain.
+This operation is idempotent: deleting from a domain that has no templates returns 204.
+
+Return codes:
+
+- `204` Templates deleted (or were already absent)
+- `404` Domain does not exist
+

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -163,6 +163,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-domain-signature-templates</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>welcome-listener</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed/src/doc/release-instructions/1.0.18/index.md
+++ b/tmail-backend/apps/distributed/src/doc/release-instructions/1.0.18/index.md
@@ -1,0 +1,33 @@
+# Distributed Twake Mail backend 1.0.18 release instructions
+
+## Schema migration
+
+### Cassandra: new columns on the domains table
+
+Two new frozen map columns have been added to the `domains` Cassandra table to store per-language
+email signature templates.
+
+These columns are added automatically at startup via the data definition migration mechanism. No
+manual CQL migration is required.
+
+If for some reason you need to apply them manually:
+
+```cql
+ALTER TABLE domains ADD signature_text_per_language frozen<map<text, text>>;
+ALTER TABLE domains ADD signature_html_per_language frozen<map<text, text>>;
+```
+
+## New features
+
+### Domain-based signature templates (Optional)
+
+- [WebAdmin API](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc#_domain_signature_templates)
+- [Listener configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc#_domain_based_signature_engine)
+
+## Tmail deployment
+
+Please update your tmail-backend docker image to the following version: `linagora/tmail-backend:distributed-1.0.18`
+
+## References
+
+* Official Twake Mail release notes: https://github.com/linagora/tmail-backend/releases/tag/1.0.18

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -167,6 +167,7 @@ import com.linagora.tmail.imap.TMailIMAPModule;
 import com.linagora.tmail.james.jmap.ContactSupportCapabilitiesModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
+import com.linagora.tmail.james.jmap.event.CassandraDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.CassandraFirebaseSubscriptionRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseCommonModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
@@ -230,6 +231,7 @@ import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
 import com.linagora.tmail.webadmin.data.DomainTasksModule;
 import com.linagora.tmail.webadmin.data.UserDataTieringRoutesModule;
 import com.linagora.tmail.webadmin.data.UserDataTieringTaskModule;
+import com.linagora.tmail.webadmin.domainsignature.DomainSignatureTemplateRoutesModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
@@ -280,6 +282,7 @@ public class DistributedServer {
         new TeamMailboxModule(),
         new TeamMailboxRoutesModule(),
         new LabelRoutesModule(),
+        new DomainSignatureTemplateRoutesModule(),
         new SieveRoutesModule(),
         new WebAdminServerModule(),
         new WebAdminReIndexingTaskSerializationModule(),
@@ -383,6 +386,7 @@ public class DistributedServer {
             REQUIRE_TASK_MANAGER_MODULE,
             new DistributedTaskManagerModule()))
         .with(new CassandraLabelRepositoryModule(),
+            new CassandraDomainSignatureTemplateRepositoryModule(),
             new CassandraRateLimitingModule(),
             new CassandraUserQuotaReporterModule(),
             new CassandraJmapSettingsRepositoryModule(),

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -103,6 +103,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-domain-signature-templates</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>webadmin-jmap-labels</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -78,6 +78,7 @@ import com.linagora.tmail.OpenPaasModuleChooserConfiguration;
 import com.linagora.tmail.configuration.OpenPaasConfiguration;
 import com.linagora.tmail.disconnector.EventBusDisconnectorModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
+import com.linagora.tmail.james.app.modules.jmap.MemoryDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.app.modules.jmap.MemoryDownloadAllModule;
 import com.linagora.tmail.james.app.modules.jmap.MemoryFirebaseSubscriptionRepositoryModule;
 import com.linagora.tmail.james.app.modules.jmap.MemoryJmapSettingsRepositoryModule;
@@ -130,6 +131,7 @@ import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
 import com.linagora.tmail.webadmin.data.DomainTasksModule;
+import com.linagora.tmail.webadmin.domainsignature.DomainSignatureTemplateRoutesModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
@@ -194,6 +196,7 @@ public class MemoryServer {
           new TeamMailboxRoutesModule(),
           new TeamMailboxVaultRoutesModule(),
           new LabelRoutesModule(),
+          new DomainSignatureTemplateRoutesModule(),
           new DKIMMailetModule())
         .with(new TeamMailboxModule(),
             new TMailScanningQuotaSearcherModule(),
@@ -205,6 +208,7 @@ public class MemoryServer {
             new InMemoryEmailAddressContactSearchEngineModule(),
             new MemoryTmailEventBusModule(),
             new EmailAddressContactRoutesModule(),
+            new MemoryDomainSignatureTemplateRepositoryModule(),
             new MemoryLabelRepositoryModule(),
             new MemoryKeywordEmailQueryViewModule(),
             new MemoryJmapSettingsRepositoryModule(),

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/modules/jmap/MemoryDomainSignatureTemplateRepositoryModule.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/modules/jmap/MemoryDomainSignatureTemplateRepositoryModule.java
@@ -1,0 +1,33 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.app.modules.jmap;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.linagora.tmail.james.jmap.event.DomainSignatureTemplateRepository;
+import com.linagora.tmail.james.jmap.event.MemoryDomainSignatureTemplateRepository;
+
+public class MemoryDomainSignatureTemplateRepositoryModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(MemoryDomainSignatureTemplateRepository.class).in(Scopes.SINGLETON);
+        bind(DomainSignatureTemplateRepository.class).to(MemoryDomainSignatureTemplateRepository.class);
+    }
+}

--- a/tmail-backend/apps/postgres/pom.xml
+++ b/tmail-backend/apps/postgres/pom.xml
@@ -257,6 +257,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-domain-signature-templates</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-webadmin-team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/postgres/src/doc/release-instructions/1.0.18/index.md
+++ b/tmail-backend/apps/postgres/src/doc/release-instructions/1.0.18/index.md
@@ -1,0 +1,32 @@
+# Postgres Twake Mail backend 1.0.18 release instructions
+
+## Schema migration
+
+### Postgres: new column on the domains table
+
+A new JSONB column `signature_templates` has been added to the `domains` Postgres table to store
+per-language email signature templates.
+
+This column is added automatically at startup via the data definition migration mechanism. No manual
+SQL migration is required.
+
+If for some reason you need to apply it manually:
+
+```sql
+ALTER TABLE domains ADD COLUMN signature_templates jsonb;
+```
+
+## New features
+
+### Domain-based signature templates (Optional)
+
+- [WebAdmin API](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc#_domain_signature_templates)
+- [Listener configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc#_domain_based_signature_engine)
+
+## Tmail deployment
+
+Please update your tmail-backend docker image to the following version: `linagora/tmail-backend:postgresql-1.0.18`
+
+## References
+
+* Official Twake Mail release notes: https://github.com/linagora/tmail-backend/releases/tag/1.0.18

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -152,6 +152,7 @@ import com.linagora.tmail.james.app.modules.jmap.MemoryTmailEventBusModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
 import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
+import com.linagora.tmail.james.jmap.event.PostgresDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseCommonModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
 import com.linagora.tmail.james.jmap.firebase.PostgresFirebaseRepositoryModule;
@@ -208,6 +209,7 @@ import com.linagora.tmail.webadmin.archival.InboxArchivalTaskModule;
 import com.linagora.tmail.webadmin.cleanup.MailboxesCleanupModule;
 import com.linagora.tmail.webadmin.contact.aucomplete.ContactIndexingModule;
 import com.linagora.tmail.webadmin.data.DomainTasksModule;
+import com.linagora.tmail.webadmin.domainsignature.DomainSignatureTemplateRoutesModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
@@ -313,6 +315,7 @@ public class PostgresTmailServer {
         new TeamMailboxRoutesModule(),
         new TeamMailboxVaultRoutesModule(),
         new LabelRoutesModule(),
+        new DomainSignatureTemplateRoutesModule(),
         new UserIdentityModule(),
         new ContactIndexingModule(),
         new WebAdminMailOverWebModule(),
@@ -395,6 +398,7 @@ public class PostgresTmailServer {
             new RateLimitsRoutesModule(),
             new EmailAddressContactRoutesModule(),
             new PostgresLabelRepositoryModule(),
+            new PostgresDomainSignatureTemplateRepositoryModule(),
             new PostgresJmapSettingsRepositoryModule(),
             new PostgresPublicAssetRepositoryModule(),
             new PostgresTicketStoreModule(),

--- a/tmail-backend/data/data-cassandra/src/main/java/com/linagora/tmail/domainlist/cassandra/TMailCassandraDomainListDataDefinition.java
+++ b/tmail-backend/data/data-cassandra/src/main/java/com/linagora/tmail/domainlist/cassandra/TMailCassandraDomainListDataDefinition.java
@@ -39,6 +39,8 @@ public interface TMailCassandraDomainListDataDefinition {
     CqlIdentifier ACTIVATED = CqlIdentifier.fromCql("activated");
     CqlIdentifier CAN_UPGRADE = CqlIdentifier.fromCql("can_upgrade");
     CqlIdentifier IS_PAYING = CqlIdentifier.fromCql("is_paying");
+    CqlIdentifier SIGNATURE_TEXT_PER_LANGUAGE = CqlIdentifier.fromCql("signature_text_per_language");
+    CqlIdentifier SIGNATURE_HTML_PER_LANGUAGE = CqlIdentifier.fromCql("signature_html_per_language");
 
     CassandraDataDefinition MODULE = CassandraDataDefinition.table(TABLE_NAME)
         .comment("Holds domains this TMail server is operating on.")
@@ -54,6 +56,8 @@ public interface TMailCassandraDomainListDataDefinition {
             .withColumn(MAILS_RECEIVED_PER_DAYS, DataTypes.BIGINT)
             .withColumn(ACTIVATED, DataTypes.BOOLEAN)
             .withColumn(CAN_UPGRADE, DataTypes.BOOLEAN)
-            .withColumn(IS_PAYING, DataTypes.BOOLEAN))
+            .withColumn(IS_PAYING, DataTypes.BOOLEAN)
+            .withColumn(SIGNATURE_TEXT_PER_LANGUAGE, DataTypes.frozenMapOf(DataTypes.TEXT, DataTypes.TEXT))
+            .withColumn(SIGNATURE_HTML_PER_LANGUAGE, DataTypes.frozenMapOf(DataTypes.TEXT, DataTypes.TEXT)))
         .build();
 }

--- a/tmail-backend/data/data-postgres/src/main/java/com/linagora/tmail/domainlist/postgres/TMailPostgresDomainDataDefinition.java
+++ b/tmail-backend/data/data-postgres/src/main/java/com/linagora/tmail/domainlist/postgres/TMailPostgresDomainDataDefinition.java
@@ -38,6 +38,7 @@ import org.apache.james.backends.postgres.PostgresIndex;
 import org.apache.james.backends.postgres.PostgresTable;
 import org.apache.james.domainlist.postgres.PostgresDomainDataDefinition;
 import org.jooq.Field;
+import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
@@ -51,6 +52,7 @@ public interface TMailPostgresDomainDataDefinition {
         Field<Boolean> ACTIVATED = DSL.field("activated", SQLDataType.BOOLEAN);
         Field<Boolean> CAN_UPGRADE = DSL.field("can_upgrade", SQLDataType.BOOLEAN);
         Field<Boolean> IS_PAYING = DSL.field("is_paying", SQLDataType.BOOLEAN);
+        Field<JSONB> SIGNATURE_TEMPLATES = DSL.field("signature_templates", SQLDataType.JSONB);
 
         PostgresTable TABLE = PostgresTable.name(TABLE_NAME.getName())
             .createTableStep(((dsl, tableName) -> dsl.createTableIfNotExists(tableName)
@@ -64,6 +66,7 @@ public interface TMailPostgresDomainDataDefinition {
                 .column(ACTIVATED)
                 .column(CAN_UPGRADE)
                 .column(IS_PAYING)
+                .column(SIGNATURE_TEMPLATES)
                 .primaryKey(DOMAIN)))
             .disableRowLevelSecurity()
             .build();

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/event/DomainSignatureTemplateRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/event/DomainSignatureTemplateRepository.java
@@ -1,0 +1,34 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import java.util.Optional;
+
+import org.apache.james.core.Domain;
+
+import reactor.core.publisher.Mono;
+
+public interface DomainSignatureTemplateRepository {
+
+    Mono<Optional<DomainSignatureTemplate>> get(Domain domain);
+
+    Mono<Void> store(Domain domain, DomainSignatureTemplate template);
+
+    Mono<Void> delete(Domain domain);
+}

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/event/MemoryDomainSignatureTemplateRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/event/MemoryDomainSignatureTemplateRepository.java
@@ -1,0 +1,47 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.james.core.Domain;
+
+import reactor.core.publisher.Mono;
+
+public class MemoryDomainSignatureTemplateRepository implements DomainSignatureTemplateRepository {
+
+    private final Map<Domain, DomainSignatureTemplate> store = new ConcurrentHashMap<>();
+
+    @Override
+    public Mono<Optional<DomainSignatureTemplate>> get(Domain domain) {
+        return Mono.just(Optional.ofNullable(store.get(domain)));
+    }
+
+    @Override
+    public Mono<Void> store(Domain domain, DomainSignatureTemplate template) {
+        return Mono.fromRunnable(() -> store.put(domain, template));
+    }
+
+    @Override
+    public Mono<Void> delete(Domain domain) {
+        return Mono.fromRunnable(() -> store.remove(domain));
+    }
+}

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/event/DomainSignatureTemplate.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/event/DomainSignatureTemplate.scala
@@ -1,0 +1,46 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event
+
+import java.util.{Locale, Optional}
+
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText
+
+import scala.jdk.CollectionConverters._
+
+class DomainSignatureTemplate(val templates: java.util.Map[Locale, SignatureText]) {
+
+  def forLocale(locale: Locale, defaultLocale: Locale): Optional[SignatureText] =
+    Optional.ofNullable(templates.get(locale))
+      .or(() => Optional.ofNullable(templates.get(defaultLocale)))
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: DomainSignatureTemplate => templates == other.templates
+    case _ => false
+  }
+
+  override def hashCode(): Int = templates.hashCode()
+
+  override def toString: String = s"DomainSignatureTemplate($templates)"
+}
+
+object DomainSignatureTemplate {
+  def apply(templates: Map[Locale, SignatureText]): DomainSignatureTemplate =
+    new DomainSignatureTemplate(templates.asJava)
+}

--- a/tmail-backend/jmap/extensions-api/src/test/java/com/linagora/tmail/james/jmap/event/DomainSignatureTemplateRepositoryContract.java
+++ b/tmail-backend/jmap/extensions-api/src/test/java/com/linagora/tmail/james/jmap/event/DomainSignatureTemplateRepositoryContract.java
@@ -1,0 +1,115 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.james.core.Domain;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText;
+
+public interface DomainSignatureTemplateRepositoryContract {
+
+    Domain DOMAIN_A = Domain.of("a.com");
+    Domain DOMAIN_B = Domain.of("b.com");
+
+    DomainSignatureTemplateRepository testee();
+
+    @Test
+    default void getShouldReturnEmptyWhenNothingStored() {
+        assertThat(testee().get(DOMAIN_A).block()).isEmpty();
+    }
+
+    @Test
+    default void getShouldReturnStoredTemplate() {
+        DomainSignatureTemplate template = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text en", "html en")));
+
+        testee().store(DOMAIN_A, template).block();
+
+        assertThat(testee().get(DOMAIN_A).block()).contains(template);
+    }
+
+    @Test
+    default void getShouldReturnLatestTemplate() {
+        DomainSignatureTemplate first = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text v1", "html v1")));
+        DomainSignatureTemplate second = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text v2", "html v2")));
+
+        testee().store(DOMAIN_A, first).block();
+        testee().store(DOMAIN_A, second).block();
+
+        assertThat(testee().get(DOMAIN_A).block()).contains(second);
+    }
+
+    @Test
+    default void getShouldNotReturnTemplateOfOtherDomain() {
+        DomainSignatureTemplate template = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text en", "html en")));
+
+        testee().store(DOMAIN_A, template).block();
+
+        assertThat(testee().get(DOMAIN_B).block()).isEmpty();
+    }
+
+    @Test
+    default void getShouldReturnMultiLocaleTemplate() {
+        DomainSignatureTemplate template = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text en", "html en"),
+            Locale.FRENCH, new SignatureText("texte fr", "html fr")));
+
+        testee().store(DOMAIN_A, template).block();
+
+        assertThat(testee().get(DOMAIN_A).block()).contains(template);
+    }
+
+    @Test
+    default void deleteShouldRemoveTemplate() {
+        DomainSignatureTemplate template = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text en", "html en")));
+
+        testee().store(DOMAIN_A, template).block();
+        testee().delete(DOMAIN_A).block();
+
+        assertThat(testee().get(DOMAIN_A).block()).isEmpty();
+    }
+
+    @Test
+    default void deleteShouldBeIdempotent() {
+        testee().delete(DOMAIN_A).block();
+        assertThat(testee().get(DOMAIN_A).block()).isEmpty();
+    }
+
+    @Test
+    default void deleteShouldNotAffectOtherDomains() {
+        DomainSignatureTemplate template = new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, new SignatureText("text en", "html en")));
+
+        testee().store(DOMAIN_A, template).block();
+        testee().store(DOMAIN_B, template).block();
+        testee().delete(DOMAIN_A).block();
+
+        assertThat(testee().get(DOMAIN_B).block()).contains(template);
+    }
+}

--- a/tmail-backend/jmap/extensions-api/src/test/java/com/linagora/tmail/james/jmap/event/MemoryDomainSignatureTemplateRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-api/src/test/java/com/linagora/tmail/james/jmap/event/MemoryDomainSignatureTemplateRepositoryTest.java
@@ -1,0 +1,29 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+class MemoryDomainSignatureTemplateRepositoryTest implements DomainSignatureTemplateRepositoryContract {
+
+    private final MemoryDomainSignatureTemplateRepository repository = new MemoryDomainSignatureTemplateRepository();
+
+    @Override
+    public DomainSignatureTemplateRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepository.scala
+++ b/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepository.scala
@@ -1,0 +1,93 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event
+
+import java.util.{Locale, Optional}
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.`type`.codec.TypeCodecs
+import com.datastax.oss.driver.api.core.cql.PreparedStatement
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder.{bindMarker, selectFrom, update}
+import com.datastax.oss.driver.api.querybuilder.relation.Relation.column
+import com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition.{DOMAIN, SIGNATURE_HTML_PER_LANGUAGE, SIGNATURE_TEXT_PER_LANGUAGE, TABLE_NAME}
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText
+import jakarta.inject.Inject
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor
+import org.apache.james.core.Domain
+import reactor.core.publisher.Mono
+
+import scala.jdk.CollectionConverters._
+
+class CassandraDomainSignatureTemplateRepository @Inject()(session: CqlSession) extends DomainSignatureTemplateRepository {
+
+  private val executor: CassandraAsyncExecutor = new CassandraAsyncExecutor(session)
+
+  private val selectStatement: PreparedStatement = session.prepare(selectFrom(TABLE_NAME)
+    .columns(SIGNATURE_TEXT_PER_LANGUAGE, SIGNATURE_HTML_PER_LANGUAGE)
+    .where(column(DOMAIN).isEqualTo(bindMarker(DOMAIN)))
+    .build())
+
+  private val upsertStatement: PreparedStatement = session.prepare(update(TABLE_NAME)
+    .setColumn(SIGNATURE_TEXT_PER_LANGUAGE, bindMarker(SIGNATURE_TEXT_PER_LANGUAGE))
+    .setColumn(SIGNATURE_HTML_PER_LANGUAGE, bindMarker(SIGNATURE_HTML_PER_LANGUAGE))
+    .where(column(DOMAIN).isEqualTo(bindMarker(DOMAIN)))
+    .build())
+
+  private def fromRow(row: com.datastax.oss.driver.api.core.cql.Row): Optional[DomainSignatureTemplate] = {
+    val textMap = Option(row.getMap(SIGNATURE_TEXT_PER_LANGUAGE, classOf[String], classOf[String]))
+    val htmlMap = Option(row.getMap(SIGNATURE_HTML_PER_LANGUAGE, classOf[String], classOf[String]))
+    val langs = textMap.map(_.keySet.asScala).getOrElse(Set.empty) ++
+                htmlMap.map(_.keySet.asScala).getOrElse(Set.empty)
+    if (langs.isEmpty) {
+      Optional.empty[DomainSignatureTemplate]()
+    } else {
+      val templates = langs.map { lang =>
+        val locale = Locale.forLanguageTag(lang)
+        val text = textMap.flatMap(m => Option(m.get(lang))).getOrElse("")
+        val html = htmlMap.flatMap(m => Option(m.get(lang))).getOrElse("")
+        locale -> new SignatureText(text, html)
+      }.toMap
+      Optional.of(new DomainSignatureTemplate(templates.asJava))
+    }
+  }
+
+  override def get(domain: Domain): Mono[Optional[DomainSignatureTemplate]] =
+    executor.executeSingleRowOptional(selectStatement.bind()
+        .set(DOMAIN, domain.asString(), TypeCodecs.TEXT))
+      .map(rowOpt => rowOpt.flatMap[DomainSignatureTemplate](fromRow))
+
+  override def store(domain: Domain, template: DomainSignatureTemplate): Mono[Void] = {
+    val textMap: java.util.Map[String, String] = template.templates.asScala
+      .map { case (locale, sig) => locale.toLanguageTag -> sig.textSignature() }
+      .toMap.asJava
+    val htmlMap: java.util.Map[String, String] = template.templates.asScala
+      .map { case (locale, sig) => locale.toLanguageTag -> sig.htmlSignature() }
+      .toMap.asJava
+    executor.executeVoid(upsertStatement.bind()
+      .set(DOMAIN, domain.asString(), TypeCodecs.TEXT)
+      .setMap(SIGNATURE_TEXT_PER_LANGUAGE, textMap, classOf[String], classOf[String])
+      .setMap(SIGNATURE_HTML_PER_LANGUAGE, htmlMap, classOf[String], classOf[String]))
+  }
+
+  override def delete(domain: Domain): Mono[Void] =
+    executor.executeVoid(upsertStatement.bind()
+      .setToNull(SIGNATURE_TEXT_PER_LANGUAGE)
+      .setToNull(SIGNATURE_HTML_PER_LANGUAGE)
+      .set(DOMAIN, domain.asString(), TypeCodecs.TEXT))
+}

--- a/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepositoryModule.scala
+++ b/tmail-backend/jmap/extensions-cassandra/src/main/scala/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepositoryModule.scala
@@ -1,0 +1,28 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event
+
+import com.google.inject.{AbstractModule, Scopes}
+
+class CassandraDomainSignatureTemplateRepositoryModule extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[CassandraDomainSignatureTemplateRepository]).in(Scopes.SINGLETON)
+    bind(classOf[DomainSignatureTemplateRepository]).to(classOf[CassandraDomainSignatureTemplateRepository])
+  }
+}

--- a/tmail-backend/jmap/extensions-cassandra/src/test/java/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-cassandra/src/test/java/com/linagora/tmail/james/jmap/event/CassandraDomainSignatureTemplateRepositoryTest.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraDataDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.domainlist.cassandra.TMailCassandraDomainListDataDefinition;
+
+class CassandraDomainSignatureTemplateRepositoryTest implements DomainSignatureTemplateRepositoryContract {
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(TMailCassandraDomainListDataDefinition.MODULE);
+
+    private CassandraDomainSignatureTemplateRepository repository;
+
+    @BeforeEach
+    void setUp(CassandraCluster cluster) {
+        repository = new CassandraDomainSignatureTemplateRepository(cluster.getConf());
+    }
+
+    @Override
+    public DomainSignatureTemplateRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepository.java
+++ b/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepository.java
@@ -69,13 +69,14 @@ public class PostgresDomainSignatureTemplateRepository implements DomainSignatur
 
     @Override
     public Mono<Void> store(Domain domain, DomainSignatureTemplate template) {
+        String serialized = serialize(template);
         return postgresExecutor.executeVoid(dsl -> Mono.from(
             dsl.insertInto(org.apache.james.domainlist.postgres.PostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME,
                     DOMAIN, SIGNATURE_TEMPLATES)
-                .values(domain.asString(), jsonb(serialize(template)))
+                .values(domain.asString(), jsonb(serialized))
                 .onConflict(DOMAIN)
                 .doUpdate()
-                .set(SIGNATURE_TEMPLATES, jsonb(serialize(template)))));
+                .set(SIGNATURE_TEMPLATES, jsonb(serialized))));
     }
 
     @Override

--- a/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepository.java
+++ b/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepository.java
@@ -1,0 +1,111 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import static com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition.PostgresDomainTable.SIGNATURE_TEMPLATES;
+import static org.apache.james.backends.postgres.utils.PostgresExecutor.DEFAULT_INJECT;
+import static org.apache.james.domainlist.postgres.PostgresDomainDataDefinition.PostgresDomainTable.DOMAIN;
+import static org.jooq.JSONB.jsonb;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.apache.james.backends.postgres.utils.PostgresExecutor;
+import org.apache.james.core.Domain;
+import org.jooq.JSONB;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.lambdas.Throwing;
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText;
+
+import reactor.core.publisher.Mono;
+
+public class PostgresDomainSignatureTemplateRepository implements DomainSignatureTemplateRepository {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Map<String, String>>> TYPE_REF =
+        new TypeReference<>() {};
+
+    private final PostgresExecutor postgresExecutor;
+
+    @Inject
+    public PostgresDomainSignatureTemplateRepository(@Named(DEFAULT_INJECT) PostgresExecutor postgresExecutor) {
+        this.postgresExecutor = postgresExecutor;
+    }
+
+    @Override
+    public Mono<Optional<DomainSignatureTemplate>> get(Domain domain) {
+        return postgresExecutor.executeRow(dsl -> Mono.from(
+                dsl.select(SIGNATURE_TEMPLATES)
+                    .from(org.apache.james.domainlist.postgres.PostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME)
+                    .where(DOMAIN.eq(domain.asString()))))
+            .map(record -> Optional.ofNullable(record.get(SIGNATURE_TEMPLATES))
+                .map(Throwing.function((JSONB jsonb) -> deserialize(jsonb.data())).sneakyThrow()))
+            .defaultIfEmpty(Optional.empty());
+    }
+
+    @Override
+    public Mono<Void> store(Domain domain, DomainSignatureTemplate template) {
+        return postgresExecutor.executeVoid(dsl -> Mono.from(
+            dsl.insertInto(org.apache.james.domainlist.postgres.PostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME,
+                    DOMAIN, SIGNATURE_TEMPLATES)
+                .values(domain.asString(), jsonb(serialize(template)))
+                .onConflict(DOMAIN)
+                .doUpdate()
+                .set(SIGNATURE_TEMPLATES, jsonb(serialize(template)))));
+    }
+
+    @Override
+    public Mono<Void> delete(Domain domain) {
+        return postgresExecutor.executeVoid(dsl -> Mono.from(
+            dsl.update(org.apache.james.domainlist.postgres.PostgresDomainDataDefinition.PostgresDomainTable.TABLE_NAME)
+                .setNull(SIGNATURE_TEMPLATES)
+                .where(DOMAIN.eq(domain.asString()))));
+    }
+
+    private String serialize(DomainSignatureTemplate template) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(
+                template.templates().entrySet().stream()
+                    .collect(Collectors.toMap(
+                        entry -> entry.getKey().toLanguageTag(),
+                        entry -> Map.of("text", entry.getValue().textSignature(), "html", entry.getValue().htmlSignature()))));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize DomainSignatureTemplate", e);
+        }
+    }
+
+    private DomainSignatureTemplate deserialize(String json) throws JsonProcessingException {
+        Map<String, Map<String, String>> raw = OBJECT_MAPPER.readValue(json, TYPE_REF);
+        return new DomainSignatureTemplate(
+            raw.entrySet().stream()
+                .collect(Collectors.toMap(
+                    entry -> Locale.forLanguageTag(entry.getKey()),
+                    entry -> new SignatureText(
+                        entry.getValue().getOrDefault("text", ""),
+                        entry.getValue().getOrDefault("html", "")))));
+    }
+}

--- a/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepositoryModule.java
+++ b/tmail-backend/jmap/extensions-postgres/src/main/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepositoryModule.java
@@ -1,0 +1,31 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+public class PostgresDomainSignatureTemplateRepositoryModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(PostgresDomainSignatureTemplateRepository.class).in(Scopes.SINGLETON);
+        bind(DomainSignatureTemplateRepository.class).to(PostgresDomainSignatureTemplateRepository.class);
+    }
+}

--- a/tmail-backend/jmap/extensions-postgres/src/test/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-postgres/src/test/java/com/linagora/tmail/james/jmap/event/PostgresDomainSignatureTemplateRepositoryTest.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import org.apache.james.backends.postgres.PostgresDataDefinition;
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.domainlist.postgres.TMailPostgresDomainDataDefinition;
+
+class PostgresDomainSignatureTemplateRepositoryTest implements DomainSignatureTemplateRepositoryContract {
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.withoutRowLevelSecurity(
+        PostgresDataDefinition.aggregateModules(TMailPostgresDomainDataDefinition.MODULE));
+
+    private PostgresDomainSignatureTemplateRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new PostgresDomainSignatureTemplateRepository(postgresExtension.getDefaultPostgresExecutor());
+    }
+
+    @Override
+    public DomainSignatureTemplateRepository testee() {
+        return repository;
+    }
+}

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/DomainBasedSignatureTextFactory.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/DomainBasedSignatureTextFactory.java
@@ -1,0 +1,86 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
+import com.linagora.tmail.james.jmap.settings.JmapSettingsUtil;
+
+import reactor.core.publisher.Mono;
+
+public class DomainBasedSignatureTextFactory implements SignatureTextFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DomainBasedSignatureTextFactory.class);
+    private static final Locale DEFAULT_LANGUAGE = Locale.ENGLISH;
+
+    private final DomainSignatureTemplateRepository repository;
+    private final JmapSettingsRepository jmapSettingsRepository;
+
+    @Inject
+    public DomainBasedSignatureTextFactory(DomainSignatureTemplateRepository repository,
+                                           JmapSettingsRepository jmapSettingsRepository) {
+        this.repository = repository;
+        this.jmapSettingsRepository = jmapSettingsRepository;
+    }
+
+    @Override
+    public Mono<Optional<SignatureText>> forUser(Username username) {
+        return username.getDomainPart()
+            .map(domain -> resolveForDomain(username, domain))
+            .orElseGet(() -> {
+                LOGGER.debug("Username {} has no domain part. Returning empty signature.", username.asString());
+                return Mono.just(Optional.empty());
+            });
+    }
+
+    private Mono<Optional<SignatureText>> resolveForDomain(Username username, Domain domain) {
+        return repository.get(domain)
+            .flatMap(templateOpt -> templateOpt
+                .map(template -> resolveSignature(username, template))
+                .orElseGet(() -> {
+                    LOGGER.debug("No domain signature template found for domain {}. Returning empty.", domain.asString());
+                    return Mono.just(Optional.empty());
+                }));
+    }
+
+    private Mono<Optional<SignatureText>> resolveSignature(Username username, DomainSignatureTemplate template) {
+        return resolveUserLocale(username)
+            .map(locale -> template.forLocale(locale, DEFAULT_LANGUAGE));
+    }
+
+    private Mono<Locale> resolveUserLocale(Username username) {
+        return Mono.from(jmapSettingsRepository.get(username))
+            .map(settings -> JmapSettingsUtil.parseLocaleFromSettings(settings, DEFAULT_LANGUAGE)
+                .orElse(DEFAULT_LANGUAGE))
+            .defaultIfEmpty(DEFAULT_LANGUAGE)
+            .onErrorResume(error -> {
+                LOGGER.error("Error retrieving language for user {}. Falling back to {}.", username.asString(), DEFAULT_LANGUAGE, error);
+                return Mono.just(DEFAULT_LANGUAGE);
+            });
+    }
+}

--- a/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListener.java
+++ b/tmail-backend/jmap/extensions/src/main/java/com/linagora/tmail/james/jmap/event/IdentityProvisionListener.java
@@ -84,6 +84,8 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
     private static final int DEFAULT_IDENTITY_SORT_ORDER = 0;
     private static final int TEAM_MAILBOX_IDENTITY_SORT_ORDER = 10;
     private static final String APPLY_WHEN_PATH = "defaultText.applyWhen";
+    private static final String PROVIDER_PATH = "defaultText.provider";
+    private static final String DOMAIN_BASED_PROVIDER = "DomainBasedSignatureTemplateEngine";
 
     private final LDAPConnectionPool ldapConnectionPool;
     private final IdentityRepository identityRepository;
@@ -106,7 +108,7 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
         this.ldapConnectionPool = ldapConnectionPool;
         this.ldapConfiguration = ldapConfiguration;
         this.identityRepository = identityRepository;
-        this.signatureTextFactory = new DefaultSignatureTextFactory(jmapSettingsRepository, listenerConfig, resolveApplyWhenFilter(listenerConfig, guiceLoader));
+        this.signatureTextFactory = resolveSignatureTextFactory(jmapSettingsRepository, guiceLoader, listenerConfig);
         this.objectClassFilter = Filter.createEqualityFilter("objectClass", ldapConfiguration.getUserObjectClass());
         this.userExtraFilter = Optional.ofNullable(ldapConfiguration.getFilter())
             .map(Throwing.function(Filter::create).sneakyThrow());
@@ -119,6 +121,24 @@ public class IdentityProvisionListener implements EventListener.ReactiveGroupEve
             .add(surnameAttribute)
             .add(usernameAttribute)
             .build();
+    }
+
+    private SignatureTextFactory resolveSignatureTextFactory(JmapSettingsRepository jmapSettingsRepository,
+                                                              GuiceLoader guiceLoader,
+                                                              HierarchicalConfiguration<ImmutableNode> listenerConfig) {
+        String provider = listenerConfig.getString(PROVIDER_PATH, null);
+        if (provider != null && !provider.isBlank()) {
+            String fqdn = DOMAIN_BASED_PROVIDER.equals(provider)
+                ? DomainBasedSignatureTextFactory.class.getName() : provider;
+            try {
+                return guiceLoader.<SignatureTextFactory>withNamingSheme(NamingScheme.IDENTITY)
+                    .instantiate(new ClassName(fqdn));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to load SignatureTextFactory '%s'".formatted(provider), e);
+            }
+        }
+        return new DefaultSignatureTextFactory(jmapSettingsRepository, listenerConfig,
+            resolveApplyWhenFilter(listenerConfig, guiceLoader));
     }
 
     private ApplyWhenFilter resolveApplyWhenFilter(HierarchicalConfiguration<ImmutableNode> listenerConfig, GuiceLoader guiceLoader) {

--- a/tmail-backend/jmap/extensions/src/test/java/com/linagora/tmail/james/jmap/event/DomainBasedSignatureTextFactoryTest.java
+++ b/tmail-backend/jmap/extensions/src/test/java/com/linagora/tmail/james/jmap/event/DomainBasedSignatureTextFactoryTest.java
@@ -1,0 +1,122 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText;
+import com.linagora.tmail.james.jmap.settings.JmapSettingsKey;
+import com.linagora.tmail.james.jmap.settings.JmapSettingsPatch$;
+import com.linagora.tmail.james.jmap.settings.MemoryJmapSettingsRepository;
+
+import reactor.core.publisher.Mono;
+
+class DomainBasedSignatureTextFactoryTest {
+
+    private static final Username BOB = Username.of("bob@domain.tld");
+    private static final Username BOB_NO_DOMAIN = Username.of("bob");
+    private static final Domain DOMAIN = Domain.of("domain.tld");
+    private static final JmapSettingsKey LANGUAGE_KEY = JmapSettingsKey.liftOrThrow("language");
+    private static final SignatureText EN_SIG = new SignatureText("en text", "<p>en html</p>");
+    private static final SignatureText FR_SIG = new SignatureText("fr text", "<p>fr html</p>");
+
+    private MemoryDomainSignatureTemplateRepository repository;
+    private MemoryJmapSettingsRepository jmapSettingsRepository;
+    private DomainBasedSignatureTextFactory testee;
+
+    @BeforeEach
+    void setUp() {
+        repository = new MemoryDomainSignatureTemplateRepository();
+        jmapSettingsRepository = new MemoryJmapSettingsRepository();
+        testee = new DomainBasedSignatureTextFactory(repository, jmapSettingsRepository);
+    }
+
+    @Test
+    void forUserShouldReturnEmptyWhenNoDomainTemplate() {
+        assertThat(testee.forUser(BOB).block()).isEmpty();
+    }
+
+    @Test
+    void forUserShouldReturnEmptyWhenUserHasNoDomain() {
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(Locale.ENGLISH, EN_SIG))).block();
+
+        assertThat(testee.forUser(BOB_NO_DOMAIN).block()).isEmpty();
+    }
+
+    @Test
+    void forUserShouldReturnDefaultLanguageTemplateWhenUserHasNoLanguageSetting() {
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, EN_SIG,
+            Locale.FRENCH, FR_SIG))).block();
+
+        assertThat(testee.forUser(BOB).block()).contains(EN_SIG);
+    }
+
+    @Test
+    void forUserShouldReturnUserLanguageTemplate() {
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, EN_SIG,
+            Locale.FRENCH, FR_SIG))).block();
+
+        Mono.from(jmapSettingsRepository.updatePartial(BOB, JmapSettingsPatch$.MODULE$.toUpsert(LANGUAGE_KEY, "fr"))).block();
+
+        assertThat(testee.forUser(BOB).block()).contains(FR_SIG);
+    }
+
+    @Test
+    void forUserShouldFallBackToEnglishWhenUserLanguageNotInTemplate() {
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, EN_SIG))).block();
+
+        Mono.from(jmapSettingsRepository.updatePartial(BOB, JmapSettingsPatch$.MODULE$.toUpsert(LANGUAGE_KEY, "fr"))).block();
+
+        assertThat(testee.forUser(BOB).block()).contains(EN_SIG);
+    }
+
+    @Test
+    void forUserShouldReturnEmptyWhenDomainTemplateHasNoEnglishFallback() {
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+            Locale.FRENCH, FR_SIG))).block();
+
+        assertThat(testee.forUser(BOB).block()).isEmpty();
+    }
+
+    @Test
+    void ldapPlaceholdersShouldBeInterpolatedByCallerAfterForUser() {
+        SignatureText templateWithPlaceholders = new SignatureText(
+            "Regards, {ldap:givenName} {ldap:sn}",
+            "<p>Regards, {ldap:givenName} {ldap:sn}</p>");
+        repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+            Locale.ENGLISH, templateWithPlaceholders))).block();
+
+        SignatureText raw = testee.forUser(BOB).block().get();
+        SignatureText interpolated = raw.interpolate(Map.of("givenName", "John", "sn", "Doe"));
+
+        assertThat(interpolated.textSignature()).isEqualTo("Regards, John Doe");
+        assertThat(interpolated.htmlSignature()).isEqualTo("<p>Regards, John Doe</p>");
+    }
+}

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -99,6 +99,7 @@
         <module>webadmin/webadmin-jmap-labels</module>
         <module>webadmin/webadmin-team-mailboxes</module>
         <module>webadmin/webadmin-rate-limit</module>
+        <module>webadmin/webadmin-domain-signature-templates</module>
         <module>webadmin/webadmin-tmail-tasks</module>
         <module>healthcheck</module>
 
@@ -337,6 +338,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>webadmin-rate-limit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>webadmin-domain-signature-templates</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/pom.xml
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~  As a subpart of Twake Mail, this file is edited by Linagora.   ~
+  ~                                                                 ~
+  ~  https://twake-mail.com/                                        ~
+  ~  https://linagora.com                                           ~
+  ~                                                                 ~
+  ~  This file is subject to The Affero Gnu Public License          ~
+  ~  version 3.                                                     ~
+  ~                                                                 ~
+  ~  https://www.gnu.org/licenses/agpl-3.0.en.html                  ~
+  ~                                                                 ~
+  ~  This program is distributed in the hope that it will be        ~
+  ~  useful, but WITHOUT ANY WARRANTY; without even the implied     ~
+  ~  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR        ~
+  ~  PURPOSE. See the GNU Affero General Public License for         ~
+  ~  more details.                                                  ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tmail-backend</artifactId>
+        <groupId>com.linagora.tmail</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webadmin-domain-signature-templates</artifactId>
+    <name>Twake Mail :: WebAdmin :: Domain Signature Templates</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateDTO.java
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateDTO.java
@@ -1,0 +1,55 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.webadmin.domainsignature;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.tmail.james.jmap.event.DomainSignatureTemplate;
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText;
+
+public record DomainSignatureTemplateDTO(
+    @JsonProperty("signatures") List<SignatureEntryDTO> signatures) {
+
+    public record SignatureEntryDTO(
+        @JsonProperty("language") String language,
+        @JsonProperty("textSignature") String textSignature,
+        @JsonProperty("htmlSignature") String htmlSignature) {
+    }
+
+    public static DomainSignatureTemplateDTO from(DomainSignatureTemplate template) {
+        List<SignatureEntryDTO> entries = template.templates().entrySet().stream()
+            .map(entry -> new SignatureEntryDTO(
+                entry.getKey().toLanguageTag(),
+                entry.getValue().textSignature(),
+                entry.getValue().htmlSignature()))
+            .collect(Collectors.toList());
+        return new DomainSignatureTemplateDTO(entries);
+    }
+
+    public DomainSignatureTemplate toDomain() {
+        Map<java.util.Locale, SignatureText> templates = signatures.stream()
+            .collect(Collectors.toMap(
+                entry -> java.util.Locale.forLanguageTag(entry.language()),
+                entry -> new SignatureText(entry.textSignature(), entry.htmlSignature())));
+        return new DomainSignatureTemplate(templates);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateDTO.java
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateDTO.java
@@ -46,10 +46,16 @@ public record DomainSignatureTemplateDTO(
     }
 
     public DomainSignatureTemplate toDomain() {
+        if (signatures == null) {
+            throw new IllegalArgumentException("'signatures' field is mandatory");
+        }
         Map<java.util.Locale, SignatureText> templates = signatures.stream()
             .collect(Collectors.toMap(
                 entry -> java.util.Locale.forLanguageTag(entry.language()),
-                entry -> new SignatureText(entry.textSignature(), entry.htmlSignature())));
+                entry -> new SignatureText(entry.textSignature(), entry.htmlSignature()),
+                (a, b) -> {
+                    throw new IllegalArgumentException("Duplicate language tag in signatures");
+                }));
         return new DomainSignatureTemplate(templates);
     }
 }

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutes.java
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutes.java
@@ -1,0 +1,137 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.webadmin.domainsignature;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+import static spark.Spark.halt;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonExtractException;
+import org.apache.james.webadmin.utils.JsonExtractor;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.linagora.tmail.james.jmap.event.DomainSignatureTemplateRepository;
+
+import spark.Request;
+import spark.Service;
+
+public class DomainSignatureTemplateRoutes implements Routes {
+
+    static final String DOMAINS_BASE = SEPARATOR + "domains";
+    private static final String DOMAIN_PARAM = ":domain";
+    static final String SIGNATURE_TEMPLATES_PATH =
+        DOMAINS_BASE + SEPARATOR + DOMAIN_PARAM + SEPARATOR + "signature-templates";
+
+    private final DomainSignatureTemplateRepository repository;
+    private final DomainList domainList;
+    private final JsonTransformer jsonTransformer;
+    private final JsonExtractor<DomainSignatureTemplateDTO> jsonExtractor;
+
+    @Inject
+    public DomainSignatureTemplateRoutes(DomainSignatureTemplateRepository repository,
+                                         DomainList domainList,
+                                         JsonTransformer jsonTransformer) {
+        this.repository = repository;
+        this.domainList = domainList;
+        this.jsonTransformer = jsonTransformer;
+        this.jsonExtractor = new JsonExtractor<>(DomainSignatureTemplateDTO.class);
+    }
+
+    @Override
+    public String getBasePath() {
+        return DOMAINS_BASE;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(SIGNATURE_TEMPLATES_PATH, (req, res) -> getTemplate(req), jsonTransformer);
+        service.put(SIGNATURE_TEMPLATES_PATH, (req, res) -> {
+            putTemplate(req);
+            return halt(HttpStatus.NO_CONTENT_204);
+        });
+        service.delete(SIGNATURE_TEMPLATES_PATH, (req, res) -> {
+            deleteTemplate(req);
+            return halt(HttpStatus.NO_CONTENT_204);
+        });
+    }
+
+    private Object getTemplate(Request request) throws DomainListException {
+        Domain domain = extractDomain(request);
+        assertDomainExists(domain);
+
+        return repository.get(domain)
+            .map(opt -> opt.map(DomainSignatureTemplateDTO::from)
+                .orElseThrow(() -> ErrorResponder.builder()
+                    .statusCode(HttpStatus.NOT_FOUND_404)
+                    .type(ErrorResponder.ErrorType.NOT_FOUND)
+                    .message("No signature template found for domain '%s'", domain.asString())
+                    .haltError()))
+            .block();
+    }
+
+    private void putTemplate(Request request) throws DomainListException, JsonExtractException {
+        Domain domain = extractDomain(request);
+        assertDomainExists(domain);
+
+        DomainSignatureTemplateDTO dto = jsonExtractor.parse(request.body());
+        if (dto.signatures() == null || dto.signatures().isEmpty()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("'signatures' must not be empty")
+                .haltError();
+        }
+        repository.store(domain, dto.toDomain()).block();
+    }
+
+    private void deleteTemplate(Request request) throws DomainListException {
+        Domain domain = extractDomain(request);
+        assertDomainExists(domain);
+        repository.delete(domain).block();
+    }
+
+    private Domain extractDomain(Request request) {
+        try {
+            return Domain.of(request.params(DOMAIN_PARAM));
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid domain: '%s'", request.params(DOMAIN_PARAM))
+                .haltError();
+        }
+    }
+
+    private void assertDomainExists(Domain domain) throws DomainListException {
+        if (!domainList.containsDomain(domain)) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Domain '%s' does not exist", domain.asString())
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutesModule.java
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/src/main/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutesModule.java
@@ -1,0 +1,34 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.webadmin.domainsignature;
+
+import org.apache.james.webadmin.Routes;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class DomainSignatureTemplateRoutesModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Routes.class)
+            .addBinding()
+            .to(DomainSignatureTemplateRoutes.class);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-domain-signature-templates/src/test/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-domain-signature-templates/src/test/java/com/linagora/tmail/webadmin/domainsignature/DomainSignatureTemplateRoutesTest.java
@@ -1,0 +1,266 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.webadmin.domainsignature;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
+import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
+import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.james.core.Domain;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.james.jmap.event.DomainSignatureTemplate;
+import com.linagora.tmail.james.jmap.event.MemoryDomainSignatureTemplateRepository;
+import com.linagora.tmail.james.jmap.event.SignatureTextFactory.SignatureText;
+
+import io.restassured.RestAssured;
+
+class DomainSignatureTemplateRoutesTest {
+
+    private static final Domain DOMAIN = Domain.of("linagora.com");
+    private static final String DOMAIN_PATH = "/domains/linagora.com/signature-templates";
+
+    private WebAdminServer webAdminServer;
+    private MemoryDomainSignatureTemplateRepository repository;
+    private DomainList domainList;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        repository = new MemoryDomainSignatureTemplateRepository();
+        domainList = mock(DomainList.class);
+        when(domainList.containsDomain(DOMAIN)).thenReturn(true);
+
+        DomainSignatureTemplateRoutes routes = new DomainSignatureTemplateRoutes(
+            repository, domainList, new JsonTransformer());
+        webAdminServer = WebAdminUtils.createWebAdminServer(routes).start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Nested
+    class GetTemplate {
+        @Test
+        void getShouldReturn404WhenNoTemplate() {
+            when()
+                .get(DOMAIN_PATH)
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void getShouldReturn404WhenDomainNotFound() throws Exception {
+            when(domainList.containsDomain(Domain.of("unknown.com"))).thenReturn(false);
+
+            when()
+                .get("/domains/unknown.com/signature-templates")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void getShouldReturnStoredTemplate() {
+            repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+                Locale.ENGLISH, new SignatureText("en text", "<p>en</p>"),
+                Locale.FRENCH, new SignatureText("fr text", "<p>fr</p>")))).block();
+
+            String body = when()
+                .get(DOMAIN_PATH)
+            .then()
+                .statusCode(OK_200)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(body).node("signatures").isArray().hasSize(2);
+        }
+
+        @Test
+        void getShouldReturnAllFields() {
+            repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+                Locale.ENGLISH, new SignatureText("en text", "<p>en html</p>")))).block();
+
+            String body = when()
+                .get(DOMAIN_PATH)
+            .then()
+                .statusCode(OK_200)
+                .contentType(JSON)
+                .extract().body().asString();
+
+            assertThatJson(body).node("signatures[0]")
+                .isObject()
+                .containsKey("language")
+                .containsKey("textSignature")
+                .containsKey("htmlSignature");
+        }
+    }
+
+    @Nested
+    class PutTemplate {
+        @Test
+        void putShouldReturn204OnSuccess() {
+            given()
+                .contentType(JSON)
+                .body("""
+                    {
+                        "signatures": [
+                            {"language": "en", "textSignature": "Best regards", "htmlSignature": "<p>Best regards</p>"}
+                        ]
+                    }""")
+            .when()
+                .put(DOMAIN_PATH)
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void putShouldStoreTemplate() {
+            given()
+                .contentType(JSON)
+                .body("""
+                    {
+                        "signatures": [
+                            {"language": "en", "textSignature": "Best regards", "htmlSignature": "<p>Best regards</p>"}
+                        ]
+                    }""")
+            .when()
+                .put(DOMAIN_PATH);
+
+            String body = when()
+                .get(DOMAIN_PATH)
+            .then()
+                .statusCode(OK_200)
+                .extract().body().asString();
+
+            assertThatJson(body).node("signatures[0].textSignature").isEqualTo("\"Best regards\"");
+        }
+
+        @Test
+        void putShouldReturn400WhenEmptySignatures() {
+            given()
+                .contentType(JSON)
+                .body("""
+                    {"signatures": []}""")
+            .when()
+                .put(DOMAIN_PATH)
+            .then()
+                .statusCode(BAD_REQUEST_400);
+        }
+
+        @Test
+        void putShouldReturn404WhenDomainNotFound() throws Exception {
+            when(domainList.containsDomain(Domain.of("unknown.com"))).thenReturn(false);
+
+            given()
+                .contentType(JSON)
+                .body("""
+                    {
+                        "signatures": [
+                            {"language": "en", "textSignature": "t", "htmlSignature": "h"}
+                        ]
+                    }""")
+            .when()
+                .put("/domains/unknown.com/signature-templates")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void putShouldSupportMultipleLocales() {
+            given()
+                .contentType(JSON)
+                .body("""
+                    {
+                        "signatures": [
+                            {"language": "en", "textSignature": "Best regards", "htmlSignature": "<p>BR</p>"},
+                            {"language": "fr", "textSignature": "Cordialement", "htmlSignature": "<p>Cordialement</p>"}
+                        ]
+                    }""")
+            .when()
+                .put(DOMAIN_PATH)
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+    }
+
+    @Nested
+    class DeleteTemplate {
+        @Test
+        void deleteShouldReturn204WhenExists() {
+            repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+                Locale.ENGLISH, new SignatureText("t", "h")))).block();
+
+            when()
+                .delete(DOMAIN_PATH)
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteShouldReturn204WhenNotExists() {
+            when()
+                .delete(DOMAIN_PATH)
+            .then()
+                .statusCode(NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteShouldRemoveTemplate() {
+            repository.store(DOMAIN, new DomainSignatureTemplate(Map.of(
+                Locale.ENGLISH, new SignatureText("t", "h")))).block();
+
+            when().delete(DOMAIN_PATH);
+
+            when()
+                .get(DOMAIN_PATH)
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+
+        @Test
+        void deleteShouldReturn404WhenDomainNotFound() throws Exception {
+            when(domainList.containsDomain(Domain.of("unknown.com"))).thenReturn(false);
+
+            when()
+                .delete("/domains/unknown.com/signature-templates")
+            .then()
+                .statusCode(NOT_FOUND_404);
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain-scoped email signature templates with multi-language support and WebAdmin endpoints to get, create/replace, and delete templates.
  * Identity Provisioner can use a domain-based signature engine selectable via configuration; language fallback behavior clarified.

* **Documentation**
  * Added configuration and WebAdmin API docs plus release instructions covering database schema migrations and required image updates.

* **Tests**
  * End-to-end and repository tests covering storage, routing, validation, and locale fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->