### PR TITLE
ISSUE-2348 Implement UnauthenticatedBlobAccess/set create

### DIFF
--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedJamesConfiguration.java
@@ -41,6 +41,7 @@ import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.OpenPaasModuleChooserConfiguration;
 import com.linagora.tmail.UsersRepositoryModuleChooser;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.james.app.module.UnauthenticatedBlobAccessModuleChooser;
 import com.linagora.tmail.james.jmap.JMAPExtensionConfiguration;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
 import com.linagora.tmail.james.jmap.oidc.JMAPOidcConfiguration;
@@ -67,6 +68,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                                             ExtensionConfiguration extentionConfiguration,
                                             boolean oidcEnabled,
                                             OidcTokenCacheModuleChooser.OidcTokenCacheChoice oidcTokenCacheChoice,
+                                            UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice,
                                             boolean keywordEmailQueryViewEnabled) implements Configuration {
     public static class Builder {
         private Optional<SearchConfiguration> searchConfiguration;
@@ -87,6 +89,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
         private Optional<ExtensionConfiguration> extentionConfiguration;
         private Optional<Boolean> oidcEnabled;
         private Optional<OidcTokenCacheModuleChooser.OidcTokenCacheChoice> oidcTokenStorageChoice;
+        private Optional<UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice> unauthenticatedBlobAccessChoice;
         private Optional<Boolean> keywordEmailQueryViewEnabled;
 
         private Builder() {
@@ -108,6 +111,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
             extentionConfiguration = Optional.empty();
             oidcEnabled = Optional.empty();
             oidcTokenStorageChoice = Optional.empty();
+            unauthenticatedBlobAccessChoice = Optional.empty();
             keywordEmailQueryViewEnabled = Optional.empty();
         }
 
@@ -219,6 +223,11 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
             return this;
         }
 
+        public Builder unauthenticatedBlobAccessChoice(UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice) {
+            this.unauthenticatedBlobAccessChoice = Optional.of(unauthenticatedBlobAccessChoice);
+            return this;
+        }
+
         public Builder keywordEmailQueryViewEnabled(boolean enable) {
             this.keywordEmailQueryViewEnabled = Optional.of(enable);
             return this;
@@ -324,6 +333,9 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
             OidcTokenCacheModuleChooser.OidcTokenCacheChoice oidcTokenCacheChoice = this.oidcTokenStorageChoice.orElseGet(Throwing.supplier(
                 () -> OidcTokenCacheModuleChooser.OidcTokenCacheChoice.from(propertiesProvider)));
 
+            UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice = this.unauthenticatedBlobAccessChoice.orElseGet(Throwing.supplier(
+                () -> UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice.from(propertiesProvider)));
+
             boolean keywordEmailQueryViewEnabled = this.keywordEmailQueryViewEnabled.orElseGet(() -> {
                 try {
                     return JMAPExtensionConfiguration.from(propertiesProvider.getConfiguration("jmap")).viewKeywordQueryEnabled();
@@ -355,6 +367,7 @@ public record DistributedJamesConfiguration(ConfigurationPath configurationPath,
                 extentionConfiguration,
                 oidcEnabled,
                 oidcTokenCacheChoice,
+                unauthenticatedBlobAccessChoice,
                 keywordEmailQueryViewEnabled);
         }
     }

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -164,10 +164,9 @@ import com.linagora.tmail.event.TMailJMAPListenerModule;
 import com.linagora.tmail.event.TmailEventModule;
 import com.linagora.tmail.healthcheck.TasksHeathCheckModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
+import com.linagora.tmail.james.app.module.UnauthenticatedBlobAccessModuleChooser;
 import com.linagora.tmail.james.jmap.ContactSupportCapabilitiesModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
-import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
-import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.CassandraDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.CassandraFirebaseSubscriptionRepositoryModule;
@@ -673,15 +672,7 @@ public class DistributedServer {
 
     private static Module chooseUnauthenticatedBlobAccessModules(DistributedJamesConfiguration configuration) {
         if (configuration.jmapEnabled()) {
-            try {
-                configuration.propertiesProvider().getConfiguration("redis");
-                return Modules.combine(new UnauthenticatedBlobAccessJmapModule(), new RedisUnauthenticatedBlobDownloadTokenRepositoryModule());
-            } catch (FileNotFoundException e) {
-                LOGGER.warn("JMAP unauthenticated blob access is disabled because Redis storage is not available.");
-                return Modules.EMPTY_MODULE;
-            } catch (ConfigurationException e) {
-                throw new RuntimeException(e);
-            }
+            return UnauthenticatedBlobAccessModuleChooser.chooseModule(configuration.unauthenticatedBlobAccessChoice());
         }
         return Modules.EMPTY_MODULE;
     }

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -167,6 +167,7 @@ import com.linagora.tmail.imap.TMailIMAPModule;
 import com.linagora.tmail.james.jmap.ContactSupportCapabilitiesModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
 import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.CassandraDomainSignatureTemplateRepositoryModule;
 import com.linagora.tmail.james.jmap.firebase.CassandraFirebaseSubscriptionRepositoryModule;
@@ -672,7 +673,15 @@ public class DistributedServer {
 
     private static Module chooseUnauthenticatedBlobAccessModules(DistributedJamesConfiguration configuration) {
         if (configuration.jmapEnabled()) {
-            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
+            try {
+                configuration.propertiesProvider().getConfiguration("redis");
+                return Modules.combine(new UnauthenticatedBlobAccessJmapModule(), new RedisUnauthenticatedBlobDownloadTokenRepositoryModule());
+            } catch (FileNotFoundException e) {
+                LOGGER.warn("JMAP unauthenticated blob access is disabled because Redis storage is not available.");
+                return Modules.EMPTY_MODULE;
+            } catch (ConfigurationException e) {
+                throw new RuntimeException(e);
+            }
         }
         return Modules.EMPTY_MODULE;
     }

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/module/UnauthenticatedBlobAccessModuleChooser.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/module/UnauthenticatedBlobAccessModuleChooser.java
@@ -1,0 +1,66 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.app.module;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
+
+public class UnauthenticatedBlobAccessModuleChooser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnauthenticatedBlobAccessModuleChooser.class);
+
+    public enum UnauthenticatedBlobAccessChoice {
+        DISABLED,
+        REDIS;
+
+        public static UnauthenticatedBlobAccessChoice from(PropertiesProvider propertiesProvider) {
+            try {
+                propertiesProvider.getConfiguration("redis");
+                return REDIS;
+            } catch (FileNotFoundException e) {
+                return DISABLED;
+            } catch (ConfigurationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Module chooseModule(UnauthenticatedBlobAccessChoice choice) {
+        switch (choice) {
+            case REDIS -> {
+                LOGGER.info("Using Redis for JMAP unauthenticated blob access token storage");
+                return Modules.combine(new UnauthenticatedBlobAccessJmapModule(), new RedisUnauthenticatedBlobDownloadTokenRepositoryModule());
+            }
+            case DISABLED -> {
+                LOGGER.warn("JMAP unauthenticated blob access is disabled because Redis storage is not available.");
+                return Modules.EMPTY_MODULE;
+            }
+            default -> throw new NotImplementedException();
+        }
+    }
+}

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -89,6 +89,7 @@ import com.linagora.tmail.james.app.modules.jmap.MemoryUnauthenticatedDownloadTo
 import com.linagora.tmail.james.app.modules.jmap.PublicAssetsMemoryModule;
 import com.linagora.tmail.james.jmap.ContactSupportCapabilitiesModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
 import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseCommonModule;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
@@ -185,6 +186,7 @@ public class MemoryServer {
         new MailboxResourcesLocationRoutesModule(),
         new InboxArchivalTaskModule(),
         new ContactSupportCapabilitiesModule(),
+        new UnauthenticatedBlobAccessJmapModule(),
         new DownloadAllRoutesModule(),
         new MailboxClearMethodModule(),
         new FolderFilteringActionMethodModule())

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
@@ -44,6 +44,7 @@ import com.github.fge.lambdas.Throwing;
 import com.linagora.tmail.OpenPaasModuleChooserConfiguration;
 import com.linagora.tmail.UsersRepositoryModuleChooser;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.james.app.module.PostgresUnauthenticatedBlobAccessModuleChooser;
 import com.linagora.tmail.james.jmap.JMAPExtensionConfiguration;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
 import com.linagora.tmail.james.jmap.oidc.JMAPOidcConfiguration;
@@ -67,6 +68,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                                          EventBusImpl eventBusImpl,
                                          boolean oidcEnabled,
                                          OidcTokenCacheModuleChooser.OidcTokenCacheChoice oidcTokenCacheChoice,
+                                         PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice,
                                          boolean keywordEmailQueryViewEnabled) implements Configuration {
 
     public enum EventBusImpl {
@@ -129,6 +131,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
         private Optional<EventBusImpl> eventBusImpl;
         private Optional<Boolean> oidcEnabled;
         private Optional<OidcTokenCacheModuleChooser.OidcTokenCacheChoice> oidcTokenStorageChoice;
+        private Optional<PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice> unauthenticatedBlobAccessChoice;
         private Optional<Boolean> keywordEmailQueryViewEnabled;
 
         private Builder() {
@@ -148,6 +151,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             eventBusImpl = Optional.empty();
             oidcEnabled = Optional.empty();
             oidcTokenStorageChoice = Optional.empty();
+            unauthenticatedBlobAccessChoice = Optional.empty();
             keywordEmailQueryViewEnabled = Optional.empty();
         }
 
@@ -249,6 +253,11 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             return this;
         }
 
+        public Builder unauthenticatedBlobAccessChoice(PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice) {
+            this.unauthenticatedBlobAccessChoice = Optional.of(unauthenticatedBlobAccessChoice);
+            return this;
+        }
+
         public Builder keywordEmailQueryViewEnabled(boolean enable) {
             this.keywordEmailQueryViewEnabled = Optional.of(enable);
             return this;
@@ -326,6 +335,9 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             OidcTokenCacheModuleChooser.OidcTokenCacheChoice oidcTokenCacheChoice = this.oidcTokenStorageChoice.orElseGet(Throwing.supplier(
                 () -> OidcTokenCacheModuleChooser.OidcTokenCacheChoice.from(propertiesProvider)));
 
+            PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice unauthenticatedBlobAccessChoice = this.unauthenticatedBlobAccessChoice.orElseGet(Throwing.supplier(
+                () -> PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice.from(propertiesProvider)));
+
             boolean keywordEmailQueryViewEnabled = this.keywordEmailQueryViewEnabled.orElseGet(() -> {
                 try {
                     return JMAPExtensionConfiguration.from(propertiesProvider.getConfiguration("jmap")).viewKeywordQueryEnabled();
@@ -354,6 +366,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                 eventBusImpl,
                 oidcEnabled,
                 oidcTokenCacheChoice,
+                unauthenticatedBlobAccessChoice,
                 keywordEmailQueryViewEnabled);
         }
 

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -21,12 +21,10 @@ package com.linagora.tmail.james.app;
 import static com.linagora.tmail.OpenPaasModule.DavModule.CALDAV_SUPPORTED;
 import static com.linagora.tmail.OpenPaasModule.DavModule.CALDAV_SUPPORT_MODULE_PROVIDER;
 
-import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.ExtraProperties;
 import org.apache.james.GuiceJamesServer;
@@ -150,11 +148,9 @@ import com.linagora.tmail.event.TMailJMAPListenerModule;
 import com.linagora.tmail.event.TmailEventModule;
 import com.linagora.tmail.healthcheck.TasksHeathCheckModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
+import com.linagora.tmail.james.app.module.PostgresUnauthenticatedBlobAccessModuleChooser;
 import com.linagora.tmail.james.app.modules.jmap.MemoryTmailEventBusModule;
-import com.linagora.tmail.james.app.modules.jmap.MemoryUnauthenticatedDownloadTokenRepositoryModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
-import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
-import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
 import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.PostgresDomainSignatureTemplateRepositoryModule;
@@ -598,24 +594,9 @@ public class PostgresTmailServer {
 
     private static Module chooseUnauthenticatedBlobAccessModules(PostgresTmailConfiguration configuration) {
         if (configuration.jmapEnabled()) {
-            return Modules.combine(
-                new UnauthenticatedBlobAccessJmapModule(),
-                chooseUnauthenticatedBlobDownloadTokenRepository(configuration));
+            return PostgresUnauthenticatedBlobAccessModuleChooser.chooseModule(configuration.unauthenticatedBlobAccessChoice());
         }
         return Modules.EMPTY_MODULE;
-    }
-
-    private static Module chooseUnauthenticatedBlobDownloadTokenRepository(PostgresTmailConfiguration configuration) {
-        try {
-            configuration.propertiesProvider().getConfiguration("redis");
-            LOGGER.info("Using Redis for Unauthenticated Blob Access repository");
-            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
-        } catch (FileNotFoundException e) {
-            LOGGER.warn("Using memory implementation for Unauthenticated Blob Access repository. Avoid using this in a distributed environment.");
-            return new MemoryUnauthenticatedDownloadTokenRepositoryModule();
-        } catch (ConfigurationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static List<Module> chooseOpenPaasModule(OpenPaasModuleChooserConfiguration openPaasModuleChooserConfiguration) {

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -21,10 +21,12 @@ package com.linagora.tmail.james.app;
 import static com.linagora.tmail.OpenPaasModule.DavModule.CALDAV_SUPPORTED;
 import static com.linagora.tmail.OpenPaasModule.DavModule.CALDAV_SUPPORT_MODULE_PROVIDER;
 
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.ExtraProperties;
 import org.apache.james.GuiceJamesServer;
@@ -149,8 +151,10 @@ import com.linagora.tmail.event.TmailEventModule;
 import com.linagora.tmail.healthcheck.TasksHeathCheckModule;
 import com.linagora.tmail.imap.TMailIMAPModule;
 import com.linagora.tmail.james.app.modules.jmap.MemoryTmailEventBusModule;
+import com.linagora.tmail.james.app.modules.jmap.MemoryUnauthenticatedDownloadTokenRepositoryModule;
 import com.linagora.tmail.james.jmap.TMailJMAPModule;
 import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
 import com.linagora.tmail.james.jmap.contact.InMemoryEmailAddressContactSearchEngineModule;
 import com.linagora.tmail.james.jmap.contact.RabbitMQEmailAddressContactModule;
 import com.linagora.tmail.james.jmap.event.PostgresDomainSignatureTemplateRepositoryModule;
@@ -594,9 +598,24 @@ public class PostgresTmailServer {
 
     private static Module chooseUnauthenticatedBlobAccessModules(PostgresTmailConfiguration configuration) {
         if (configuration.jmapEnabled()) {
-            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
+            return Modules.combine(
+                new UnauthenticatedBlobAccessJmapModule(),
+                chooseUnauthenticatedBlobDownloadTokenRepository(configuration));
         }
         return Modules.EMPTY_MODULE;
+    }
+
+    private static Module chooseUnauthenticatedBlobDownloadTokenRepository(PostgresTmailConfiguration configuration) {
+        try {
+            configuration.propertiesProvider().getConfiguration("redis");
+            LOGGER.info("Using Redis for Unauthenticated Blob Access repository");
+            return new RedisUnauthenticatedBlobDownloadTokenRepositoryModule();
+        } catch (FileNotFoundException e) {
+            LOGGER.warn("Using memory implementation for Unauthenticated Blob Access repository. Avoid using this in a distributed environment.");
+            return new MemoryUnauthenticatedDownloadTokenRepositoryModule();
+        } catch (ConfigurationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static List<Module> chooseOpenPaasModule(OpenPaasModuleChooserConfiguration openPaasModuleChooserConfiguration) {

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/module/PostgresUnauthenticatedBlobAccessModuleChooser.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/module/PostgresUnauthenticatedBlobAccessModuleChooser.java
@@ -1,0 +1,67 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.app.module;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.linagora.tmail.james.app.modules.jmap.MemoryUnauthenticatedDownloadTokenRepositoryModule;
+import com.linagora.tmail.james.jmap.blob.RedisUnauthenticatedBlobDownloadTokenRepositoryModule;
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobAccessJmapModule;
+
+public class PostgresUnauthenticatedBlobAccessModuleChooser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresUnauthenticatedBlobAccessModuleChooser.class);
+
+    public enum UnauthenticatedBlobAccessChoice {
+        REDIS,
+        MEMORY;
+
+        public static UnauthenticatedBlobAccessChoice from(PropertiesProvider propertiesProvider) {
+            try {
+                propertiesProvider.getConfiguration("redis");
+                return REDIS;
+            } catch (FileNotFoundException e) {
+                return MEMORY;
+            } catch (ConfigurationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Module chooseModule(UnauthenticatedBlobAccessChoice choice) {
+        switch (choice) {
+            case REDIS -> {
+                LOGGER.info("Using Redis for JMAP unauthenticated blob access token storage");
+                return Modules.combine(new UnauthenticatedBlobAccessJmapModule(), new RedisUnauthenticatedBlobDownloadTokenRepositoryModule());
+            }
+            case MEMORY -> {
+                LOGGER.warn("Using memory implementation for JMAP unauthenticated blob access token storage. Avoid using this in a distributed environment.");
+                return Modules.combine(new UnauthenticatedBlobAccessJmapModule(), new MemoryUnauthenticatedDownloadTokenRepositoryModule());
+            }
+            default -> throw new NotImplementedException();
+        }
+    }
+}

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedUnauthenticatedBlobAccessSetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedUnauthenticatedBlobAccessSetMethodTest.java
@@ -18,12 +18,7 @@
 
 package com.linagora.tmail.james;
 
-import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
+import static com.linagora.tmail.james.app.module.UnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice.REDIS;
 
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
@@ -31,12 +26,9 @@ import org.apache.james.SearchConfiguration;
 import org.apache.james.backends.redis.RedisExtension;
 import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbeModule;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.common.collect.ImmutableList;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
-import com.linagora.tmail.common.TemporaryTmailServerUtils;
 import com.linagora.tmail.james.app.CassandraExtension;
 import com.linagora.tmail.james.app.DistributedJamesConfiguration;
 import com.linagora.tmail.james.app.DistributedServer;
@@ -55,7 +47,7 @@ public class DistributedUnauthenticatedBlobAccessSetMethodTest implements Unauth
     static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
         DistributedJamesConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationPath(setupConfigurationPath(tmpDir))
+            .configurationFromClasspath()
             .blobStore(BlobStoreConfiguration.builder()
                 .s3()
                 .noSecondaryS3BlobStore()
@@ -65,6 +57,7 @@ public class DistributedUnauthenticatedBlobAccessSetMethodTest implements Unauth
                 .disableSingleSave())
             .eventBusKeysChoice(EventBusKeysChoice.REDIS)
             .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+            .unauthenticatedBlobAccessChoice(REDIS)
             .searchConfiguration(SearchConfiguration.openSearch())
             .build())
         .extension(new DockerOpenSearchExtension())
@@ -78,19 +71,4 @@ public class DistributedUnauthenticatedBlobAccessSetMethodTest implements Unauth
             .overrideWith(new UnauthenticatedBlobAccessTokenRepositoryProbeModule()))
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
-
-    private static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
-        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
-            .addAll(BASE_CONFIGURATION_FILE_NAMES)
-            .build());
-
-        try {
-            Files.writeString(serverUtils.getConfigFolder().resolve("redis.properties"),
-                "redisURL=" + REDIS_EXTENSION.dockerRedis().redisURI() + "\n");
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        return serverUtils.getConfigurationPath();
-    }
 }

--- a/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedUnauthenticatedBlobAccessSetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/distributed-jmap-integration-tests/src/test/java/com/linagora/tmail/james/DistributedUnauthenticatedBlobAccessSetMethodTest.java
@@ -1,0 +1,96 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james;
+
+import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.backends.redis.RedisExtension;
+import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbeModule;
+import org.apache.james.modules.AwsS3BlobStoreExtension;
+import org.apache.james.server.core.configuration.Configuration;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.common.TemporaryTmailServerUtils;
+import com.linagora.tmail.james.app.CassandraExtension;
+import com.linagora.tmail.james.app.DistributedJamesConfiguration;
+import com.linagora.tmail.james.app.DistributedServer;
+import com.linagora.tmail.james.app.DockerOpenSearchExtension;
+import com.linagora.tmail.james.app.EventBusKeysChoice;
+import com.linagora.tmail.james.app.RabbitMQExtension;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessSetMethodContract;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessTokenRepositoryProbeModule;
+import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+public class DistributedUnauthenticatedBlobAccessSetMethodTest implements UnauthenticatedBlobAccessSetMethodContract {
+    private static final RedisExtension REDIS_EXTENSION = new RedisExtension();
+
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
+        DistributedJamesConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationPath(setupConfigurationPath(tmpDir))
+            .blobStore(BlobStoreConfiguration.builder()
+                .s3()
+                .noSecondaryS3BlobStore()
+                .disableCache()
+                .deduplication()
+                .noCryptoConfig()
+                .disableSingleSave())
+            .eventBusKeysChoice(EventBusKeysChoice.REDIS)
+            .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+            .searchConfiguration(SearchConfiguration.openSearch())
+            .build())
+        .extension(new DockerOpenSearchExtension())
+        .extension(new CassandraExtension())
+        .extension(new RabbitMQExtension())
+        .extension(REDIS_EXTENSION)
+        .extension(new AwsS3BlobStoreExtension())
+        .server(configuration -> DistributedServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(new DelegationProbeModule())
+            .overrideWith(new UnauthenticatedBlobAccessTokenRepositoryProbeModule()))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+
+    private static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
+        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
+            .addAll(BASE_CONFIGURATION_FILE_NAMES)
+            .build());
+
+        try {
+            Files.writeString(serverUtils.getConfigFolder().resolve("redis.properties"),
+                "redisURL=" + REDIS_EXTENSION.dockerRedis().redisURI() + "\n");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return serverUtils.getConfigurationPath();
+    }
+}

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
@@ -156,7 +156,7 @@ trait UnauthenticatedBlobAccessSetMethodContract {
   }
 
   @Test
-  def createShouldReturnTokenForAccessibleBlob(server: GuiceJamesServer): Unit = {
+  def shouldGrantAccessForUploadBlob(server: GuiceJamesServer): Unit = {
     val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
     val response: String = createAccess(server, bobAccountId, blobId)
     val token: String = createdToken(response, blobId)
@@ -194,6 +194,24 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |    }
            |}""".stripMargin)
     assertThat(tokenProbe(server).isValid(bobAccountId, messageBlobId, token)).isTrue
+  }
+
+  @Test
+  def shouldGrantAccessForMessagePartBlob(server: GuiceJamesServer): Unit = {
+    val messageId = appendMessage(server, bobUsername)
+    val messagePartBlobId: String = firstTextBodyBlobId(server, bobUsername, BOB_PASSWORD, bobAccountId, messageId)
+    val response: String = createAccess(server, bobAccountId, messagePartBlobId)
+    val token: String = createdToken(response, messagePartBlobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].created")
+      .isEqualTo(
+        s"""{
+           |    "$messagePartBlobId": {
+           |        "token": "$${json-unit.ignore}"
+           |    }
+           |}""".stripMargin)
+    assertThat(tokenProbe(server).isValid(bobAccountId, messagePartBlobId, token)).isTrue
   }
 
   @Test
@@ -313,7 +331,8 @@ trait UnauthenticatedBlobAccessSetMethodContract {
   @Test
   def foreignUploadedBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
     val andreBlobId: String = uploadBlob(server, andreUsername, ANDRE_PASSWORD, andreAccountId)
-    val response: String = createAccess(server, bobAccountId, andreBlobId)
+    val response: String = createAccess(server, bobAccountId, andreBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
 
     // Bob should not be granted access to Andre's blob
     assertThatJson(response)
@@ -323,6 +342,59 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |    "$andreBlobId": {
            |        "type": "notFound",
            |        "description": "Blob BlobId($andreBlobId) could not be found"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def foreignMessagePartBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
+    val andreMessageId = appendMessage(server, andreUsername)
+    val andreMessagePartBlobId: String = firstTextBodyBlobId(server, andreUsername, ANDRE_PASSWORD, andreAccountId, andreMessageId)
+    val response: String = createAccess(server, bobAccountId, andreMessagePartBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "$andreMessagePartBlobId": {
+           |        "type": "notFound",
+           |        "description": "Blob BlobId($andreMessagePartBlobId) could not be found"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def foreignMessageBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
+    val andreMessageBlobId = appendMessage(server, andreUsername).serialize()
+    val response: String = createAccess(server, bobAccountId, andreMessageBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "$andreMessageBlobId": {
+           |        "type": "notFound",
+           |        "description": "Blob BlobId($andreMessageBlobId) could not be found"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def foreignAttachmentBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
+    val andreMessageId = appendMessageFromResource(server, andreUsername, "emailWithTextAttachment.eml")
+    val andreAttachmentBlobId: String = firstAttachmentBlobId(server, andreUsername, ANDRE_PASSWORD, andreAccountId, andreMessageId)
+    val response: String = createAccess(server, bobAccountId, andreAttachmentBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "$andreAttachmentBlobId": {
+           |        "type": "notFound",
+           |        "description": "Blob BlobId($andreAttachmentBlobId) could not be found"
            |    }
            |}""".stripMargin)
   }
@@ -660,6 +732,34 @@ trait UnauthenticatedBlobAccessSetMethodContract {
       .contentType(JSON)
       .extract()
       .path("methodResponses[0][1].list[0].attachments[0].blobId")
+
+  private def firstTextBodyBlobId(server: GuiceJamesServer,
+                                  username: Username,
+                                  password: String,
+                                  accountId: String,
+                                  messageId: MessageId): String =
+    `given`(authenticatedSpec(server, username, password))
+      .body(
+        s"""{
+           |  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+           |  "methodCalls": [[
+           |    "Email/get",
+           |    {
+           |      "accountId": "$accountId",
+           |      "ids": ["${messageId.serialize()}"],
+           |      "properties": ["textBody"],
+           |      "bodyProperties": ["blobId"]
+           |    },
+           |    "c1"
+           |  ]]
+           |}""".stripMargin)
+    .when()
+      .post()
+    .`then`()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract()
+      .path("methodResponses[0][1].list[0].textBody[0].blobId")
 
   private def createAccess(server: GuiceJamesServer,
                            accountId: String,

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
@@ -1,0 +1,706 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.common
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+import com.google.common.hash.Hashing
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import com.linagora.tmail.james.jmap.blob.{UnauthenticatedBlobDownloadToken, UnauthenticatedBlobDownloadTokenRepository}
+import io.netty.handler.codec.http.HttpHeaderNames.ACCEPT
+import io.restassured.RestAssured.{`given`, requestSpecification}
+import io.restassured.http.ContentType.JSON
+import io.restassured.specification.RequestSpecification
+import jakarta.inject.Inject
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.apache.http.HttpStatus.{SC_CREATED, SC_OK}
+import org.apache.james.GuiceJamesServer
+import org.apache.james.blob.api.BlobId
+import org.apache.james.core.Username
+import org.apache.james.jmap.api.model.{AccountId => JavaAccountId}
+import org.apache.james.jmap.http.UserCredential
+import org.apache.james.jmap.rfc8621.contract.Fixture.{ACCEPT_RFC8621_VERSION_HEADER, ANDRE_PASSWORD, BOB_PASSWORD, DOMAIN, authScheme, baseRequestSpecBuilder}
+import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbe
+import org.apache.james.jmap.rfc8621.contract.tags.CategoryTags
+import org.apache.james.mailbox.MessageManager.AppendCommand
+import org.apache.james.mailbox.model.{MailboxPath, MessageId}
+import org.apache.james.mime4j.dom.Message
+import org.apache.james.modules.MailboxProbeImpl
+import org.apache.james.util.ClassLoaderUtils
+import org.apache.james.utils.{DataProbeImpl, GuiceProbe}
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import play.api.libs.json.{JsObject, Json}
+
+object UnauthenticatedBlobAccessSetMethodContract {
+  private val CAPABILITY: String = "com:linagora:params:jmap:unauthenticated:blob:access"
+
+  case class TestContext(bobUsername: Username,
+                         bobAccountId: String,
+                         andreUsername: Username,
+                         andreAccountId: String)
+
+  private val currentContext: AtomicReference[TestContext] = new AtomicReference[TestContext]()
+}
+
+class UnauthenticatedBlobAccessTokenRepositoryProbe @Inject()(repository: UnauthenticatedBlobDownloadTokenRepository,
+                                                              blobIdFactory: BlobId.Factory) extends GuiceProbe {
+  def isValid(accountId: String, blobId: String, token: String): Boolean =
+    repository.check(JavaAccountId.fromString(accountId), blobIdFactory.parse(blobId), new UnauthenticatedBlobDownloadToken(UUID.fromString(token)))
+      .block()
+      .booleanValue()
+}
+
+class UnauthenticatedBlobAccessTokenRepositoryProbeModule extends AbstractModule {
+  override def configure(): Unit =
+    Multibinder.newSetBinder(binder(), classOf[GuiceProbe])
+      .addBinding()
+      .to(classOf[UnauthenticatedBlobAccessTokenRepositoryProbe])
+}
+
+trait UnauthenticatedBlobAccessSetMethodContract {
+  import UnauthenticatedBlobAccessSetMethodContract._
+
+  def bobUsername: Username = currentContext.get().bobUsername
+  def bobAccountId: String = currentContext.get().bobAccountId
+  def andreUsername: Username = currentContext.get().andreUsername
+  def andreAccountId: String = currentContext.get().andreAccountId
+
+  @BeforeEach
+  def setUp(server: GuiceJamesServer): Unit = {
+    val uniqueSuffix = UUID.randomUUID().toString.replace("-", "").take(8)
+    val bob = Username.fromLocalPartWithDomain(s"bob$uniqueSuffix", DOMAIN)
+    val andre = Username.fromLocalPartWithDomain(s"andre$uniqueSuffix", DOMAIN)
+    currentContext.set(TestContext(
+      bobUsername = bob,
+      bobAccountId = sha256AccountId(bob),
+      andreUsername = andre,
+      andreAccountId = sha256AccountId(andre)))
+
+    server.getProbe(classOf[DataProbeImpl])
+      .fluent()
+      .addDomain(DOMAIN.asString)
+      .addUser(bob.asString, BOB_PASSWORD)
+      .addUser(andre.asString, ANDRE_PASSWORD)
+
+    requestSpecification = authenticatedSpec(server, bob, BOB_PASSWORD)
+  }
+
+  @Test
+  def sessionShouldAdvertiseCapability(): Unit =
+    assertThatJson(`given`()
+      .when()
+        .get("/session")
+      .`then`()
+        .statusCode(SC_OK)
+        .contentType(JSON)
+        .extract()
+        .body()
+        .asString())
+      .inPath(s"capabilities['$CAPABILITY']")
+      .isEqualTo(
+        s"""{
+           |    "endpoint": "http://localhost/unauthenticatedDownload/{accountId}/{blobId}?token={token}",
+           |    "tokenTtlInSeconds": 300
+           |}""".stripMargin)
+
+  @Test
+  def missingCapabilityShouldReturnUnknownMethod(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        "$blobId": {}
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "error",
+           |    {
+           |        "type": "unknownMethod",
+           |        "description": "Missing capability(ies): $CAPABILITY"
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def createShouldReturnTokenForAccessibleBlob(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val response: String = createAccess(server, bobAccountId, blobId)
+    val token: String = createdToken(response, blobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "created": {
+           |            "$blobId": {
+           |                "token": "$${json-unit.ignore}"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+    assertThat(tokenProbe(server).isValid(bobAccountId, blobId, token)).isTrue
+  }
+
+  @Test
+  def shouldGrantAccessForMessageBlob(server: GuiceJamesServer): Unit = {
+    val messageBlobId = appendMessage(server, bobUsername).serialize()
+    val response: String = createAccess(server, bobAccountId, messageBlobId)
+    val token: String = createdToken(response, messageBlobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].created")
+      .isEqualTo(
+        s"""{
+           |    "$messageBlobId": {
+           |        "token": "$${json-unit.ignore}"
+           |    }
+           |}""".stripMargin)
+    assertThat(tokenProbe(server).isValid(bobAccountId, messageBlobId, token)).isTrue
+  }
+
+  @Test
+  @Tag(CategoryTags.BASIC_FEATURE)
+  def shouldGrantAccessForAttachmentBlob(server: GuiceJamesServer): Unit = {
+    val messageId = appendMessageFromResource(server, bobUsername, "emailWithTextAttachment.eml")
+    val attachmentBlobId: String = firstAttachmentBlobId(server, bobUsername, BOB_PASSWORD, bobAccountId, messageId)
+    val response: String = createAccess(server, bobAccountId, attachmentBlobId)
+    val token: String = createdToken(response, attachmentBlobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].created")
+      .isEqualTo(
+        s"""{
+           |    "$attachmentBlobId": {
+           |        "token": "$${json-unit.ignore}"
+           |    }
+           |}""".stripMargin)
+    assertThat(tokenProbe(server).isValid(bobAccountId, attachmentBlobId, token)).isTrue
+  }
+
+  @Test
+  def invalidBlobIdShouldReturnNotCreatedInvalidArguments(server: GuiceJamesServer): Unit = {
+    val response: String = createAccess(server, bobAccountId, "")
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "notCreated": {
+           |            "": {
+           |                "type": "invalidArguments",
+           |                "description": "$${json-unit.ignore}"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def invalidCreateObjectShouldReturnNotCreatedWithInvalidArguments(server: GuiceJamesServer): Unit = {
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        "blobId": {
+         |          "unexpected": true
+         |        }
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "blobId": {
+           |        "type": "invalidArguments",
+           |        "description": "create value must be an empty object"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def nonObjectCreateValueShouldReturnNotCreatedInvalidArguments(server: GuiceJamesServer): Unit = {
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        "blobId": true
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "blobId": {
+           |        "type": "invalidArguments",
+           |        "description": "create value must be an empty object"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def nonExistingBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
+    val response: String = createAccess(server, bobAccountId, "nonexistentBlobId")
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "nonexistentBlobId": {
+           |        "type": "notFound",
+           |        "description": "Blob BlobId(nonexistentBlobId) could not be found"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def foreignUploadedBlobShouldReturnNotCreatedNotFound(server: GuiceJamesServer): Unit = {
+    val andreBlobId: String = uploadBlob(server, andreUsername, ANDRE_PASSWORD, andreAccountId)
+    val response: String = createAccess(server, bobAccountId, andreBlobId)
+
+    // Bob should not be granted access to Andre's blob
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].notCreated")
+      .isEqualTo(
+        s"""{
+           |    "$andreBlobId": {
+           |        "type": "notFound",
+           |        "description": "Blob BlobId($andreBlobId) could not be found"
+           |    }
+           |}""".stripMargin)
+  }
+
+  @Test
+  def delegatedAccountShouldReturnTokenBoundToDelegatedAccount(server: GuiceJamesServer): Unit = {
+    val andreBlobId = appendMessage(server, andreUsername).serialize()
+    // GIVEN Andre delegates Bob to access Andre account
+    server.getProbe(classOf[DelegationProbe]).addAuthorizedUser(andreUsername, bobUsername)
+
+    // WHEN Bob grant access to Andre's blob using Andre's accountId
+    val response: String = createAccess(server, andreAccountId, andreBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
+    val token: String = createdToken(response, andreBlobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].created")
+      .isEqualTo(
+        s"""{
+           |    "$andreBlobId": {
+           |        "token": "$${json-unit.ignore}"
+           |    }
+           |}""".stripMargin)
+
+    // THEN the blob should be granted under Andre accountId, not bob accountId
+    assertThat(tokenProbe(server).isValid(andreAccountId, andreBlobId, token)).isTrue
+    assertThat(tokenProbe(server).isValid(bobAccountId, andreBlobId, token)).isFalse
+  }
+
+  @Test
+  def delegatedAccountWithoutDelegationShouldReturnAccountNotFound(server: GuiceJamesServer): Unit = {
+    val andreBlobId = appendMessage(server, andreUsername).serialize()
+
+    val response: String = createAccess(server, andreAccountId, andreBlobId,
+      username = bobUsername, password = BOB_PASSWORD)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "error",
+           |    {
+           |        "type": "accountNotFound"
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def mixedCreateShouldReturnCreatedAndNotCreated(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        "$blobId": {},
+         |        "nonexistentBlobId": {}
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "created": {
+           |            "$blobId": {
+           |                "token": "$${json-unit.ignore}"
+           |            }
+           |        },
+           |        "notCreated": {
+           |            "nonexistentBlobId": {
+           |                "type": "notFound",
+           |                "description": "Blob BlobId(nonexistentBlobId) could not be found"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def secondTokenShouldInvalidateFirstToken(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val firstToken: String = createdToken(createAccess(server, bobAccountId, blobId), blobId)
+    val response: String = createAccess(server, bobAccountId, blobId)
+    val secondToken: String = createdToken(response, blobId)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0][1].created")
+      .isEqualTo(
+        s"""{
+           |    "$blobId": {
+           |        "token": "$${json-unit.ignore}"
+           |    }
+           |}""".stripMargin)
+    assertThat(firstToken).isNotEqualTo(secondToken)
+    assertThat(tokenProbe(server).isValid(bobAccountId, blobId, firstToken)).isFalse
+    assertThat(tokenProbe(server).isValid(bobAccountId, blobId, secondToken)).isTrue
+  }
+
+  @Test
+  def tooManyCreateEntriesShouldReturnRequestTooLarge(server: GuiceJamesServer): Unit = {
+    val createEntries: String = (1 to 600)
+      .map(index => s""""blob$index": {}""")
+      .mkString(",")
+
+    val response = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        $createEntries
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "error",
+           |    {
+           |        "type": "requestTooLarge",
+           |        "description": "$${json-unit.ignore}"
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def updateShouldNotBeSupported(server: GuiceJamesServer): Unit = {
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "update": {
+         |        "blobId": {}
+         |      }
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "notUpdated": {
+           |            "blobId": {
+           |                "type": "invalidArguments",
+           |                "description": "`update` is not supported by UnauthenticatedBlobAccess/set"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def destroyShouldNotBeSupported(server: GuiceJamesServer): Unit = {
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "destroy": ["blobId"]
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "notDestroyed": {
+           |            "blobId": {
+           |                "type": "invalidArguments",
+           |                "description": "`destroy` is not supported by UnauthenticatedBlobAccess/set"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  @Test
+  def createWithUpdateAndDestroyShouldReturnAllResultSections(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val response: String = postJmap(server, bobUsername, BOB_PASSWORD,
+      s"""{
+         |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+         |  "methodCalls": [[
+         |    "UnauthenticatedBlobAccess/set",
+         |    {
+         |      "accountId": "$bobAccountId",
+         |      "create": {
+         |        "$blobId": {}
+         |      },
+         |      "update": {
+         |        "updatedBlob": {}
+         |      },
+         |      "destroy": ["destroyedBlob"]
+         |    },
+         |    "c1"
+         |  ]]
+         |}""".stripMargin)
+    assertThatJson(response)
+      .inPath("methodResponses[0]")
+      .isEqualTo(
+        s"""[
+           |    "UnauthenticatedBlobAccess/set",
+           |    {
+           |        "accountId": "$bobAccountId",
+           |        "created": {
+           |            "$blobId": {
+           |                "token": "$${json-unit.ignore}"
+           |            }
+           |        },
+           |        "notUpdated": {
+           |            "updatedBlob": {
+           |                "type": "invalidArguments",
+           |                "description": "`update` is not supported by UnauthenticatedBlobAccess/set"
+           |            }
+           |        },
+           |        "notDestroyed": {
+           |            "destroyedBlob": {
+           |                "type": "invalidArguments",
+           |                "description": "`destroy` is not supported by UnauthenticatedBlobAccess/set"
+           |            }
+           |        }
+           |    },
+           |    "c1"
+           |]""".stripMargin)
+  }
+
+  private def sha256AccountId(username: Username): String =
+    Hashing.sha256()
+      .hashString(username.asString(), StandardCharsets.UTF_8)
+      .toString
+
+  private def authenticatedSpec(server: GuiceJamesServer, username: Username, password: String): RequestSpecification =
+    baseRequestSpecBuilder(server)
+      .setAuth(authScheme(UserCredential(username, password)))
+      .addHeader(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .build()
+      .log()
+      .ifValidationFails()
+
+  private def uploadBlob(server: GuiceJamesServer,
+                         username: Username,
+                         password: String,
+                         accountId: String,
+                         contentType: String = "text/plain"): String =
+    `given`(authenticatedSpec(server, username, password))
+      .basePath("")
+      .contentType(contentType)
+      .body(UUID.randomUUID().toString)
+    .when()
+      .post(s"/upload/$accountId")
+    .`then`()
+      .statusCode(SC_CREATED)
+      .extract()
+      .path("blobId")
+
+  private def appendMessage(server: GuiceJamesServer, username: Username): MessageId = {
+    val path = MailboxPath.inbox(username)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
+    server.getProbe(classOf[MailboxProbeImpl])
+      .appendMessage(username.asString, path, AppendCommand.from(Message.Builder.of()
+        .setSubject("subject")
+        .setBody("body", StandardCharsets.UTF_8)
+        .build()))
+      .getMessageId
+  }
+
+  private def appendMessageFromResource(server: GuiceJamesServer, username: Username, resourceName: String): MessageId = {
+    val path = MailboxPath.inbox(username)
+    server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)
+    server.getProbe(classOf[MailboxProbeImpl])
+      .appendMessage(username.asString, path, AppendCommand.from(ClassLoaderUtils.getSystemResourceAsSharedStream(resourceName)))
+      .getMessageId
+  }
+
+  private def firstAttachmentBlobId(server: GuiceJamesServer,
+                                    username: Username,
+                                    password: String,
+                                    accountId: String,
+                                    messageId: MessageId): String =
+    `given`(authenticatedSpec(server, username, password))
+      .body(
+        s"""{
+           |  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+           |  "methodCalls": [[
+           |    "Email/get",
+           |    {
+           |      "accountId": "$accountId",
+           |      "ids": ["${messageId.serialize()}"],
+           |      "properties": ["attachments"],
+           |      "bodyProperties": ["blobId"]
+           |    },
+           |    "c1"
+           |  ]]
+           |}""".stripMargin)
+    .when()
+      .post()
+    .`then`()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract()
+      .path("methodResponses[0][1].list[0].attachments[0].blobId")
+
+  private def createAccess(server: GuiceJamesServer,
+                           accountId: String,
+                           blobId: String,
+                           username: Username = bobUsername,
+                           password: String = BOB_PASSWORD): String =
+    postJmap(server, username, password, createRequest(accountId, blobId))
+
+  private def createRequest(accountId: String, blobId: String): String =
+    s"""{
+       |  "using": ["urn:ietf:params:jmap:core", "$CAPABILITY"],
+       |  "methodCalls": [[
+       |    "UnauthenticatedBlobAccess/set",
+       |    {
+       |      "accountId": "$accountId",
+       |      "create": {
+       |        "$blobId": {}
+       |      }
+       |    },
+       |    "c1"
+       |  ]]
+       |}""".stripMargin
+
+  private def postJmap(server: GuiceJamesServer, username: Username, password: String, request: String): String =
+    `given`(authenticatedSpec(server, username, password))
+      .body(request)
+    .when()
+      .post()
+    .`then`()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract()
+      .body()
+      .asString()
+
+  private def firstArguments(response: String): JsObject =
+    (Json.parse(response) \ "methodResponses" \ 0 \ 1).as[JsObject]
+
+  private def createdToken(response: String, blobId: String): String =
+    (firstArguments(response) \ "created" \ blobId \ "token").as[String]
+
+  private def tokenProbe(server: GuiceJamesServer): UnauthenticatedBlobAccessTokenRepositoryProbe =
+    server.getProbe(classOf[UnauthenticatedBlobAccessTokenRepositoryProbe])
+}

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/pom.xml
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/pom.xml
@@ -120,7 +120,7 @@
                 <configuration>
                     <reuseForks>true</reuseForks>
                     <forkCount>2</forkCount>
-                    <argLine>-Xms1524m -Xmx2548m</argLine>
+                    <argLine>-Xms1524m -Xmx3048m</argLine>
                     <!-- Fail tests longer than 30 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                 </configuration>

--- a/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryUnauthenticatedBlobAccessSetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/memory-jmap-integration-tests/src/test/java/com/linagora/tmail/james/MemoryUnauthenticatedBlobAccessSetMethodTest.java
@@ -1,0 +1,50 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james;
+
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbeModule;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.james.app.MemoryConfiguration;
+import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessSetMethodContract;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessTokenRepositoryProbeModule;
+import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+public class MemoryUnauthenticatedBlobAccessSetMethodTest implements UnauthenticatedBlobAccessSetMethodContract {
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+        MemoryConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .usersRepository(DEFAULT)
+            .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+            .build())
+        .server(configuration -> MemoryServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(new DelegationProbeModule())
+            .overrideWith(new UnauthenticatedBlobAccessTokenRepositoryProbeModule()))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+}

--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresUnauthenticatedBlobAccessSetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresUnauthenticatedBlobAccessSetMethodTest.java
@@ -1,0 +1,92 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james;
+
+import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
+import static com.linagora.tmail.james.app.PostgresTmailConfiguration.EventBusImpl.IN_MEMORY;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.backends.redis.RedisExtension;
+import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbeModule;
+import org.apache.james.server.core.configuration.Configuration;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.common.TemporaryTmailServerUtils;
+import com.linagora.tmail.james.app.PostgresTmailConfiguration;
+import com.linagora.tmail.james.app.PostgresTmailServer;
+import com.linagora.tmail.james.common.LabelChangesMethodContract;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessSetMethodContract;
+import com.linagora.tmail.james.common.UnauthenticatedBlobAccessTokenRepositoryProbeModule;
+import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.james.jmap.firebase.FirebasePushClient;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+public class PostgresUnauthenticatedBlobAccessSetMethodTest implements UnauthenticatedBlobAccessSetMethodContract {
+    private static final RedisExtension REDIS_EXTENSION = new RedisExtension();
+
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<PostgresTmailConfiguration>(tmpDir ->
+        PostgresTmailConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationPath(setupConfigurationPath(tmpDir))
+            .blobStore(BlobStoreConfiguration.builder()
+                .postgres()
+                .disableCache()
+                .deduplication()
+                .noCryptoConfig()
+                .disableSingleSave())
+            .searchConfiguration(SearchConfiguration.scanning())
+            .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.ENABLED)
+            .eventBusImpl(IN_MEMORY)
+            .build())
+        .server(configuration -> PostgresTmailServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(binder -> binder.bind(FirebasePushClient.class).toInstance(LabelChangesMethodContract.firebasePushClient()))
+            .overrideWith(new DelegationProbeModule())
+            .overrideWith(new UnauthenticatedBlobAccessTokenRepositoryProbeModule()))
+        .extension(TmailJmapBase.postgresExtension)
+        .extension(REDIS_EXTENSION)
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+
+    private static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
+        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
+            .addAll(BASE_CONFIGURATION_FILE_NAMES)
+            .add("usersrepository.xml")
+            .build());
+
+        try {
+            Files.writeString(serverUtils.getConfigFolder().resolve("redis.properties"),
+                "redisURL=" + REDIS_EXTENSION.dockerRedis().redisURI() + "\n");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return serverUtils.getConfigurationPath();
+    }
+}

--- a/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresUnauthenticatedBlobAccessSetMethodTest.java
+++ b/tmail-backend/integration-tests/jmap/postgres-jmap-integration-tests/src/test/java/com/linagora/tmail/james/PostgresUnauthenticatedBlobAccessSetMethodTest.java
@@ -18,25 +18,17 @@
 
 package com.linagora.tmail.james;
 
-import static com.linagora.tmail.common.TemporaryTmailServerUtils.BASE_CONFIGURATION_FILE_NAMES;
 import static com.linagora.tmail.james.app.PostgresTmailConfiguration.EventBusImpl.IN_MEMORY;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
+import static com.linagora.tmail.james.app.module.PostgresUnauthenticatedBlobAccessModuleChooser.UnauthenticatedBlobAccessChoice.REDIS;
 
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
 import org.apache.james.backends.redis.RedisExtension;
 import org.apache.james.jmap.rfc8621.contract.probe.DelegationProbeModule;
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.common.collect.ImmutableList;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
-import com.linagora.tmail.common.TemporaryTmailServerUtils;
 import com.linagora.tmail.james.app.PostgresTmailConfiguration;
 import com.linagora.tmail.james.app.PostgresTmailServer;
 import com.linagora.tmail.james.common.LabelChangesMethodContract;
@@ -53,7 +45,7 @@ public class PostgresUnauthenticatedBlobAccessSetMethodTest implements Unauthent
     static JamesServerExtension testExtension = new JamesServerBuilder<PostgresTmailConfiguration>(tmpDir ->
         PostgresTmailConfiguration.builder()
             .workingDirectory(tmpDir)
-            .configurationPath(setupConfigurationPath(tmpDir))
+            .configurationFromClasspath()
             .blobStore(BlobStoreConfiguration.builder()
                 .postgres()
                 .disableCache()
@@ -63,6 +55,7 @@ public class PostgresUnauthenticatedBlobAccessSetMethodTest implements Unauthent
             .searchConfiguration(SearchConfiguration.scanning())
             .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.ENABLED)
             .eventBusImpl(IN_MEMORY)
+            .unauthenticatedBlobAccessChoice(REDIS)
             .build())
         .server(configuration -> PostgresTmailServer.createServer(configuration)
             .overrideWith(new LinagoraTestJMAPServerModule())
@@ -73,20 +66,4 @@ public class PostgresUnauthenticatedBlobAccessSetMethodTest implements Unauthent
         .extension(REDIS_EXTENSION)
         .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
         .build();
-
-    private static Configuration.ConfigurationPath setupConfigurationPath(File workingDir) {
-        TemporaryTmailServerUtils serverUtils = new TemporaryTmailServerUtils(workingDir, ImmutableList.<String>builder()
-            .addAll(BASE_CONFIGURATION_FILE_NAMES)
-            .add("usersrepository.xml")
-            .build());
-
-        try {
-            Files.writeString(serverUtils.getConfigFolder().resolve("redis.properties"),
-                "redisURL=" + REDIS_EXTENSION.dockerRedis().redisURI() + "\n");
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        return serverUtils.getConfigurationPath();
-    }
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobAccessJmapModule.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobAccessJmapModule.scala
@@ -1,0 +1,37 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.blob
+
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import com.linagora.tmail.james.jmap.method.{UnauthenticatedBlobAccessCapabilityFactory, UnauthenticatedBlobAccessSetMethod}
+import org.apache.james.jmap.core.CapabilityFactory
+import org.apache.james.jmap.method.Method
+
+class UnauthenticatedBlobAccessJmapModule extends AbstractModule {
+  override def configure(): Unit = {
+    Multibinder.newSetBinder(binder(), classOf[CapabilityFactory])
+      .addBinding()
+      .to(classOf[UnauthenticatedBlobAccessCapabilityFactory])
+
+    Multibinder.newSetBinder(binder(), classOf[Method])
+      .addBinding()
+      .to(classOf[UnauthenticatedBlobAccessSetMethod])
+  }
+}

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/json/UnauthenticatedBlobAccessSerializer.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/json/UnauthenticatedBlobAccessSerializer.scala
@@ -1,0 +1,44 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.json
+
+import com.linagora.tmail.james.jmap.model.{UnauthenticatedBlobAccessCreationResponse, UnauthenticatedBlobAccessSetRequest, UnauthenticatedBlobAccessSetResponse}
+import org.apache.james.jmap.core.SetError
+import org.apache.james.jmap.json.mapWrites
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
+
+object UnauthenticatedBlobAccessSerializer {
+  private implicit val creationResponseWrites: Writes[UnauthenticatedBlobAccessCreationResponse] =
+    Json.writes[UnauthenticatedBlobAccessCreationResponse]
+  private implicit val stringCreationResponseMapWrites: Writes[Map[String, UnauthenticatedBlobAccessCreationResponse]] =
+    mapWrites[String, UnauthenticatedBlobAccessCreationResponse](identity, creationResponseWrites)
+  private implicit val stringSetErrorMapWrites: Writes[Map[String, SetError]] =
+    mapWrites[String, SetError](identity, setErrorWrites)
+
+  private implicit val setRequestReads: Reads[UnauthenticatedBlobAccessSetRequest] =
+    Json.reads[UnauthenticatedBlobAccessSetRequest]
+  private implicit val setResponseWrites: Writes[UnauthenticatedBlobAccessSetResponse] =
+    Json.writes[UnauthenticatedBlobAccessSetResponse]
+
+  def deserializeSetRequest(input: JsValue) =
+    Json.fromJson[UnauthenticatedBlobAccessSetRequest](input)
+
+  def serializeSetResponse(response: UnauthenticatedBlobAccessSetResponse): JsValue =
+    Json.toJson(response)(setResponseWrites)
+}

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CustomMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/CustomMethod.scala
@@ -45,6 +45,7 @@ object CapabilityIdentifier {
   val LINAGORA_LABEL: CapabilityIdentifier = "com:linagora:params:jmap:labels"
   val LINAGORA_SETTINGS: CapabilityIdentifier = "com:linagora:params:jmap:settings"
   val LINAGORA_PUBLIC_ASSETS: CapabilityIdentifier = "com:linagora:params:jmap:public:assets"
+  val LINAGORA_UNAUTHENTICATED_BLOB_ACCESS: CapabilityIdentifier = "com:linagora:params:jmap:unauthenticated:blob:access"
   val LINAGORA_CONTACT_SUPPORT: CapabilityIdentifier = "com:linagora:params:jmap:contact:support"
   val LINAGORA_DOWNLOAD_ALL: CapabilityIdentifier = "com:linagora:params:downloadAll"
   val LINAGORA_MAILBOX_CLEAR: CapabilityIdentifier = "com:linagora:params:jmap:mailbox:clear"

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/EncryptedAttachmentBlobResolver.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/EncryptedAttachmentBlobResolver.scala
@@ -19,8 +19,9 @@
 package com.linagora.tmail.james.jmap.method
 
 import java.io.{ByteArrayInputStream, InputStream}
+import java.lang.Boolean.{FALSE, TRUE}
 
-import com.linagora.tmail.encrypted.{EncryptedAttachmentBlobId, EncryptedEmailContentStore}
+import com.linagora.tmail.encrypted.{EncryptedAttachmentBlobId, EncryptedEmailContentStore, AttachmentNotFoundException => EncryptedAttachmentNotFoundException}
 import jakarta.inject.Inject
 import org.apache.james.blob.api.BlobStore
 import org.apache.james.blob.api.BlobStore.StoragePolicy
@@ -54,4 +55,14 @@ class EncryptedAttachmentBlobResolver @Inject()(encryptedEmailContentStore: Encr
             .flatMap((blobStoreId: org.apache.james.blob.api.BlobId) =>
               SMono(blobStore.readBytes(blobStore.getDefaultBucketName, blobStoreId, StoragePolicy.LOW_COST)))
             .map(bytes => EncryptedAttachmentBlob(blobId, bytes)))))
+
+  override def validateAccess(blobId: BlobId, mailboxSession: MailboxSession): Publisher[java.lang.Boolean] =
+    EncryptedAttachmentBlobId.parse(messageIdFactory, blobId.value.value)
+      .fold(_ => SMono.just(FALSE),
+        encryptedId => SMono(encryptedEmailContentStore.retrieveAttachmentContent(encryptedId.messageId, encryptedId.position))
+          .map(_ => TRUE)
+          .onErrorResume {
+            case _: EncryptedAttachmentNotFoundException => SMono.just(FALSE)
+            case e => SMono.error[java.lang.Boolean](e)
+          })
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessCapability.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessCapability.scala
@@ -1,0 +1,48 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.method
+
+import com.linagora.tmail.james.jmap.UnauthenticatedBlobAccessConfiguration
+import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_UNAUTHENTICATED_BLOB_ACCESS
+import jakarta.inject.Inject
+import org.apache.james.core.Username
+import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
+import org.apache.james.jmap.core.UnsignedInt.UnsignedInt
+import org.apache.james.jmap.core.{Capability, CapabilityFactory, CapabilityProperties, URL, UnsignedInt, UrlPrefixes}
+import play.api.libs.json.{JsObject, Json}
+
+case class UnauthenticatedBlobAccessCapabilityProperties(endpoint: URL,
+                                                         tokenTtlInSeconds: UnsignedInt) extends CapabilityProperties {
+  override def jsonify(): JsObject = Json.obj(
+    "endpoint" -> endpoint.value,
+    "tokenTtlInSeconds" -> tokenTtlInSeconds.value)
+}
+
+case class UnauthenticatedBlobAccessCapability(properties: UnauthenticatedBlobAccessCapabilityProperties,
+                                               identifier: CapabilityIdentifier = LINAGORA_UNAUTHENTICATED_BLOB_ACCESS) extends Capability
+
+class UnauthenticatedBlobAccessCapabilityFactory @Inject()(configuration: UnauthenticatedBlobAccessConfiguration) extends CapabilityFactory {
+
+  override def id(): CapabilityIdentifier = LINAGORA_UNAUTHENTICATED_BLOB_ACCESS
+
+  override def create(urlPrefixes: UrlPrefixes, username: Username): Capability =
+    UnauthenticatedBlobAccessCapability(UnauthenticatedBlobAccessCapabilityProperties(
+      endpoint = URL(urlPrefixes.httpUrlPrefix.toString + "/unauthenticatedDownload/{accountId}/{blobId}?token={token}"),
+      tokenTtlInSeconds = UnsignedInt.liftOrThrow(configuration.tokenTtl.getSeconds)))
+}

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
@@ -132,14 +132,17 @@ class UnauthenticatedBlobAccessSetCreatePerformer @Inject()(val tokenRepository:
       case _ => Left(SetError.invalidArguments(SetErrorDescription("create value must be an empty object")))
     }
 
-  private def parseBlobIds(blobIdAsString: String): Either[SetError, BlobIds] =
-    (for {
+  private def parseBlobIds(blobIdAsString: String): Either[SetError, BlobIds] = {
+    val blobIdsTry: Try[BlobIds] = for {
       jmapBlobId <- JmapBlobId.of(blobIdAsString)
       blobStoreBlobId <- Try(blobIdFactory.parse(blobIdAsString))
-    } yield BlobIds(jmapBlobId, blobStoreBlobId)) match {
+    } yield BlobIds(jmapBlobId, blobStoreBlobId)
+
+    blobIdsTry match {
       case Success(blobIds) => Right(blobIds)
       case Failure(e) => Left(SetError.invalidArguments(SetErrorDescription(e.getMessage)))
     }
+  }
 
   private def toJavaAccountId(accountId: AccountId): JavaAccountId =
     JavaAccountId.fromString(accountId.id.value)

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
@@ -1,0 +1,188 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.method
+
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobDownloadTokenRepository
+import com.linagora.tmail.james.jmap.json.UnauthenticatedBlobAccessSerializer
+import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_UNAUTHENTICATED_BLOB_ACCESS
+import com.linagora.tmail.james.jmap.model.{UnauthenticatedBlobAccessCreationResponse, UnauthenticatedBlobAccessSetRequest, UnauthenticatedBlobAccessSetResponse}
+import eu.timepit.refined.auto._
+import jakarta.inject.Inject
+import org.apache.james.blob.api.{BlobId => BlobStoreBlobId}
+import org.apache.james.jmap.api.model.{AccountId => JavaAccountId}
+import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE}
+import org.apache.james.jmap.core.Invocation.{Arguments, MethodName}
+import org.apache.james.jmap.core.SetError.SetErrorDescription
+import org.apache.james.jmap.core.{AccountId, Invocation, JmapRfc8621Configuration, SessionTranslator, SetError}
+import org.apache.james.jmap.mail.{BlobId => JmapBlobId}
+import org.apache.james.jmap.method.{InvocationWithContext, MethodRequiringAccountId}
+import org.apache.james.jmap.routes.{Blob, BlobNotFoundException, BlobResolvers, SessionSupplier}
+import org.apache.james.mailbox.MailboxSession
+import org.apache.james.metrics.api.MetricFactory
+import org.apache.james.util.ReactorUtils
+import org.reactivestreams.Publisher
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.json.{JsObject, JsValue}
+import reactor.core.scala.publisher.{SFlux, SMono}
+
+import scala.util.{Failure, Success, Try}
+
+object UnauthenticatedBlobAccessSetMethod {
+  val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnauthenticatedBlobAccessSetMethod])
+}
+
+class UnauthenticatedBlobAccessSetMethod @Inject()(val createPerformer: UnauthenticatedBlobAccessSetCreatePerformer,
+                                                   val metricFactory: MetricFactory,
+                                                   val sessionTranslator: SessionTranslator,
+                                                   val sessionSupplier: SessionSupplier,
+                                                   val configuration: JmapRfc8621Configuration) extends MethodRequiringAccountId[UnauthenticatedBlobAccessSetRequest] {
+
+  override val methodName: MethodName = MethodName("UnauthenticatedBlobAccess/set")
+  override val requiredCapabilities: Set[CapabilityIdentifier] = Set(JMAP_CORE, LINAGORA_UNAUTHENTICATED_BLOB_ACCESS)
+
+  override def getRequest(mailboxSession: MailboxSession, invocation: Invocation): Either[Exception, UnauthenticatedBlobAccessSetRequest] =
+    for {
+      request <- UnauthenticatedBlobAccessSerializer.deserializeSetRequest(invocation.arguments.value).asEitherRequest
+      _ <- request.validate(configuration)
+    } yield request
+
+  override def doProcess(capabilities: Set[CapabilityIdentifier],
+                         invocation: InvocationWithContext,
+                         mailboxSession: MailboxSession,
+                         request: UnauthenticatedBlobAccessSetRequest): Publisher[InvocationWithContext] =
+    createPerformer.create(mailboxSession, request)
+      .map(results => InvocationWithContext(
+        invocation = Invocation(
+          methodName = methodName,
+          arguments = Arguments(UnauthenticatedBlobAccessSerializer.serializeSetResponse(UnauthenticatedBlobAccessSetResponse(
+            accountId = request.accountId,
+            created = Some(results.created).filter(_.nonEmpty),
+            notCreated = Some(results.notCreated).filter(_.nonEmpty),
+            notUpdated = unsupportedUpdates(request),
+            notDestroyed = unsupportedDestroy(request))).as[JsObject]),
+          methodCallId = invocation.invocation.methodCallId),
+        processingContext = invocation.processingContext))
+
+  private def unsupportedUpdates(request: UnauthenticatedBlobAccessSetRequest): Option[Map[String, SetError]] =
+    request.update
+      .map(_.keys.map(id => id -> unsupportedOperationError("update")).toMap)
+      .filter(_.nonEmpty)
+
+  private def unsupportedDestroy(request: UnauthenticatedBlobAccessSetRequest): Option[Map[String, SetError]] =
+    request.destroy
+      .map(_.map(id => id -> unsupportedOperationError("destroy")).toMap)
+      .filter(_.nonEmpty)
+
+  private def unsupportedOperationError(operation: String): SetError =
+    SetError.invalidArguments(SetErrorDescription(s"`$operation` is not supported by UnauthenticatedBlobAccess/set"))
+}
+
+class UnauthenticatedBlobAccessSetCreatePerformer @Inject()(val tokenRepository: UnauthenticatedBlobDownloadTokenRepository,
+                                                            val blobResolvers: BlobResolvers,
+                                                            val blobIdFactory: BlobStoreBlobId.Factory) {
+  import UnauthenticatedBlobAccessSetMethod.LOGGER
+
+  def create(mailboxSession: MailboxSession, request: UnauthenticatedBlobAccessSetRequest): SMono[UnauthenticatedBlobAccessCreationResults] =
+    SFlux.fromIterable(request.create.getOrElse(Map.empty))
+      .flatMap({
+        case (blobIdAsString, createValue) => create(mailboxSession, request.accountId, blobIdAsString, createValue)
+      }, ReactorUtils.DEFAULT_CONCURRENCY)
+      .collectSeq()
+      .map(UnauthenticatedBlobAccessCreationResults)
+
+  private def create(mailboxSession: MailboxSession,
+                     accountId: AccountId,
+                     blobIdAsString: String,
+                     createValue: JsValue): SMono[UnauthenticatedBlobAccessCreationResult] =
+    validateCreateEntry(blobIdAsString, createValue) match {
+      case Left(error) => SMono.just(UnauthenticatedBlobAccessCreationFailure(blobIdAsString, error))
+      case Right(blobIds) => blobResolvers.resolve(blobIds.jmapBlobId, mailboxSession)
+        .flatMap(blob => SMono(tokenRepository.generate(toJavaAccountId(accountId), blobIds.blobStoreBlobId))
+          .doFinally(_ => closeBlobContentAsync(blob)))
+        .map(token => UnauthenticatedBlobAccessCreationSuccess(blobIdAsString, UnauthenticatedBlobAccessCreationResponse(token.value().toString)): UnauthenticatedBlobAccessCreationResult)
+        .onErrorResume(error => SMono.just(UnauthenticatedBlobAccessCreationFailure(blobIdAsString, asSetError(error))))
+    }
+
+  private def validateCreateEntry(blobIdAsString: String, createValue: JsValue): Either[SetError, BlobIds] =
+    validateCreateValue(createValue)
+      .flatMap(_ => parseBlobIds(blobIdAsString))
+
+  private def validateCreateValue(createValue: JsValue): Either[SetError, Unit] =
+    createValue match {
+      case jsObject: JsObject if jsObject.value.isEmpty => Right(())
+      case _: JsObject => Left(SetError.invalidArguments(SetErrorDescription("create value must be an empty object")))
+      case _ => Left(SetError.invalidArguments(SetErrorDescription("create value must be an empty object")))
+    }
+
+  private def parseBlobIds(blobIdAsString: String): Either[SetError, BlobIds] =
+    (for {
+      jmapBlobId <- JmapBlobId.of(blobIdAsString)
+      blobStoreBlobId <- Try(blobIdFactory.parse(blobIdAsString))
+    } yield BlobIds(jmapBlobId, blobStoreBlobId)) match {
+      case Success(blobIds) => Right(blobIds)
+      case Failure(e) => Left(SetError.invalidArguments(SetErrorDescription(e.getMessage)))
+    }
+
+  private def toJavaAccountId(accountId: AccountId): JavaAccountId =
+    JavaAccountId.fromString(accountId.id.value)
+
+  private def closeBlobContentAsync(blob: Blob): Unit =
+    SMono.fromCallable(() => blob.content.close())
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
+      .onErrorResume(e => {
+        LOGGER.warn("Failed to close resolved blob content", e)
+        SMono.empty[Unit]
+      })
+      .subscribe()
+
+  private def asSetError(error: Throwable): SetError =
+    error match {
+      case e: BlobNotFoundException =>
+        LOGGER.info("Could not generate unauthenticated blob access token as blob {} is not found", e.blobId)
+        SetError.notFound(SetErrorDescription(s"Blob ${e.blobId} could not be found"))
+      case e: IllegalArgumentException => SetError.invalidArguments(SetErrorDescription(e.getMessage))
+      case e =>
+        LOGGER.error("Failed to generate unauthenticated blob access token", e)
+        SetError.serverFail(SetErrorDescription(e.getMessage))
+    }
+
+  private case class BlobIds(jmapBlobId: JmapBlobId, blobStoreBlobId: BlobStoreBlobId)
+}
+
+sealed trait UnauthenticatedBlobAccessCreationResult
+
+case class UnauthenticatedBlobAccessCreationSuccess(blobId: String,
+                                                    response: UnauthenticatedBlobAccessCreationResponse) extends UnauthenticatedBlobAccessCreationResult
+
+case class UnauthenticatedBlobAccessCreationFailure(blobId: String,
+                                                    error: SetError) extends UnauthenticatedBlobAccessCreationResult
+
+case class UnauthenticatedBlobAccessCreationResults(results: Seq[UnauthenticatedBlobAccessCreationResult]) {
+  def created: Map[String, UnauthenticatedBlobAccessCreationResponse] =
+    results.flatMap {
+      case success: UnauthenticatedBlobAccessCreationSuccess => Some(success.blobId -> success.response)
+      case _ => None
+    }.toMap
+
+  def notCreated: Map[String, SetError] =
+    results.flatMap {
+      case failure: UnauthenticatedBlobAccessCreationFailure => Some(failure.blobId -> failure.error)
+      case _ => None
+    }.toMap
+}

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
@@ -32,7 +32,7 @@ import org.apache.james.jmap.core.SetError.SetErrorDescription
 import org.apache.james.jmap.core.{AccountId, Invocation, JmapRfc8621Configuration, SessionTranslator, SetError}
 import org.apache.james.jmap.mail.{BlobId => JmapBlobId}
 import org.apache.james.jmap.method.{InvocationWithContext, MethodRequiringAccountId}
-import org.apache.james.jmap.routes.{Blob, BlobNotFoundException, BlobResolvers, SessionSupplier}
+import org.apache.james.jmap.routes.{BlobNotFoundException, BlobResolvers, SessionSupplier}
 import org.apache.james.mailbox.MailboxSession
 import org.apache.james.metrics.api.MetricFactory
 import org.apache.james.util.ReactorUtils
@@ -112,9 +112,11 @@ class UnauthenticatedBlobAccessSetCreatePerformer @Inject()(val tokenRepository:
                      createValue: JsValue): SMono[UnauthenticatedBlobAccessCreationResult] =
     validateCreateEntry(blobIdAsString, createValue) match {
       case Left(error) => SMono.just(UnauthenticatedBlobAccessCreationFailure(blobIdAsString, error))
-      case Right(blobIds) => blobResolvers.resolve(blobIds.jmapBlobId, mailboxSession)
-        .flatMap(blob => SMono(tokenRepository.generate(toJavaAccountId(accountId), blobIds.blobStoreBlobId))
-          .doFinally(_ => closeBlobContentAsync(blob)))
+      case Right(blobIds) => blobResolvers.validateAccess(blobIds.jmapBlobId, mailboxSession)
+        .flatMap {
+          case hasAccess if hasAccess.booleanValue() => SMono(tokenRepository.generate(toJavaAccountId(accountId), blobIds.blobStoreBlobId))
+          case _ => SMono.error(BlobNotFoundException(blobIds.jmapBlobId))
+        }
         .map(token => UnauthenticatedBlobAccessCreationSuccess(blobIdAsString, UnauthenticatedBlobAccessCreationResponse(token.value().toString)): UnauthenticatedBlobAccessCreationResult)
         .onErrorResume(error => SMono.just(UnauthenticatedBlobAccessCreationFailure(blobIdAsString, asSetError(error))))
     }
@@ -141,15 +143,6 @@ class UnauthenticatedBlobAccessSetCreatePerformer @Inject()(val tokenRepository:
 
   private def toJavaAccountId(accountId: AccountId): JavaAccountId =
     JavaAccountId.fromString(accountId.id.value)
-
-  private def closeBlobContentAsync(blob: Blob): Unit =
-    SMono.fromCallable(() => blob.content.close())
-      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
-      .onErrorResume(e => {
-        LOGGER.warn("Failed to close resolved blob content", e)
-        SMono.empty[Unit]
-      })
-      .subscribe()
 
   private def asSetError(error: Throwable): SetError =
     error match {

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/model/UnauthenticatedBlobAccess.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/model/UnauthenticatedBlobAccess.scala
@@ -1,0 +1,41 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.model
+
+import org.apache.james.jmap.core.{AccountId, SetError}
+import org.apache.james.jmap.method.{SetRequest, WithAccountId}
+import play.api.libs.json.JsValue
+
+case class UnauthenticatedBlobAccessSetRequest(accountId: AccountId,
+                                               create: Option[Map[String, JsValue]],
+                                               update: Option[Map[String, JsValue]],
+                                               destroy: Option[Seq[String]]) extends WithAccountId with SetRequest {
+  override def idCount: Int =
+    create.fold(0)(_.size) +
+      update.fold(0)(_.size) +
+      destroy.fold(0)(_.size)
+}
+
+case class UnauthenticatedBlobAccessCreationResponse(token: String)
+
+case class UnauthenticatedBlobAccessSetResponse(accountId: AccountId,
+                                                created: Option[Map[String, UnauthenticatedBlobAccessCreationResponse]],
+                                                notCreated: Option[Map[String, SetError]],
+                                                notUpdated: Option[Map[String, SetError]],
+                                                notDestroyed: Option[Map[String, SetError]])

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/perfs/TMailCleverBlobResolver.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/perfs/TMailCleverBlobResolver.scala
@@ -18,6 +18,8 @@
 
 package com.linagora.tmail.james.jmap.perfs
 
+import java.lang.Boolean.TRUE
+
 import jakarta.inject.Inject
 import org.apache.james.jmap.mail.BlobId
 import org.apache.james.jmap.routes.{AttachmentBlobResolver, BlobResolutionResult, BlobResolver, MessagePartBlobResolver, NonApplicable}
@@ -31,4 +33,14 @@ class TMailCleverBlobResolver @Inject() (messagePartBlobResolver: MessagePartBlo
       case NonApplicable => messagePartBlobResolver.resolve(blobId, mailboxSession)
       case any => SMono.just(any)
     }
+
+  override def validateAccess(blobId: BlobId, mailboxSession: MailboxSession): SMono[java.lang.Boolean] =
+    attachmentBlobResolver.validateAccess(blobId, mailboxSession)
+      .flatMap { hasAccess =>
+        if (hasAccess.booleanValue()) {
+          SMono.just(TRUE)
+        } else {
+          messagePartBlobResolver.validateAccess(blobId, mailboxSession)
+        }
+      }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CalDavCollectIntegrationTest.java
@@ -39,7 +39,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jmap.mail.BlobId;
+import org.apache.james.jmap.routes.BlobResolutionResult;
 import org.apache.james.jmap.routes.BlobResolver;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MultimailboxesSearchQuery;
 import org.apache.james.mailbox.model.SearchQuery;
@@ -63,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.reactivestreams.Publisher;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
@@ -256,7 +260,17 @@ public class CalDavCollectIntegrationTest {
 
                 @ProvidesIntoSet
                 public BlobResolver provideFakeBlobResolver() {
-                    return (blobId, mailboxSession) -> Mono.empty();
+                    return new BlobResolver() {
+                        @Override
+                        public Publisher<BlobResolutionResult> resolve(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.empty();
+                        }
+
+                        @Override
+                        public Publisher<Boolean> validateAccess(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.just(false);
+                        }
+                    };
                 }
             })
             .withOverrides(openPaasExtension.openpaasModule())

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CardDavCollectedContactIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/CardDavCollectedContactIntegrationTest.java
@@ -39,8 +39,11 @@ import jakarta.mail.MessagingException;
 import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.Username;
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.jmap.mail.BlobId;
+import org.apache.james.jmap.routes.BlobResolutionResult;
 import org.apache.james.jmap.routes.BlobResolver;
 import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -63,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.reactivestreams.Publisher;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -126,7 +130,17 @@ public class CardDavCollectedContactIntegrationTest {
 
                 @ProvidesIntoSet
                 public BlobResolver provideFakeBlobResolver() {
-                    return (blobId, mailboxSession) -> Mono.empty();
+                    return new BlobResolver() {
+                        @Override
+                        public Publisher<BlobResolutionResult> resolve(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.empty();
+                        }
+
+                        @Override
+                        public Publisher<Boolean> validateAccess(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.just(false);
+                        }
+                    };
                 }
             })
             .withMailetContainer(TemporaryJamesServer.defaultMailetContainerConfiguration()

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/RestrictiveCalDavCollectIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/RestrictiveCalDavCollectIntegrationTest.java
@@ -40,7 +40,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jmap.mail.BlobId;
+import org.apache.james.jmap.routes.BlobResolutionResult;
 import org.apache.james.jmap.routes.BlobResolver;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MultimailboxesSearchQuery;
 import org.apache.james.mailbox.model.SearchQuery;
@@ -64,12 +67,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.reactivestreams.Publisher;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.util.Modules;
@@ -188,7 +191,17 @@ public class RestrictiveCalDavCollectIntegrationTest {
 
                 @ProvidesIntoSet
                 public BlobResolver provideFakeBlobResolver() {
-                    return (blobId, mailboxSession) -> Mono.empty();
+                    return new BlobResolver() {
+                        @Override
+                        public Publisher<BlobResolutionResult> resolve(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.empty();
+                        }
+
+                        @Override
+                        public Publisher<Boolean> validateAccess(BlobId blobId, MailboxSession mailboxSession) {
+                            return Mono.just(false);
+                        }
+                    };
                 }
             })
             .withOverrides(openPaasExtension.openpaasModule())


### PR DESCRIPTION
resolve #2348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UnauthenticatedBlobAccess JMAP capability: sessions advertise a download endpoint and token TTL; clients can request short-lived download tokens with per-blob created/notCreated results.

* **Improvements**
  * Stricter blob access validation with resolver fallback to better authorize attachments and message parts.
  * Configurable unauthenticated-token storage choice (Redis, memory, or disabled) via configuration.

* **Tests**
  * New comprehensive integration tests (memory, distributed, Postgres) and shared contract covering creation, delegation, errors, mixed outcomes, limits, and token invalidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->