### PR TITLE
ISSUE-2391 CalDavCollect should not log error upon malformed organizer

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.dav.DavClient;
 import com.linagora.tmail.dav.DavUser;
 import com.linagora.tmail.dav.DavUserProvider;
@@ -255,7 +254,7 @@ public class CalDavCollect extends GenericMailet {
             .map(attendee -> (Attendee) attendee)
             .map(Attendee::getCalAddress)
             .map(URI::getSchemeSpecificPart)
-            .map(Throwing.function(MailAddress::new))
+            .flatMap(address -> toMailAddressSilently(address).stream())
             .anyMatch(mailAddress::equals);
     }
 
@@ -263,7 +262,7 @@ public class CalDavCollect extends GenericMailet {
         return Optional.ofNullable(event.getOrganizer())
             .map(Organizer::getCalAddress)
             .map(URI::getSchemeSpecificPart)
-            .map(Throwing.function(MailAddress::new))
+            .flatMap(CalDavCollect::toMailAddressSilently)
             .map(mailAddress::equals)
             .orElse(false);
     }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/RestrictiveCalDavCollect.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.dav.DavClient;
 import com.linagora.tmail.dav.DavUid;
 import com.linagora.tmail.dav.DavUser;
@@ -276,7 +275,7 @@ public class RestrictiveCalDavCollect extends GenericMailet {
             .map(attendee -> (Attendee) attendee)
             .map(Attendee::getCalAddress)
             .map(URI::getSchemeSpecificPart)
-            .map(Throwing.function(MailAddress::new))
+            .flatMap(address -> toMailAddressSilently(address).stream())
             .anyMatch(mailAddress::equals);
     }
 
@@ -284,7 +283,7 @@ public class RestrictiveCalDavCollect extends GenericMailet {
         return Optional.ofNullable(event.getOrganizer())
             .map(Organizer::getCalAddress)
             .map(URI::getSchemeSpecificPart)
-            .map(Throwing.function(MailAddress::new))
+            .flatMap(RestrictiveCalDavCollect::toMailAddressSilently)
             .map(mailAddress::equals)
             .orElse(false);
     }


### PR DESCRIPTION
resolve #2391 

Error log printed: `"message":"Error while handling calendar in mail Mail1778535540879-xxx with recipient recipient@govmu.org","context":"default","exception":"com.github.fge.lambdas.ThrownByLambdaException: jakarta.mail.internet.AddressException: Out of data at position 1 in 'nomail' in string `nomail'' at position 1`

Likely happens when `ORGANIZER:MAILTO:nomail`.
Written a unit test locally, confirm the error log no longer printed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar data processing now handles invalid email addresses more gracefully, preventing potential failures during attendee and organizer alignment checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2392)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->