### PR TITLE
ISSUE-2347 Implement RedisUnauthenticatedBlobDownloadTokenRepository

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/redis.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/redis.adoc
@@ -12,6 +12,12 @@ Specified to TMail backend, we can configure the following configurations in the
 | eventBus.redis.timeout
 | Timeout for Redis event bus operations. Optional. Duration. Default to `10seconds`.
 
+| unauthenticated.blob.access.redis.command.timeout
+| Timeout for unauthenticated blob access Redis commands. Optional. Duration. Default to `3 seconds`.
+
+| oidc.token.cache.redis.command.timeout
+| Timeout for OIDC token cache Redis commands. Optional. Duration. Default to `3 seconds`.
+
 |===
 
 Additionally, Twake mail allows executing some listeners in a synchronous fashion upon dispatching. They are then

--- a/tmail-backend/apps/distributed/docker-configuration/redis.properties
+++ b/tmail-backend/apps/distributed/docker-configuration/redis.properties
@@ -30,3 +30,9 @@ redisURL=redis://redis:6379
 
 # Timeout for redis event bus operations. Defaults to 10 seconds.
 # eventBus.redis.timeout=10seconds
+
+# Timeout for unauthenticated blob access Redis commands. Defaults to 3 seconds.
+# unauthenticated.blob.access.redis.command.timeout=3seconds
+
+# Timeout for OIDC token cache Redis commands. Defaults to 3 seconds.
+# oidc.token.cache.redis.command.timeout=3seconds

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -166,6 +166,7 @@ import com.linagora.tmail.healthcheck.TasksHeathCheckModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
 import com.linagora.tmail.james.jmap.ContactSupportCapabilitiesModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
+import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.CassandraDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.CassandraFirebaseSubscriptionRepositoryModule;
@@ -461,6 +462,7 @@ public class DistributedServer {
             .overrideWith(overrideEventBusModule(configuration))
             .overrideWith(chooseDropListsModule(configuration))
             .overrideWith(chooseJmapOidc(configuration))
+            .overrideWith(chooseUnauthenticatedBlobAccessModules(configuration))
             .overrideWith(chooseKeywordEmailQueryListener(configuration))
             .overrideWith(QUOTA_USERNAME_SUPPLIER_MODULE);
     }
@@ -662,6 +664,13 @@ public class DistributedServer {
         return binder -> {
 
         };
+    }
+
+    private static Module chooseUnauthenticatedBlobAccessModules(DistributedJamesConfiguration configuration) {
+        if (configuration.jmapEnabled()) {
+            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
+        }
+        return Modules.EMPTY_MODULE;
     }
 
     private static Module chooseKeywordEmailQueryListener(DistributedJamesConfiguration configuration) {

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -150,6 +150,7 @@ import com.linagora.tmail.healthcheck.TasksHeathCheckModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
 import com.linagora.tmail.james.app.modules.jmap.MemoryTmailEventBusModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
+import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
 import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.PostgresDomainSignatureTemplateRepositoryModule;
@@ -284,6 +285,7 @@ public class PostgresTmailServer {
             .overrideWith(chooseJmapModule(configuration))
             .overrideWith(chooseTaskManagerModules(configuration))
             .overrideWith(chooseJmapOidc(configuration))
+            .overrideWith(chooseUnauthenticatedBlobAccessModules(configuration))
             .overrideWith(chooseTWPSettingsModule(configuration.twpSettingsModuleChooserConfiguration()))
             .overrideWith(chooseEventBusModules(configuration.eventBusImpl()))
             .overrideWith(chooseKeywordEmailQueryListener(configuration));
@@ -584,6 +586,13 @@ public class PostgresTmailServer {
         return binder -> {
 
         };
+    }
+
+    private static Module chooseUnauthenticatedBlobAccessModules(PostgresTmailConfiguration configuration) {
+        if (configuration.jmapEnabled()) {
+            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
+        }
+        return Modules.EMPTY_MODULE;
     }
 
     private static List<Module> chooseOpenPaasModule(OpenPaasModuleChooserConfiguration openPaasModuleChooserConfiguration) {

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepository.java
@@ -21,7 +21,6 @@ package com.linagora.tmail.james.jmap.blob;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -54,7 +53,7 @@ public class MemoryUnauthenticatedBlobDownloadTokenRepository implements Unauthe
     @Override
     public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId) {
         return Mono.fromCallable(() -> {
-            UnauthenticatedBlobDownloadToken token = new UnauthenticatedBlobDownloadToken(UUID.randomUUID());
+            UnauthenticatedBlobDownloadToken token = UnauthenticatedBlobDownloadToken.generate();
             store.put(new TokenKey(accountId, blobId), new StoredToken(token, clock.instant().plus(tokenTtl)));
             return token;
         });

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadToken.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadToken.java
@@ -23,6 +23,10 @@ import java.util.UUID;
 import com.google.common.base.Preconditions;
 
 public record UnauthenticatedBlobDownloadToken(UUID value) {
+    public static UnauthenticatedBlobDownloadToken generate() {
+        return new UnauthenticatedBlobDownloadToken(UUID.randomUUID());
+    }
+
     public UnauthenticatedBlobDownloadToken {
         Preconditions.checkNotNull(value);
     }

--- a/tmail-backend/jmap/extensions-redis/pom.xml
+++ b/tmail-backend/jmap/extensions-redis/pom.xml
@@ -59,6 +59,16 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jmap-extensions</artifactId>
             <scope>test</scope>
             <type>test-jar</type>

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
@@ -1,0 +1,81 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.jmap.api.model.AccountId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.hash.Hashing;
+import com.linagora.tmail.james.jmap.UnauthenticatedBlobAccessConfiguration;
+
+import reactor.core.publisher.Mono;
+
+public class RedisUnauthenticatedBlobDownloadTokenRepository implements UnauthenticatedBlobDownloadTokenRepository {
+    public static String resolveKey(AccountId accountId, BlobId blobId) {
+        return KEY_PREFIX + hash(accountId.getIdentifier()) + "_" + hash(blobId.asString());
+    }
+
+    public static String hashToken(UnauthenticatedBlobDownloadToken token) {
+        return hash(token.value().toString());
+    }
+
+    private static String hash(String value) {
+        return Hashing.sha512().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisUnauthenticatedBlobDownloadTokenRepository.class);
+    private static final String KEY_PREFIX = "tmail_unauthenticated_blob_access_blob_";
+
+    private final RedisUnauthenticatedBlobDownloadTokenRepositoryCommands redisCommands;
+    private final Duration tokenTtl;
+
+    @Inject
+    public RedisUnauthenticatedBlobDownloadTokenRepository(RedisUnauthenticatedBlobDownloadTokenRepositoryCommands redisCommands,
+                                                           UnauthenticatedBlobAccessConfiguration configuration) {
+        this.redisCommands = redisCommands;
+        this.tokenTtl = configuration.tokenTtl();
+    }
+
+    @Override
+    public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId) {
+        return Mono.fromCallable(() -> new UnauthenticatedBlobDownloadToken(UUID.randomUUID()))
+            .flatMap(token -> redisCommands.set(resolveKey(accountId, blobId), hashToken(token), tokenTtl)
+                .thenReturn(token));
+    }
+
+    @Override
+    public Mono<Boolean> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token) {
+        return redisCommands.get(resolveKey(accountId, blobId))
+            .map(storedTokenHash -> storedTokenHash
+                .map(hashToken(token)::equals)
+                .orElse(false))
+            .onErrorResume(error -> {
+                LOGGER.warn("Failed to validate unauthenticated blob download token for accountId={} blobId={}", accountId.getIdentifier(), blobId.asString(), error);
+                return Mono.just(false);
+            });
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
@@ -20,7 +20,6 @@ package com.linagora.tmail.james.jmap.blob;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.UUID;
 
 import jakarta.inject.Inject;
 
@@ -62,7 +61,7 @@ public class RedisUnauthenticatedBlobDownloadTokenRepository implements Unauthen
 
     @Override
     public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId) {
-        return Mono.fromCallable(() -> new UnauthenticatedBlobDownloadToken(UUID.randomUUID()))
+        return Mono.fromCallable(UnauthenticatedBlobDownloadToken::generate)
             .flatMap(token -> redisCommands.set(resolveKey(accountId, blobId), hashToken(token), tokenTtl)
                 .thenReturn(token));
     }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.java
@@ -1,0 +1,67 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.api.reactive.RedisStringReactiveCommands;
+import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import reactor.core.publisher.Mono;
+
+public class RedisUnauthenticatedBlobDownloadTokenRepositoryCommands {
+    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisReactiveCommands<String, String> commands) {
+        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands);
+    }
+
+    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisClusterReactiveCommands<String, String> commands) {
+        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands);
+    }
+
+    private static final Duration REDIS_REACTOR_TIMEOUT = Duration.ofSeconds(3);
+
+    private final RedisStringReactiveCommands<String, String> stringCommands;
+    private final RedisKeyReactiveCommands<String, String> keyCommands;
+
+    public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(RedisStringReactiveCommands<String, String> stringCommands,
+                                                                   RedisKeyReactiveCommands<String, String> keyCommands) {
+        this.stringCommands = stringCommands;
+        this.keyCommands = keyCommands;
+    }
+
+    public Mono<Void> set(String key, String value, Duration ttl) {
+        return stringCommands.psetex(key, ttl.toMillis(), value)
+            .timeout(REDIS_REACTOR_TIMEOUT)
+            .then();
+    }
+
+    public Mono<Optional<String>> get(String key) {
+        return stringCommands.get(key)
+            .timeout(REDIS_REACTOR_TIMEOUT)
+            .map(Optional::of)
+            .defaultIfEmpty(Optional.empty());
+    }
+
+    Mono<Long> ttl(String key) {
+        return keyCommands.pttl(key)
+            .timeout(REDIS_REACTOR_TIMEOUT);
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.java
@@ -28,40 +28,41 @@ import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import reactor.core.publisher.Mono;
 
 public class RedisUnauthenticatedBlobDownloadTokenRepositoryCommands {
-    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisReactiveCommands<String, String> commands) {
-        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands);
+    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisReactiveCommands<String, String> commands, Duration commandTimeout) {
+        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands, commandTimeout);
     }
 
-    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisClusterReactiveCommands<String, String> commands) {
-        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands);
+    public static RedisUnauthenticatedBlobDownloadTokenRepositoryCommands of(RedisClusterReactiveCommands<String, String> commands, Duration commandTimeout) {
+        return new RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(commands, commands, commandTimeout);
     }
-
-    private static final Duration REDIS_REACTOR_TIMEOUT = Duration.ofSeconds(3);
 
     private final RedisStringReactiveCommands<String, String> stringCommands;
     private final RedisKeyReactiveCommands<String, String> keyCommands;
+    private final Duration commandTimeout;
 
     public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands(RedisStringReactiveCommands<String, String> stringCommands,
-                                                                   RedisKeyReactiveCommands<String, String> keyCommands) {
+                                                                   RedisKeyReactiveCommands<String, String> keyCommands,
+                                                                   Duration commandTimeout) {
         this.stringCommands = stringCommands;
         this.keyCommands = keyCommands;
+        this.commandTimeout = commandTimeout;
     }
 
     public Mono<Void> set(String key, String value, Duration ttl) {
         return stringCommands.psetex(key, ttl.toMillis(), value)
-            .timeout(REDIS_REACTOR_TIMEOUT)
+            .timeout(commandTimeout)
             .then();
     }
 
     public Mono<Optional<String>> get(String key) {
         return stringCommands.get(key)
-            .timeout(REDIS_REACTOR_TIMEOUT)
+            .timeout(commandTimeout)
             .map(Optional::of)
             .defaultIfEmpty(Optional.empty());
     }
 
     Mono<Long> ttl(String key) {
         return keyCommands.pttl(key)
-            .timeout(REDIS_REACTOR_TIMEOUT);
+            .timeout(commandTimeout);
     }
 }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.james.util.DurationParser;
+
+import com.google.common.base.Preconditions;
+
+public record RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration(Duration commandTimeout) {
+    public static final String COMMAND_TIMEOUT_PROPERTY = "unauthenticated.blob.access.redis.command.timeout";
+    public static final Duration DEFAULT_COMMAND_TIMEOUT = Duration.ofSeconds(3);
+    public static final RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration DEFAULT =
+        new RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration(DEFAULT_COMMAND_TIMEOUT);
+
+    public static RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration from(Configuration configuration) {
+        return new RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration(
+            Optional.ofNullable(configuration.getString(COMMAND_TIMEOUT_PROPERTY, null))
+                .map(DurationParser::parse)
+                .orElse(DEFAULT_COMMAND_TIMEOUT));
+    }
+
+    public RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration {
+        Preconditions.checkArgument(!commandTimeout.isZero() && !commandTimeout.isNegative(), "commandTimeout must be positive");
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
@@ -14,13 +14,12 @@
  *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
  *  PURPOSE. See the GNU Affero General Public License for          *
  *  more details.                                                   *
- *******************************************************************/
+ ********************************************************************/
 
-package com.linagora.tmail.james.jmap.oidc;
+package com.linagora.tmail.james.jmap.blob;
 
 import java.io.FileNotFoundException;
 import java.util.List;
-import java.util.function.Function;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.backends.redis.ClusterRedisConfiguration;
@@ -48,55 +47,48 @@ import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.masterreplica.MasterReplica;
 import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 
-public class RedisOidcTokenCacheModule extends AbstractModule {
-    public static final Logger LOGGER = LoggerFactory.getLogger(RedisOidcTokenCacheModule.class);
+public class RedisUnauthenticatedBlobDownloadTokenRepositoryModule extends AbstractModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisUnauthenticatedBlobDownloadTokenRepositoryModule.class);
 
     @Override
     protected void configure() {
-        bind(OidcTokenCache.class).to(RedisOidcTokenCache.class)
+        bind(UnauthenticatedBlobDownloadTokenRepository.class).to(RedisUnauthenticatedBlobDownloadTokenRepository.class)
             .in(Scopes.SINGLETON);
     }
 
     @Provides
     @Singleton
-    public RedisOidcTokenCache provideRedisOIDCTokenCache(RedisClientFactory redisClientFactory,
-                                                          RedisConfiguration redisConfiguration,
-                                                          OidcTokenCacheConfiguration oidcTokenCacheConfiguration,
-                                                          TokenInfoResolver tokenInfoResolver) {
-
+    public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(RedisClientFactory redisClientFactory,
+                                                                                                                                  RedisConfiguration redisConfiguration) {
         AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
 
-        Function<AbstractRedisClient, RedisClient> toRedisClient = client -> (RedisClient) rawClient;
-
-        RedisTokenCacheCommands redisReactiveCommands = switch (redisConfiguration) {
+        return switch (redisConfiguration) {
             case StandaloneRedisConfiguration ignored ->
-                RedisTokenCacheCommands.of(toRedisClient.apply(rawClient).connect(StringCodec.UTF8).reactive());
+                RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(((RedisClient) rawClient).connect(StringCodec.UTF8).reactive());
 
             case ClusterRedisConfiguration clusterConfiguration -> {
                 RedisClusterClient client = (RedisClusterClient) rawClient;
                 StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
                 connection.setReadFrom(clusterConfiguration.readFrom());
-                yield RedisTokenCacheCommands.of(connection.reactive());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(connection.reactive());
             }
 
-            case SentinelRedisConfiguration sentinelConf -> {
-                StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, sentinelConf.redisURI());
-                sentinelConnection.setReadFrom(sentinelConf.readFrom());
-                yield RedisTokenCacheCommands.of(sentinelConnection.reactive());
+            case SentinelRedisConfiguration sentinelConfiguration -> {
+                StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, sentinelConfiguration.redisURI());
+                sentinelConnection.setReadFrom(sentinelConfiguration.readFrom());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(sentinelConnection.reactive());
             }
 
-            case MasterReplicaRedisConfiguration replicaConf -> {
-                List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConf.redisURI());
-                StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, uris);
-                masterReplicaConnection.setReadFrom(replicaConf.readFrom());
-                yield RedisTokenCacheCommands.of(masterReplicaConnection.reactive());
+            case MasterReplicaRedisConfiguration replicaConfiguration -> {
+                List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConfiguration.redisURI());
+                StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, uris);
+                masterReplicaConnection.setReadFrom(replicaConfiguration.readFrom());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(masterReplicaConnection.reactive());
             }
 
             default ->
                 throw new RuntimeException("Unknown redis configuration type: " + redisConfiguration.getClass().getName());
         };
-
-        return new RedisOidcTokenCache(tokenInfoResolver, oidcTokenCacheConfiguration, redisReactiveCommands);
     }
 
     @Provides
@@ -105,7 +97,7 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
         try {
             return RedisConfiguration.from(propertiesProvider.getConfiguration("redis"));
         } catch (FileNotFoundException e) {
-            LOGGER.error("Missing `redis.properties` configuration file for Redis OIDC token cache usage.");
+            LOGGER.error("Missing `redis.properties` configuration file for unauthenticated blob access token storage.");
             throw e;
         }
     }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
@@ -20,15 +20,9 @@ package com.linagora.tmail.james.jmap.blob;
 
 import java.io.FileNotFoundException;
 import java.time.Duration;
-import java.util.List;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.backends.redis.ClusterRedisConfiguration;
-import org.apache.james.backends.redis.MasterReplicaRedisConfiguration;
-import org.apache.james.backends.redis.RedisClientFactory;
 import org.apache.james.backends.redis.RedisConfiguration;
-import org.apache.james.backends.redis.SentinelRedisConfiguration;
-import org.apache.james.backends.redis.StandaloneRedisConfiguration;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,16 +31,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.linagora.tmail.james.jmap.redis.RedisConfigurationUtils;
-
-import io.lettuce.core.AbstractRedisClient;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
-import io.lettuce.core.codec.StringCodec;
-import io.lettuce.core.masterreplica.MasterReplica;
-import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+import com.linagora.tmail.james.jmap.redis.RedisReactiveCommandsFactory;
 
 public class RedisUnauthenticatedBlobDownloadTokenRepositoryModule extends AbstractModule {
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisUnauthenticatedBlobDownloadTokenRepositoryModule.class);
@@ -60,39 +45,13 @@ public class RedisUnauthenticatedBlobDownloadTokenRepositoryModule extends Abstr
     @Provides
     @Singleton
     public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(
-        RedisClientFactory redisClientFactory,
-        RedisConfiguration redisConfiguration,
+        RedisReactiveCommandsFactory redisReactiveCommandsFactory,
         RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration configuration) {
-        AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
         Duration commandTimeout = configuration.commandTimeout();
 
-        return switch (redisConfiguration) {
-            case StandaloneRedisConfiguration ignored ->
-                RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(((RedisClient) rawClient).connect(StringCodec.UTF8).reactive(), commandTimeout);
-
-            case ClusterRedisConfiguration clusterConfiguration -> {
-                RedisClusterClient client = (RedisClusterClient) rawClient;
-                StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
-                connection.setReadFrom(clusterConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(connection.reactive(), commandTimeout);
-            }
-
-            case SentinelRedisConfiguration sentinelConfiguration -> {
-                StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, sentinelConfiguration.redisURI());
-                sentinelConnection.setReadFrom(sentinelConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(sentinelConnection.reactive(), commandTimeout);
-            }
-
-            case MasterReplicaRedisConfiguration replicaConfiguration -> {
-                List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConfiguration.redisURI());
-                StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, uris);
-                masterReplicaConnection.setReadFrom(replicaConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(masterReplicaConnection.reactive(), commandTimeout);
-            }
-
-            default ->
-                throw new RuntimeException("Unknown redis configuration type: " + redisConfiguration.getClass().getName());
-        };
+        return redisReactiveCommandsFactory.create(
+            commands -> RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(commands, commandTimeout),
+            commands -> RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(commands, commandTimeout));
     }
 
     @Provides

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryModule.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.james.jmap.blob;
 
 import java.io.FileNotFoundException;
+import java.time.Duration;
 import java.util.List;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -58,32 +59,35 @@ public class RedisUnauthenticatedBlobDownloadTokenRepositoryModule extends Abstr
 
     @Provides
     @Singleton
-    public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(RedisClientFactory redisClientFactory,
-                                                                                                                                  RedisConfiguration redisConfiguration) {
+    public RedisUnauthenticatedBlobDownloadTokenRepositoryCommands provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(
+        RedisClientFactory redisClientFactory,
+        RedisConfiguration redisConfiguration,
+        RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration configuration) {
         AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
+        Duration commandTimeout = configuration.commandTimeout();
 
         return switch (redisConfiguration) {
             case StandaloneRedisConfiguration ignored ->
-                RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(((RedisClient) rawClient).connect(StringCodec.UTF8).reactive());
+                RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(((RedisClient) rawClient).connect(StringCodec.UTF8).reactive(), commandTimeout);
 
             case ClusterRedisConfiguration clusterConfiguration -> {
                 RedisClusterClient client = (RedisClusterClient) rawClient;
                 StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
                 connection.setReadFrom(clusterConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(connection.reactive());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(connection.reactive(), commandTimeout);
             }
 
             case SentinelRedisConfiguration sentinelConfiguration -> {
                 StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, sentinelConfiguration.redisURI());
                 sentinelConnection.setReadFrom(sentinelConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(sentinelConnection.reactive());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(sentinelConnection.reactive(), commandTimeout);
             }
 
             case MasterReplicaRedisConfiguration replicaConfiguration -> {
                 List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConfiguration.redisURI());
                 StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect((RedisClient) rawClient, StringCodec.UTF8, uris);
                 masterReplicaConnection.setReadFrom(replicaConfiguration.readFrom());
-                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(masterReplicaConnection.reactive());
+                yield RedisUnauthenticatedBlobDownloadTokenRepositoryCommands.of(masterReplicaConnection.reactive(), commandTimeout);
             }
 
             default ->
@@ -99,6 +103,17 @@ public class RedisUnauthenticatedBlobDownloadTokenRepositoryModule extends Abstr
         } catch (FileNotFoundException e) {
             LOGGER.error("Missing `redis.properties` configuration file for unauthenticated blob access token storage.");
             throw e;
+        }
+    }
+
+    @Provides
+    @Singleton
+    public RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration redisUnauthenticatedBlobDownloadTokenRepositoryConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            return RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.from(propertiesProvider.getConfiguration("redis"));
+        } catch (FileNotFoundException e) {
+            LOGGER.info("Missing `redis.properties` configuration file -> using default RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration");
+            return RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.DEFAULT;
         }
     }
 }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheConfiguration.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheConfiguration.java
@@ -1,0 +1,44 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.oidc;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.james.util.DurationParser;
+
+import com.google.common.base.Preconditions;
+
+public record RedisOidcTokenCacheConfiguration(Duration commandTimeout) {
+    public static final String COMMAND_TIMEOUT_PROPERTY = "oidc.token.cache.redis.command.timeout";
+    public static final Duration DEFAULT_COMMAND_TIMEOUT = Duration.ofSeconds(3);
+    public static final RedisOidcTokenCacheConfiguration DEFAULT = new RedisOidcTokenCacheConfiguration(DEFAULT_COMMAND_TIMEOUT);
+
+    public static RedisOidcTokenCacheConfiguration from(Configuration configuration) {
+        return new RedisOidcTokenCacheConfiguration(
+            Optional.ofNullable(configuration.getString(COMMAND_TIMEOUT_PROPERTY, null))
+                .map(DurationParser::parse)
+                .orElse(DEFAULT_COMMAND_TIMEOUT));
+    }
+
+    public RedisOidcTokenCacheConfiguration {
+        Preconditions.checkArgument(!commandTimeout.isZero() && !commandTimeout.isNegative(), "commandTimeout must be positive");
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
@@ -20,16 +20,9 @@ package com.linagora.tmail.james.jmap.oidc;
 
 import java.io.FileNotFoundException;
 import java.time.Duration;
-import java.util.List;
-import java.util.function.Function;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.backends.redis.ClusterRedisConfiguration;
-import org.apache.james.backends.redis.MasterReplicaRedisConfiguration;
-import org.apache.james.backends.redis.RedisClientFactory;
 import org.apache.james.backends.redis.RedisConfiguration;
-import org.apache.james.backends.redis.SentinelRedisConfiguration;
-import org.apache.james.backends.redis.StandaloneRedisConfiguration;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,16 +31,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.linagora.tmail.james.jmap.redis.RedisConfigurationUtils;
-
-import io.lettuce.core.AbstractRedisClient;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
-import io.lettuce.core.codec.StringCodec;
-import io.lettuce.core.masterreplica.MasterReplica;
-import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+import com.linagora.tmail.james.jmap.redis.RedisReactiveCommandsFactory;
 
 public class RedisOidcTokenCacheModule extends AbstractModule {
     public static final Logger LOGGER = LoggerFactory.getLogger(RedisOidcTokenCacheModule.class);
@@ -60,44 +44,14 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public RedisOidcTokenCache provideRedisOIDCTokenCache(RedisClientFactory redisClientFactory,
-                                                          RedisConfiguration redisConfiguration,
+    public RedisOidcTokenCache provideRedisOIDCTokenCache(RedisReactiveCommandsFactory redisReactiveCommandsFactory,
                                                           OidcTokenCacheConfiguration oidcTokenCacheConfiguration,
                                                           RedisOidcTokenCacheConfiguration redisOidcTokenCacheConfiguration,
                                                           TokenInfoResolver tokenInfoResolver) {
-
-        AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
         Duration commandTimeout = redisOidcTokenCacheConfiguration.commandTimeout();
-
-        Function<AbstractRedisClient, RedisClient> toRedisClient = client -> (RedisClient) rawClient;
-
-        RedisTokenCacheCommands redisReactiveCommands = switch (redisConfiguration) {
-            case StandaloneRedisConfiguration ignored ->
-                RedisTokenCacheCommands.of(toRedisClient.apply(rawClient).connect(StringCodec.UTF8).reactive(), commandTimeout);
-
-            case ClusterRedisConfiguration clusterConfiguration -> {
-                RedisClusterClient client = (RedisClusterClient) rawClient;
-                StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
-                connection.setReadFrom(clusterConfiguration.readFrom());
-                yield RedisTokenCacheCommands.of(connection.reactive());
-            }
-
-            case SentinelRedisConfiguration sentinelConf -> {
-                StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, sentinelConf.redisURI());
-                sentinelConnection.setReadFrom(sentinelConf.readFrom());
-                yield RedisTokenCacheCommands.of(sentinelConnection.reactive(), commandTimeout);
-            }
-
-            case MasterReplicaRedisConfiguration replicaConf -> {
-                List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConf.redisURI());
-                StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, uris);
-                masterReplicaConnection.setReadFrom(replicaConf.readFrom());
-                yield RedisTokenCacheCommands.of(masterReplicaConnection.reactive(), commandTimeout);
-            }
-
-            default ->
-                throw new RuntimeException("Unknown redis configuration type: " + redisConfiguration.getClass().getName());
-        };
+        RedisTokenCacheCommands redisReactiveCommands = redisReactiveCommandsFactory.create(
+            commands -> RedisTokenCacheCommands.of(commands, commandTimeout),
+            commands -> RedisTokenCacheCommands.of(commands, commandTimeout));
 
         return new RedisOidcTokenCache(tokenInfoResolver, oidcTokenCacheConfiguration, redisReactiveCommands);
     }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheModule.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.james.jmap.oidc;
 
 import java.io.FileNotFoundException;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
 
@@ -62,15 +63,17 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
     public RedisOidcTokenCache provideRedisOIDCTokenCache(RedisClientFactory redisClientFactory,
                                                           RedisConfiguration redisConfiguration,
                                                           OidcTokenCacheConfiguration oidcTokenCacheConfiguration,
+                                                          RedisOidcTokenCacheConfiguration redisOidcTokenCacheConfiguration,
                                                           TokenInfoResolver tokenInfoResolver) {
 
         AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
+        Duration commandTimeout = redisOidcTokenCacheConfiguration.commandTimeout();
 
         Function<AbstractRedisClient, RedisClient> toRedisClient = client -> (RedisClient) rawClient;
 
         RedisTokenCacheCommands redisReactiveCommands = switch (redisConfiguration) {
             case StandaloneRedisConfiguration ignored ->
-                RedisTokenCacheCommands.of(toRedisClient.apply(rawClient).connect(StringCodec.UTF8).reactive());
+                RedisTokenCacheCommands.of(toRedisClient.apply(rawClient).connect(StringCodec.UTF8).reactive(), commandTimeout);
 
             case ClusterRedisConfiguration clusterConfiguration -> {
                 RedisClusterClient client = (RedisClusterClient) rawClient;
@@ -82,14 +85,14 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
             case SentinelRedisConfiguration sentinelConf -> {
                 StatefulRedisMasterReplicaConnection<String, String> sentinelConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, sentinelConf.redisURI());
                 sentinelConnection.setReadFrom(sentinelConf.readFrom());
-                yield RedisTokenCacheCommands.of(sentinelConnection.reactive());
+                yield RedisTokenCacheCommands.of(sentinelConnection.reactive(), commandTimeout);
             }
 
             case MasterReplicaRedisConfiguration replicaConf -> {
                 List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(replicaConf.redisURI());
                 StatefulRedisMasterReplicaConnection<String, String> masterReplicaConnection = MasterReplica.connect(toRedisClient.apply(rawClient), StringCodec.UTF8, uris);
                 masterReplicaConnection.setReadFrom(replicaConf.readFrom());
-                yield RedisTokenCacheCommands.of(masterReplicaConnection.reactive());
+                yield RedisTokenCacheCommands.of(masterReplicaConnection.reactive(), commandTimeout);
             }
 
             default ->
@@ -107,6 +110,17 @@ public class RedisOidcTokenCacheModule extends AbstractModule {
         } catch (FileNotFoundException e) {
             LOGGER.error("Missing `redis.properties` configuration file for Redis OIDC token cache usage.");
             throw e;
+        }
+    }
+
+    @Provides
+    @Singleton
+    public RedisOidcTokenCacheConfiguration redisOidcTokenCacheConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            return RedisOidcTokenCacheConfiguration.from(propertiesProvider.getConfiguration("redis"));
+        } catch (FileNotFoundException e) {
+            LOGGER.info("Missing `redis.properties` configuration file -> using default RedisOidcTokenCacheConfiguration");
+            return RedisOidcTokenCacheConfiguration.DEFAULT;
         }
     }
 }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisTokenCacheCommands.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/oidc/RedisTokenCacheCommands.java
@@ -32,58 +32,59 @@ import reactor.core.publisher.Mono;
 
 public class RedisTokenCacheCommands {
 
-    public static RedisTokenCacheCommands of(RedisReactiveCommands<String, String> commands) {
-        return new RedisTokenCacheCommands(commands, commands, commands);
+    public static RedisTokenCacheCommands of(RedisReactiveCommands<String, String> commands, Duration commandTimeout) {
+        return new RedisTokenCacheCommands(commands, commands, commands, commandTimeout);
     }
 
-    public static RedisTokenCacheCommands of(RedisClusterReactiveCommands<String, String> commands) {
-        return new RedisTokenCacheCommands(commands, commands, commands);
+    public static RedisTokenCacheCommands of(RedisClusterReactiveCommands<String, String> commands, Duration commandTimeout) {
+        return new RedisTokenCacheCommands(commands, commands, commands, commandTimeout);
     }
-
-    private static final Duration REDIS_REACTOR_TIMEOUT = Duration.ofSeconds(3);
 
     private final RedisKeyReactiveCommands<String, String> keyCommand;
     private final RedisListReactiveCommands<String, String> listCommand;
     private final RedisHashReactiveCommands<String, String> hashCommand;
+    private final Duration commandTimeout;
 
     public RedisTokenCacheCommands(RedisKeyReactiveCommands<String, String> keyCommand,
                                    RedisListReactiveCommands<String, String> listCommand,
-                                   RedisHashReactiveCommands<String, String> hashCommand) {
+                                   RedisHashReactiveCommands<String, String> hashCommand,
+                                   Duration commandTimeout) {
         this.keyCommand = keyCommand;
         this.listCommand = listCommand;
         this.hashCommand = hashCommand;
+        this.commandTimeout = commandTimeout;
     }
 
     public Flux<String> lrange(String key) {
         return listCommand.lrange(key, 0, -1)
-            .timeout(REDIS_REACTOR_TIMEOUT);
+            .timeout(commandTimeout);
     }
 
     public Mono<Long> rpush(String key, String... values) {
         return listCommand.rpush(key, values)
-            .timeout(REDIS_REACTOR_TIMEOUT);
+            .timeout(commandTimeout);
     }
 
     public Mono<Void> del(String... key) {
         return keyCommand.del(key)
-            .timeout(REDIS_REACTOR_TIMEOUT)
+            .timeout(commandTimeout)
             .then();
     }
 
     public Mono<Void> expire(String key, Duration duration) {
         return keyCommand.expire(key, duration)
-            .timeout(REDIS_REACTOR_TIMEOUT)
+            .timeout(commandTimeout)
             .then();
     }
 
     public Mono<Void> hset(String key, Map<String, String> map) {
         return hashCommand.hset(key, map)
-            .timeout(REDIS_REACTOR_TIMEOUT)
+            .timeout(commandTimeout)
             .then();
     }
 
     public Flux<KeyValue<String, String>> hgetall(String key) {
         return hashCommand.hgetall(key)
-            .timeout(REDIS_REACTOR_TIMEOUT);
+            .timeout(commandTimeout);
     }
 }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/redis/RedisReactiveCommandsFactory.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/redis/RedisReactiveCommandsFactory.java
@@ -1,0 +1,94 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.redis;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.backends.redis.ClusterRedisConfiguration;
+import org.apache.james.backends.redis.MasterReplicaRedisConfiguration;
+import org.apache.james.backends.redis.RedisClientFactory;
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.apache.james.backends.redis.SentinelRedisConfiguration;
+import org.apache.james.backends.redis.StandaloneRedisConfiguration;
+
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+
+public class RedisReactiveCommandsFactory {
+    public interface CommandsFactory<T> {
+        T create(RedisReactiveCommands<String, String> commands);
+    }
+
+    public interface ClusterCommandsFactory<T> {
+        T create(RedisClusterReactiveCommands<String, String> commands);
+    }
+
+    private final RedisClientFactory redisClientFactory;
+    private final RedisConfiguration redisConfiguration;
+
+    @Inject
+    public RedisReactiveCommandsFactory(RedisClientFactory redisClientFactory, RedisConfiguration redisConfiguration) {
+        this.redisClientFactory = redisClientFactory;
+        this.redisConfiguration = redisConfiguration;
+    }
+
+    public <T> T create(CommandsFactory<T> commandsFactory, ClusterCommandsFactory<T> clusterCommandsFactory) {
+        AbstractRedisClient rawClient = redisClientFactory.rawRedisClient();
+
+        return switch (redisConfiguration) {
+            case StandaloneRedisConfiguration ignored ->
+                commandsFactory.create(((RedisClient) rawClient).connect(StringCodec.UTF8).reactive());
+
+            case ClusterRedisConfiguration clusterConfiguration -> {
+                RedisClusterClient client = (RedisClusterClient) rawClient;
+                StatefulRedisClusterConnection<String, String> connection = client.connect(StringCodec.UTF8);
+                connection.setReadFrom(clusterConfiguration.readFrom());
+                yield clusterCommandsFactory.create(connection.reactive());
+            }
+
+            case SentinelRedisConfiguration sentinelConfiguration -> {
+                StatefulRedisMasterReplicaConnection<String, String> connection = MasterReplica.connect(
+                    (RedisClient) rawClient, StringCodec.UTF8, sentinelConfiguration.redisURI());
+                connection.setReadFrom(sentinelConfiguration.readFrom());
+                yield commandsFactory.create(connection.reactive());
+            }
+
+            case MasterReplicaRedisConfiguration masterReplicaConfiguration -> {
+                List<RedisURI> uris = RedisConfigurationUtils.asJavaRedisUris(masterReplicaConfiguration.redisURI());
+                StatefulRedisMasterReplicaConnection<String, String> connection = MasterReplica.connect(
+                    (RedisClient) rawClient, StringCodec.UTF8, uris);
+                connection.setReadFrom(masterReplicaConfiguration.readFrom());
+                yield commandsFactory.create(connection.reactive());
+            }
+
+            default ->
+                throw new RuntimeException("Unknown redis configuration type: " + redisConfiguration.getClass().getName());
+        };
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/main/scala/com/linagora/tmail/james/jmap/redis/RedisConfigurationUtils.scala
+++ b/tmail-backend/jmap/extensions-redis/src/main/scala/com/linagora/tmail/james/jmap/redis/RedisConfigurationUtils.scala
@@ -16,7 +16,7 @@
   *  more details.                                                   *
  *******************************************************************/
 
-package com.linagora.tmail.james.jmap.oidc
+package com.linagora.tmail.james.jmap.redis
 
 import io.lettuce.core.RedisURI
 import org.apache.james.backends.redis.RedisUris.RedisUris

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisClusterUnauthenticatedBlobDownloadTokenRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisClusterUnauthenticatedBlobDownloadTokenRepositoryTest.java
@@ -1,0 +1,41 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import org.apache.james.backends.redis.RedisClusterExtension;
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RedisClusterUnauthenticatedBlobDownloadTokenRepositoryTest extends RedisUnauthenticatedBlobDownloadTokenRepositoryContract {
+    @RegisterExtension
+    static RedisClusterExtension redisClusterExtension = new RedisClusterExtension();
+
+    private static RedisClusterExtension.RedisClusterContainer redisClusterContainer;
+
+    @BeforeAll
+    static void setUp(RedisClusterExtension.RedisClusterContainer container) {
+        redisClusterContainer = container;
+    }
+
+    @Override
+    public RedisConfiguration redisConfiguration() {
+        return redisClusterContainer.getRedisConfiguration();
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisSentinelUnauthenticatedBlobDownloadTokenRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisSentinelUnauthenticatedBlobDownloadTokenRepositoryTest.java
@@ -1,0 +1,33 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.apache.james.backends.redis.RedisSentinelExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RedisSentinelUnauthenticatedBlobDownloadTokenRepositoryTest extends RedisUnauthenticatedBlobDownloadTokenRepositoryContract {
+    @RegisterExtension
+    static RedisSentinelExtension redisSentinelExtension = new RedisSentinelExtension();
+
+    @Override
+    public RedisConfiguration redisConfiguration() {
+        return redisSentinelExtension.getRedisSentinelCluster().redisSentinelContainerList().getRedisConfiguration();
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisStandaloneTlsUnauthenticatedBlobDownloadTokenRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisStandaloneTlsUnauthenticatedBlobDownloadTokenRepositoryTest.java
@@ -1,0 +1,33 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.apache.james.backends.redis.RedisTLSExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RedisStandaloneTlsUnauthenticatedBlobDownloadTokenRepositoryTest extends RedisUnauthenticatedBlobDownloadTokenRepositoryContract {
+    @RegisterExtension
+    static RedisTLSExtension redisExtension = new RedisTLSExtension();
+
+    @Override
+    public RedisConfiguration redisConfiguration() {
+        return redisExtension.getRedisContainer().getConfiguration();
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisStandaloneUnauthenticatedBlobDownloadTokenRepositoryTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisStandaloneUnauthenticatedBlobDownloadTokenRepositoryTest.java
@@ -1,0 +1,34 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.apache.james.backends.redis.RedisExtension;
+import org.apache.james.backends.redis.StandaloneRedisConfiguration;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RedisStandaloneUnauthenticatedBlobDownloadTokenRepositoryTest extends RedisUnauthenticatedBlobDownloadTokenRepositoryContract {
+    @RegisterExtension
+    static RedisExtension redisExtension = new RedisExtension();
+
+    @Override
+    public RedisConfiguration redisConfiguration() {
+        return StandaloneRedisConfiguration.from(redisExtension.dockerRedis().redisURI().toString());
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryConfigurationTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryConfigurationTest.java
@@ -1,0 +1,64 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+class RedisUnauthenticatedBlobDownloadTokenRepositoryConfigurationTest {
+    @Test
+    void shouldDefaultCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+
+        assertThat(RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.from(configuration).commandTimeout())
+            .isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    void shouldParseDuration() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.COMMAND_TIMEOUT_PROPERTY, "500ms");
+
+        assertThat(RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.from(configuration).commandTimeout())
+            .isEqualTo(Duration.ofMillis(500));
+    }
+
+    @Test
+    void shouldRejectInvalidCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.COMMAND_TIMEOUT_PROPERTY, "invalid");
+
+        assertThatThrownBy(() -> RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.from(configuration))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void shouldRejectZeroCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.COMMAND_TIMEOUT_PROPERTY, "0seconds");
+
+        assertThatThrownBy(() -> RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
@@ -48,7 +48,8 @@ public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract im
         RedisConfiguration redisConfiguration = redisConfiguration();
         RedisClientFactory redisClientFactory = new RedisClientFactory(FileSystemImpl.forTesting(), redisConfiguration);
         redisCommands = new RedisUnauthenticatedBlobDownloadTokenRepositoryModule()
-            .provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(redisClientFactory, redisConfiguration);
+            .provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(redisClientFactory, redisConfiguration,
+                RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.DEFAULT);
 
         repository = new RedisUnauthenticatedBlobDownloadTokenRepository(redisCommands, new UnauthenticatedBlobAccessConfiguration(TOKEN_TTL));
     }

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
@@ -1,0 +1,93 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package com.linagora.tmail.james.jmap.blob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.apache.james.backends.redis.RedisClientFactory;
+import org.apache.james.backends.redis.RedisConfiguration;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.james.jmap.UnauthenticatedBlobAccessConfiguration;
+
+public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract implements UnauthenticatedBlobDownloadTokenRepositoryContract {
+    protected static final AccountId ACCOUNT_ID = AccountId.fromString("accountId");
+    protected static final PlainBlobId BLOB_ID = new PlainBlobId.Factory().parse("blobId");
+
+    private static final Duration TOKEN_TTL = Duration.ofSeconds(1);
+
+    private RedisUnauthenticatedBlobDownloadTokenRepository repository;
+    private RedisUnauthenticatedBlobDownloadTokenRepositoryCommands redisCommands;
+
+    public abstract RedisConfiguration redisConfiguration();
+
+    @BeforeEach
+    void setUp() {
+        RedisConfiguration redisConfiguration = redisConfiguration();
+        RedisClientFactory redisClientFactory = new RedisClientFactory(FileSystemImpl.forTesting(), redisConfiguration);
+        redisCommands = new RedisUnauthenticatedBlobDownloadTokenRepositoryModule()
+            .provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(redisClientFactory, redisConfiguration);
+
+        repository = new RedisUnauthenticatedBlobDownloadTokenRepository(redisCommands, new UnauthenticatedBlobAccessConfiguration(TOKEN_TTL));
+    }
+
+    @Override
+    public UnauthenticatedBlobDownloadTokenRepository testee() {
+        return repository;
+    }
+
+    @Override
+    public void advanceClockAfterTtl() {
+        try {
+            Thread.sleep(TOKEN_TTL.toMillis() + 100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void generateShouldStoreHashedTokenWithTtl() {
+        UnauthenticatedBlobDownloadToken token = repository.generate(ACCOUNT_ID, BLOB_ID).block();
+        String redisKey = RedisUnauthenticatedBlobDownloadTokenRepository.resolveKey(ACCOUNT_ID, BLOB_ID);
+
+        String storedTokenHash = redisCommands.get(redisKey).block().orElseThrow();
+
+        assertThat(storedTokenHash)
+            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.hashToken(token));
+        assertThat(redisCommands.ttl(redisKey).block())
+            .isPositive();
+    }
+
+    @Test
+    public void generateShouldOverwriteStoredHashForSameBlob() {
+        repository.generate(ACCOUNT_ID, BLOB_ID).block();
+        UnauthenticatedBlobDownloadToken secondToken = repository.generate(ACCOUNT_ID, BLOB_ID).block();
+        String redisKey = RedisUnauthenticatedBlobDownloadTokenRepository.resolveKey(ACCOUNT_ID, BLOB_ID);
+
+        assertThat(redisCommands.get(redisKey).block().orElseThrow())
+            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.hashToken(secondToken));
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.james.jmap.UnauthenticatedBlobAccessConfiguration;
+import com.linagora.tmail.james.jmap.redis.RedisReactiveCommandsFactory;
 
 public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract implements UnauthenticatedBlobDownloadTokenRepositoryContract {
     protected static final AccountId ACCOUNT_ID = AccountId.fromString("accountId");
@@ -48,7 +49,7 @@ public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract im
         RedisConfiguration redisConfiguration = redisConfiguration();
         RedisClientFactory redisClientFactory = new RedisClientFactory(FileSystemImpl.forTesting(), redisConfiguration);
         redisCommands = new RedisUnauthenticatedBlobDownloadTokenRepositoryModule()
-            .provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(redisClientFactory, redisConfiguration,
+            .provideRedisUnauthenticatedBlobDownloadTokenRepositoryCommands(new RedisReactiveCommandsFactory(redisClientFactory, redisConfiguration),
                 RedisUnauthenticatedBlobDownloadTokenRepositoryConfiguration.DEFAULT);
 
         repository = new RedisUnauthenticatedBlobDownloadTokenRepository(redisCommands, new UnauthenticatedBlobAccessConfiguration(TOKEN_TTL));

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheConfigurationTest.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheConfigurationTest.java
@@ -1,0 +1,64 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+class RedisOidcTokenCacheConfigurationTest {
+    @Test
+    void shouldDefaultCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+
+        assertThat(RedisOidcTokenCacheConfiguration.from(configuration).commandTimeout())
+            .isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    void shouldParseDuration() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisOidcTokenCacheConfiguration.COMMAND_TIMEOUT_PROPERTY, "500ms");
+
+        assertThat(RedisOidcTokenCacheConfiguration.from(configuration).commandTimeout())
+            .isEqualTo(Duration.ofMillis(500));
+    }
+
+    @Test
+    void shouldRejectInvalidCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisOidcTokenCacheConfiguration.COMMAND_TIMEOUT_PROPERTY, "invalid");
+
+        assertThatThrownBy(() -> RedisOidcTokenCacheConfiguration.from(configuration))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void shouldRejectZeroCommandTimeout() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(RedisOidcTokenCacheConfiguration.COMMAND_TIMEOUT_PROPERTY, "0seconds");
+
+        assertThatThrownBy(() -> RedisOidcTokenCacheConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheContract.java
@@ -46,7 +46,7 @@ public abstract class RedisOidcTokenCacheContract extends OidcTokenCacheContract
         RedisConfiguration redisConfiguration = redisConfiguration();
         RedisClientFactory redisClientFactory = new RedisClientFactory(FileSystemImpl.forTesting(), redisConfiguration);
         redisOIDCTokenCache = new RedisOidcTokenCacheModule().provideRedisOIDCTokenCache(redisClientFactory, redisConfiguration,
-            OidcTokenCacheConfiguration.DEFAULT, tokenInfoResolver);
+            OidcTokenCacheConfiguration.DEFAULT, RedisOidcTokenCacheConfiguration.DEFAULT, tokenInfoResolver);
     }
 
     @Override

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/oidc/RedisOidcTokenCacheContract.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import com.google.common.hash.Hashing;
+import com.linagora.tmail.james.jmap.redis.RedisReactiveCommandsFactory;
 
 public abstract class RedisOidcTokenCacheContract extends OidcTokenCacheContract {
 
@@ -45,7 +46,8 @@ public abstract class RedisOidcTokenCacheContract extends OidcTokenCacheContract
     void setUp() {
         RedisConfiguration redisConfiguration = redisConfiguration();
         RedisClientFactory redisClientFactory = new RedisClientFactory(FileSystemImpl.forTesting(), redisConfiguration);
-        redisOIDCTokenCache = new RedisOidcTokenCacheModule().provideRedisOIDCTokenCache(redisClientFactory, redisConfiguration,
+        RedisReactiveCommandsFactory redisReactiveCommandsFactory = new RedisReactiveCommandsFactory(redisClientFactory, redisConfiguration);
+        redisOIDCTokenCache = new RedisOidcTokenCacheModule().provideRedisOIDCTokenCache(redisReactiveCommandsFactory,
             OidcTokenCacheConfiguration.DEFAULT, RedisOidcTokenCacheConfiguration.DEFAULT, tokenInfoResolver);
     }
 


### PR DESCRIPTION
resolve #2347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Redis-backed unauthenticated blob download tokens with configurable TTLs and command timeouts; wired into distributed and Postgres server deployments.
  * Redis-backed OIDC token cache now uses configurable command timeouts and improved multi-topology support.

* **Tests**
  * Added comprehensive contract tests exercising token storage across standalone, TLS, sentinel and cluster Redis setups and timeout parsing.

* **Documentation**
  * Redis docs updated with new optional timeout properties (default 3s).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->