### PR TITLE
[FIX] Use {{input}} placeholder for remote LLM prompt

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/listener/rag/LlmMailBackendClassifierListener.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/listener/rag/LlmMailBackendClassifierListener.java
@@ -273,7 +273,14 @@ public class LlmMailBackendClassifierListener implements EventListener.ReactiveG
     }
 
     record LlmUserPromptParameters(String userDisplayName, String user, String textContent, String sender, String to, String subject, String labelsInfo) {
+        private static final String INPUT_PLACEHOLDER = "{{input}}";
+
         String correspondingUserPrompt(String userPrompt) {
+            if (userPrompt.contains(INPUT_PLACEHOLDER)) {
+                String input = String.format("From: %s\nTo: %s\nSubject: %s\n\nBody:\n%s\n\n## AVAILABLE LABELS\n%s",
+                    sender, to, subject, textContent, labelsInfo);
+                return userPrompt.replace(INPUT_PLACEHOLDER, input);
+            }
             return userPrompt.formatted(userDisplayName, user, sender, to, subject, textContent, labelsInfo);
         }
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/listener/rag/LlmUserPromptParametersTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/listener/rag/LlmUserPromptParametersTest.java
@@ -1,0 +1,70 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.listener.rag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LlmUserPromptParametersTest {
+
+    private static final LlmMailBackendClassifierListener.LlmUserPromptParameters PARAMS =
+        new LlmMailBackendClassifierListener.LlmUserPromptParameters(
+            "Alice",
+            "alice@example.com",
+            "Please review the attached report.",
+            "bob@example.com",
+            "alice@example.com",
+            "Q1 Report",
+            "- labelId : work - Label name :Work - label description :Work-related emails");
+
+    @Test
+    void correspondingUserPromptShouldReplaceInputPlaceholderWithEmailContent() {
+        String template = "INSTRUCTION:\nClassify the email.\n\nTEXT:\n{{input}}\n";
+
+        String result = PARAMS.correspondingUserPrompt(template);
+
+        assertThat(result).doesNotContain("{{input}}");
+        assertThat(result).contains("From: bob@example.com");
+        assertThat(result).contains("To: alice@example.com");
+        assertThat(result).contains("Subject: Q1 Report");
+        assertThat(result).contains("Please review the attached report.");
+        assertThat(result).contains("labelId : work");
+    }
+
+    @Test
+    void correspondingUserPromptShouldIncludeLabelsInfoWhenUsingInputPlaceholder() {
+        String template = "TEXT:\n{{input}}\n";
+
+        String result = PARAMS.correspondingUserPrompt(template);
+
+        assertThat(result).contains("## AVAILABLE LABELS");
+        assertThat(result).contains("labelId : work");
+    }
+
+    @Test
+    void correspondingUserPromptShouldFallbackToStringFormattedWhenNoInputPlaceholder() {
+        String template = "User: %s\nEmail: %s\nFrom: %s\nTo: %s\nSubject: %s\nBody: %s\nLabels: %s";
+
+        String result = PARAMS.correspondingUserPrompt(template);
+
+        assertThat(result).isEqualTo(
+            "User: Alice\nEmail: alice@example.com\nFrom: bob@example.com\nTo: alice@example.com\nSubject: Q1 Report\nBody: Please review the attached report.\nLabels: - labelId : work - Label name :Work - label description :Work-related emails");
+    }
+}


### PR DESCRIPTION
Today state: fails to load label and transfer them to the LLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for template placeholders in AI assistant prompts, enabling dynamic composition of sender, recipient, subject, body, and label information.

* **Tests**
  * Added comprehensive test coverage for prompt template functionality, including placeholder replacement and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->