### PR TITLE
[FIX] RedisOidcToken: correctly setReadFrom for cluster topology

### DIFF
--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
@@ -42,6 +42,7 @@ import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.masterreplica.MasterReplica;
 import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
@@ -72,8 +73,9 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
 
             case ClusterRedisConfiguration clusterConfiguration -> {
                 RedisClusterClient client = (RedisClusterClient) rawClient;
-                client.connect().setReadFrom(clusterConfiguration.readFrom());
-                yield RedisTokenCacheCommands.of(client.connect(StringCodec.UTF8).reactive());
+                StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
+                connection.setReadFrom(clusterConfiguration.readFrom());
+                yield RedisTokenCacheCommands.of(connection.reactive());
             }
 
             case SentinelRedisConfiguration sentinelConf -> {


### PR DESCRIPTION
Previously, we setReadFrom on a connection and then discard it. This should also avoid creating useless connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Redis cluster connection handling to improve performance and reliability in distributed deployments through enhanced connection lifecycle management and reactive API integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->