### PR TITLE
ISSUE-2345 Specs for unauthenticated blob access JMAP extension

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -40,6 +40,7 @@
 *** xref:tmail-backend/jmap-extensions/pushWithFirebase.adoc[]
 *** xref:tmail-backend/jmap-extensions/teamMailboxRevokeAccess.adoc[]
 *** xref:tmail-backend/jmap-extensions/ticketAuthentication.adoc[]
+*** xref:tmail-backend/jmap-extensions/unauthenticatedBlobAccess.adoc[]
 ** xref:tmail-backend/smtp-extensions/index.adoc[]
 *** xref:tmail-backend/smtp-extensions/smtpAuthDelegationExtension.adoc[]
 ** xref:tmail-backend/webadmin.adoc[]

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/index.adoc
@@ -49,6 +49,7 @@ from the blob id of the calendar file (.ics).
  - link:jmapSettings.adoc[com:linagora:params:jmap:settings] allows clients to store per-user settings on the backend side.
  - link:publicAssets.adoc[com:linagora:params:public:assets] allows clients to store images as public assets to use on their TMail signature.
  - link:downloadAll.adoc[com:linagora:params:downloadAll] allows clients to download all attachments of a mail at once compressed in a zip file.
+ - link:unauthenticatedBlobAccess.adoc[com:linagora:params:jmap:unauthenticated:blob:access] allows clients to generate short-lived tokens for unauthenticated blob download.
  - link:mailboxClear.adoc[com:linagora:params:jmap:mailbox:clear] allows clients to clear a user mailbox thus avoiding round trips, outdated projection and network issues.
  - link:saas.adoc[com:linagora:params:saas] allows to return the Twake Workplace SaaS capability for users.
 

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/unauthenticatedBlobAccess.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/unauthenticatedBlobAccess.adoc
@@ -1,0 +1,133 @@
+= Unauthenticated Blob Access
+:navtitle: Unauthenticated Blob Access
+
+This extension allows an authenticated JMAP client to generate a short-lived token for a blob. The token can then be
+used to download that blob from a dedicated unauthenticated HTTP endpoint.
+
+This is intended for backend-to-backend flows where another service, such as Twake Drive, needs to fetch an email
+attachment and store it on behalf of the user.
+
+== Additions to the capability object
+
+Servers supporting the JMAP unauthenticated blob access extension need to advertise it via the
+`com:linagora:params:jmap:unauthenticated:blob:access` capability.
+
+The value of this property in the JMAP session capabilities property is an object with the following fields:
+
+- *endpoint*: `String`. The unauthenticated download endpoint URL template.
+- *tokenTtlInSeconds*: `UnsignedInt`. The token validity duration, in seconds.
+
+Example:
+
+....
+{
+  "com:linagora:params:jmap:unauthenticated:blob:access": {
+    "endpoint": "https://jmap.example.com/unauthenticatedDownload/{accountId}/{blobId}?token={token}",
+    "tokenTtlInSeconds": 300
+  }
+}
+....
+
+The endpoint template must contain the following variables:
+
+- `accountId`: the account id owning the blob.
+- `blobId`: the blob id to download.
+- `token`: the generated access token.
+
+== Unauthenticated download route
+
+Servers implementing the JMAP unauthenticated blob access extension need to expose the following unauthenticated download
+route:
+
+....
+GET /unauthenticatedDownload/{accountId}/{blobId}?token={token}
+....
+
+Where:
+
+- `accountId`: *String*. The account id owning the blob.
+- `blobId`: *String*. The blob id to download.
+- `token`: *String*. The generated access token.
+
+It returns the blob content when the token grants access to the requested blob.
+
+Return codes:
+
+- `200`: blob content returned successfully.
+- `401`: missing, invalid, or expired token. The server should not expose whether `accountId` or `blobId`
+  exists, to avoid resource enumeration.
+- `404`: token is valid but the blob cannot be resolved.
+
+== UnauthenticatedBlobAccess
+
+The `UnauthenticatedBlobAccess` object represents a temporary access token for a blob.
+
+It has the following field:
+
+- *token*: `String`. Server-set. The token to be used with the unauthenticated download endpoint.
+
+Tokens are reusable until they expire. Generating a new token for the same account and blob replaces the previous token:
+the latest token remains valid until its TTL expires and the previous token no longer grants access.
+
+== UnauthenticatedBlobAccess/set
+
+Standard */set* method as described in Section 5.3, RFC8620. Only `create` is supported.
+
+For `create`, each key of the `create` object is the `blobId` to grant temporary access to. The value is an empty object.
+
+The JMAP server needs to ensure that:
+
+- the blob exists.
+- the blob belongs to the requested account.
+- the authenticated user is allowed to access the blob.
+
+`update` and `destroy` are not supported.
+
+== Examples
+
+=== UnauthenticatedBlobAccess/set create
+
+Request:
+
+....
+{
+  "using": [
+    "urn:ietf:params:jmap:core",
+    "com:linagora:params:jmap:unauthenticated:blob:access"
+  ],
+  "methodCalls": [
+    [
+      "UnauthenticatedBlobAccess/set",
+      {
+        "accountId": "ACCOUNT_ID",
+        "create": {
+          "BLOB_ID_1": {}
+        }
+      },
+      "c1"
+    ]
+  ]
+}
+....
+
+Response:
+
+....
+{
+  "sessionState": "75128d00-03e7-11ee-be56-0242ac120002",
+  "methodResponses": [
+    [
+      "UnauthenticatedBlobAccess/set",
+      {
+        "accountId": "ACCOUNT_ID",
+        "created": {
+          "BLOB_ID_1": {
+            "token": "TOKEN_VALUE"
+          }
+        }
+      },
+      "c1"
+    ]
+  ]
+}
+....


### PR DESCRIPTION
resolve #2345 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new Unauthenticated Blob Access JMAP extension, including capability advertisements, endpoint specifications, HTTP route definitions, and the UnauthenticatedBlobAccess object structure. Coverage includes token generation, lifecycle management, validation rules for blob access, and request/response examples for the new extension's set method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->