### PR TITLE
[BUILD] Run Tmail JMAP Postgres integration tests in the smoke testing mode

### DIFF
--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/pom.xml
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/pom.xml
@@ -143,6 +143,11 @@
                     <reuseForks>true</reuseForks>
                     <forkCount>2</forkCount>
                     <argLine>-Xms1024m -Xmx2048m</argLine>
+                    <groups combine.self="override">BasicFeature</groups>
+                    <excludedGroups>unstable</excludedGroups>
+                    <properties>
+                        <includeTags>junit5</includeTags>
+                    </properties>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Currently: 18:31  Integration Tests :: JMAP :: Postgres

Previously, we ran the whole PostgreSQL test suite as part of the ongoing Postgres development process. Apply similarly smoke testing, like distributed or Postgres JMAP ITs on James.