### PR TITLE
refactor(imap-delegation-ext): use new method names in James

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/imap-extensions/imapAuthDelegationExtension.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/imap-extensions/imapAuthDelegationExtension.adoc
@@ -38,12 +38,12 @@ a002 AUTHENTICATE PLAIN base64_encoded_string(minister@domain.tld\0secretary@dom
 
 The syntax will be:
 ```
-a002 AUTHENTICATE PLAIN base64_encoded_string([authorize-id+authenticate-id]\0password)
+a002 AUTHENTICATE PLAIN base64_encoded_string(\0[authentication_id+authorize_id]\0password)
 ```
 
 Example:
 ```
-a002 AUTHENTICATE PLAIN base64_encoded_string(secretary+minister@domain.tld\0secretary_password)
+a002 AUTHENTICATE PLAIN base64_encoded_string(\0secretary+minister@domain.tld\0secretary_password)
 ```
 
 == How to deploy this extension

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailAuthenticateProcessor.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailAuthenticateProcessor.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.Username;
-import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.request.ImapRequest;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapSession;
@@ -48,14 +47,13 @@ public class TMailAuthenticateProcessor extends AuthenticateProcessor {
     }
 
     @Override
-    protected void doPlainAuth(String initialClientResponse, ImapSession session, ImapRequest request, Responder responder) {
+    protected void parseAndDoPlainAuth(String initialClientResponse, ImapSession session, ImapRequest request, Responder responder) {
         AuthenticationAttempt authenticationAttempt = parseDelegationAttempt(initialClientResponse);
         if (authenticationAttempt.isDelegation()) {
-            doAuthWithDelegation(authenticationAttempt, session, request, responder);
+            doPasswordAuthWithDelegation(authenticationAttempt, session, request, responder);
         } else {
-            doAuth(authenticationAttempt, session, request, responder, HumanReadableText.AUTHENTICATION_FAILED);
+            doPasswordAuth(authenticationAttempt, session, request, responder);
         }
-        session.stopDetectingCommandInjection();
     }
 
     private AuthenticationAttempt parseDelegationAttempt(String initialClientResponse) {
@@ -80,10 +78,10 @@ public class TMailAuthenticateProcessor extends AuthenticateProcessor {
         if (!localPart.contains(DELEGATION_SPLIT_CHARACTER)) {
             return noDelegation(user, tokens.get(1));
         }
-        String authId = StringUtils.substringAfter(localPart, DELEGATION_SPLIT_CHARACTER);
-        String delegateId = StringUtils.substringBefore(localPart, DELEGATION_SPLIT_CHARACTER);
-        Username authUser = Username.of(authId).withDefaultDomain(user.getDomainPart());
-        Username delegateUser = Username.of(delegateId).withDefaultDomain(user.getDomainPart());
-        return delegation(authUser, delegateUser, tokens.get(1));
+        String authenticationId = StringUtils.substringBefore(localPart, DELEGATION_SPLIT_CHARACTER);
+        String authorizationId = StringUtils.substringAfter(localPart, DELEGATION_SPLIT_CHARACTER);
+        Username authenticationUser = Username.of(authenticationId).withDefaultDomain(user.getDomainPart());
+        Username authorizationUser = Username.of(authorizationId).withDefaultDomain(user.getDomainPart());
+        return delegation(authorizationUser, authenticationUser, tokens.get(1));
     }
 }

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailLoginProcessor.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailLoginProcessor.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.imap;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.Username;
@@ -30,12 +31,14 @@ import org.apache.james.imap.message.request.LoginRequest;
 import org.apache.james.imap.processor.LoginProcessor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.metrics.api.MetricFactory;
-import org.apache.james.util.MDCBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 
 public class TMailLoginProcessor extends LoginProcessor {
     private static final String DELEGATION_SPLIT_CHARACTER = "+";
+    private static final Logger LOGGER = LoggerFactory.getLogger(TMailLoginProcessor.class);
 
     @Inject
     public TMailLoginProcessor(MailboxManager mailboxManager, StatusResponseFactory factory,
@@ -45,29 +48,34 @@ public class TMailLoginProcessor extends LoginProcessor {
 
     @Override
     protected void processRequest(LoginRequest request, ImapSession session, Responder responder) {
+        if (session.isPlainAuthDisallowed()) {
+            LOGGER.warn("Login rejected because it is disabled or not allowed over insecure channel");
+            no(request, responder, HumanReadableText.DISABLED_LOGIN);
+            return;
+        }
+
         Username requestUserid = request.getUserid();
+        String requestPassword = request.getPassword();
         String localPart = requestUserid.getLocalPart();
         if (!localPart.contains(DELEGATION_SPLIT_CHARACTER)) {
-            super.processRequest(request, session, responder);
+            doPasswordAuth(noDelegation(requestUserid, requestPassword), session, request, responder);
         } else {
-            String delegatedUser = StringUtils.substringBefore(localPart, DELEGATION_SPLIT_CHARACTER);
-            String ownerUser = StringUtils.substringAfter(localPart, DELEGATION_SPLIT_CHARACTER);
+            String authenticationId = StringUtils.substringBefore(localPart, DELEGATION_SPLIT_CHARACTER);
+            String authorizationId = StringUtils.substringAfter(localPart, DELEGATION_SPLIT_CHARACTER);
 
-            if (StringUtils.isAnyEmpty(delegatedUser, ownerUser)) {
-                no(request, responder, HumanReadableText.INVALID_LOGIN);
-                return;
+            if (StringUtils.isAnyEmpty(authenticationId, authorizationId)) {
+                authFailure(session, request, responder, HumanReadableText.INVALID_CREDENTIALS,
+                    Optional.of(authenticationId).filter(Predicate.not(String::isEmpty)).map(Username::of),
+                    Optional.of(authorizationId).filter(Predicate.not(String::isEmpty)).map(Username::of),
+                    "Malformed authentication command."
+                 );
+            } else {
+                Username authenticationUser = Username.of(authenticationId).withDefaultDomain(requestUserid.getDomainPart());
+                Username authorizationUser = Username.of(authorizationId).withDefaultDomain(requestUserid.getDomainPart());
+
+                AuthenticationAttempt authenticationAttempt = new AuthenticationAttempt(Optional.of(authorizationUser), authenticationUser, requestPassword);
+                doPasswordAuthWithDelegation(authenticationAttempt, session, request, responder);
             }
-
-            Username authenticationId = Username.of(delegatedUser).withDefaultDomain(requestUserid.getDomainPart());
-            Username delegateUsername = Username.of(ownerUser).withDefaultDomain(requestUserid.getDomainPart());
-
-            AuthenticationAttempt authenticationAttempt = new AuthenticationAttempt(Optional.of(delegateUsername), authenticationId, request.getPassword());
-            doAuthWithDelegation(authenticationAttempt, session, request, responder);
         }
-    }
-
-    @Override
-    protected MDCBuilder mdc(LoginRequest request) {
-        return super.mdc(request);
     }
 }


### PR DESCRIPTION
This adapts the IMAP Auth Delegation extension to the changes in the IMAP authentication logic introduced in https://github.com/apache/james-project/pull/3044.
It also changes the [documentation](https://github.com/linagora/tmail-backend/blob/master/docs/modules/ROOT/pages/tmail-backend/imap-extensions/imapAuthDelegationExtension.adoc) to match the actual code and be consistent between AUTH PLAIN and LOGIN.

The following changes for the IMAP LOGIN command:

- Now honors if plain authentication is disabled.
- Use authentication (user that authenticated) / authorization (user whose identity is assumed by the authenticated user) in variable names to be closer to the docs / the SASL RFC.

The following changes for AUTH PLAIN:

- Use authentication (user that authenticated) / authorization (user whose identity is assumed by the authenticated user) in variable names to be closer to the docs / the SASL RFC.

EDIT: The following is outdated.

I generally find it confusing that the correct syntax (according to the documentation) is `authentication_id+authorize_id` for LOGIN and `authorize-id+authenticate-id` for AUTH PLAIN.
If that is something that can still change, I would advise to use the syntax `<authorization-id>+<authentication-id>`. The order would match the one used by SASL PLAIN (RFC 4616). Additionally, the `+` character is already used for plus email addressing (or subaddressing), so that might collide.