### PR TITLE
test/perf(openpaas): reduce CI test time

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/pom.xml
+++ b/tmail-backend/tmail-third-party/openpaas/pom.xml
@@ -168,7 +168,8 @@
                 <version>3.3.0</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>1</forkCount>
                     <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/DockerOpenPaasExtension.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/DockerOpenPaasExtension.java
@@ -26,7 +26,6 @@
 
 package com.linagora.tmail;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -39,16 +38,11 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.linagora.tmail.configuration.OpenPaasConfiguration;
 
-public record DockerOpenPaasExtension(DockerOpenPaasSetup dockerOpenPaasSetup) implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+public record DockerOpenPaasExtension(DockerOpenPaasSetup dockerOpenPaasSetup) implements BeforeAllCallback, ParameterResolver {
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
         dockerOpenPaasSetup.start();
-    }
-
-    @Override
-    public void afterAll(ExtensionContext extensionContext) {
-        dockerOpenPaasSetup.stop();
     }
 
     @Override

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/DockerOpenPaasSetup.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/DockerOpenPaasSetup.java
@@ -86,6 +86,8 @@ public class DockerOpenPaasSetup {
 
     private final ComposeContainer environment;
     private OpenPaaSProvisioningService openPaaSProvisioningService;
+    private boolean started;
+    private boolean shutdownHookRegistered;
 
     {
         MountableFile mountableFile = MountableFile.forClasspathResource("docker-openpaas-setup.yml");
@@ -101,13 +103,34 @@ public class DockerOpenPaasSetup {
                 .withStartupTimeout(Duration.ofMinutes(3)));
     }
 
-    public void start() {
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+
         environment.start();
         openPaaSProvisioningService = new OpenPaaSProvisioningService(getMongoDbIpAddress().toString());
+        started = true;
+        registerShutdownHook();
     }
 
-    public void stop() {
+    public synchronized void stop() {
+        if (!started) {
+            return;
+        }
+
         environment.stop();
+        started = false;
+        openPaaSProvisioningService = null;
+    }
+
+    private void registerShutdownHook() {
+        if (shutdownHookRegistered) {
+            return;
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(this::stop, "docker-openpaas-setup-shutdown-hook"));
+        shutdownHookRegistered = true;
     }
 
     public ContainerState getOpenPaasContainer() {


### PR DESCRIPTION
Keep the OpenPaaS Docker Compose environment alive for the test JVM instead of stopping it after every test class. Reuse a single Surefire fork so the shared setup avoids repeated container startup costs.


Reduce ~10 minutes 

Before
<img width="2104" height="808" alt="image" src="https://github.com/user-attachments/assets/a758221f-c8fc-4af1-b2ce-18e8be219043" />

After
<img width="2146" height="388" alt="image" src="https://github.com/user-attachments/assets/bbcb3a33-7672-4fe1-8871-270c13cb7869" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Updated Maven Surefire test execution fork reuse configuration
  - Modified Docker test environment initialization and lifecycle management
  - Enhanced service state tracking to improve test reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->