### PR TITLE
ISSUE-2349 UnauthenticatedBlobDownloadTokenRepository should return Username upon `check` API

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
@@ -19,8 +19,8 @@
 package com.linagora.tmail.james.common
 
 import java.nio.charset.StandardCharsets
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
+import java.util.{Optional, UUID}
 
 import com.google.common.hash.Hashing
 import com.google.inject.AbstractModule
@@ -65,9 +65,12 @@ object UnauthenticatedBlobAccessSetMethodContract {
 class UnauthenticatedBlobAccessTokenRepositoryProbe @Inject()(repository: UnauthenticatedBlobDownloadTokenRepository,
                                                               blobIdFactory: BlobId.Factory) extends GuiceProbe {
   def isValid(accountId: String, blobId: String, token: String): Boolean =
+    username(accountId, blobId, token)
+      .isPresent
+
+  def username(accountId: String, blobId: String, token: String): Optional[Username] =
     repository.check(JavaAccountId.fromString(accountId), blobIdFactory.parse(blobId), new UnauthenticatedBlobDownloadToken(UUID.fromString(token)))
       .block()
-      .isPresent
 }
 
 class UnauthenticatedBlobAccessTokenRepositoryProbeModule extends AbstractModule {
@@ -177,6 +180,7 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |    "c1"
            |]""".stripMargin)
     assertThat(tokenProbe(server).isValid(bobAccountId, blobId, token)).isTrue
+    assertThat(tokenProbe(server).username(bobAccountId, blobId, token)).contains(bobUsername)
   }
 
   @Test
@@ -421,6 +425,7 @@ trait UnauthenticatedBlobAccessSetMethodContract {
 
     // THEN the blob should be granted under Andre accountId, not bob accountId
     assertThat(tokenProbe(server).isValid(andreAccountId, andreBlobId, token)).isTrue
+    assertThat(tokenProbe(server).username(andreAccountId, andreBlobId, token)).contains(andreUsername)
     assertThat(tokenProbe(server).isValid(bobAccountId, andreBlobId, token)).isFalse
   }
 

--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
@@ -67,7 +67,7 @@ class UnauthenticatedBlobAccessTokenRepositoryProbe @Inject()(repository: Unauth
   def isValid(accountId: String, blobId: String, token: String): Boolean =
     repository.check(JavaAccountId.fromString(accountId), blobIdFactory.parse(blobId), new UnauthenticatedBlobDownloadToken(UUID.fromString(token)))
       .block()
-      .booleanValue()
+      .isPresent
 }
 
 class UnauthenticatedBlobAccessTokenRepositoryProbeModule extends AbstractModule {

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepository.java
@@ -21,10 +21,12 @@ package com.linagora.tmail.james.jmap.blob;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.james.blob.api.BlobId;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 
 import com.google.common.base.Preconditions;
@@ -35,7 +37,7 @@ public class MemoryUnauthenticatedBlobDownloadTokenRepository implements Unauthe
     private record TokenKey(AccountId accountId, BlobId blobId) {
     }
 
-    private record StoredToken(UnauthenticatedBlobDownloadToken token, Instant expiresAt) {
+    private record StoredToken(UnauthenticatedBlobDownloadToken token, Username username, Instant expiresAt) {
     }
 
     private final ConcurrentMap<TokenKey, StoredToken> store;
@@ -51,33 +53,35 @@ public class MemoryUnauthenticatedBlobDownloadTokenRepository implements Unauthe
     }
 
     @Override
-    public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId) {
+    public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId, Username username) {
         return Mono.fromCallable(() -> {
             UnauthenticatedBlobDownloadToken token = UnauthenticatedBlobDownloadToken.generate();
-            store.put(new TokenKey(accountId, blobId), new StoredToken(token, clock.instant().plus(tokenTtl)));
+            store.put(new TokenKey(accountId, blobId), new StoredToken(token, username, clock.instant().plus(tokenTtl)));
             return token;
         });
     }
 
     @Override
-    public Mono<Boolean> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token) {
+    public Mono<Optional<Username>> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token) {
         return Mono.fromCallable(() -> {
             TokenKey key = new TokenKey(accountId, blobId);
-            StoredToken storedToken = store.get(key);
-
-            if (storedToken == null) {
-                return false;
-            }
-            if (isExpired(storedToken)) {
-                store.remove(key, storedToken);
-                return false;
-            }
-            return storedToken.token().equals(token);
+            return Optional.ofNullable(store.get(key))
+                .filter(storedToken -> !isExpired(key, storedToken))
+                .filter(storedToken -> storedToken.token().equals(token))
+                .map(StoredToken::username);
         });
     }
 
     boolean isStored(AccountId accountId, BlobId blobId) {
         return store.containsKey(new TokenKey(accountId, blobId));
+    }
+
+    private boolean isExpired(TokenKey key, StoredToken storedToken) {
+        if (isExpired(storedToken)) {
+            store.remove(key, storedToken);
+            return true;
+        }
+        return false;
     }
 
     private boolean isExpired(StoredToken storedToken) {

--- a/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-api/src/main/java/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadTokenRepository.java
@@ -18,13 +18,16 @@
 
 package com.linagora.tmail.james.jmap.blob;
 
+import java.util.Optional;
+
 import org.apache.james.blob.api.BlobId;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 
 import reactor.core.publisher.Mono;
 
 public interface UnauthenticatedBlobDownloadTokenRepository {
-    Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId);
+    Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId, Username username);
 
-    Mono<Boolean> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token);
+    Mono<Optional<Username>> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token);
 }

--- a/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepositoryTest.scala
+++ b/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/blob/MemoryUnauthenticatedBlobDownloadTokenRepositoryTest.scala
@@ -20,7 +20,7 @@ package com.linagora.tmail.james.jmap.blob
 
 import java.time.{Duration, Instant}
 
-import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobDownloadTokenRepositoryContract.{ACCOUNT_ID, BLOB_ID}
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobDownloadTokenRepositoryContract.{ACCOUNT_ID, BLOB_ID, USERNAME}
 import org.apache.james.utils.UpdatableTickingClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, Test}
@@ -42,7 +42,7 @@ class MemoryUnauthenticatedBlobDownloadTokenRepositoryTest extends Unauthenticat
 
   @Test
   def expiredTokenShouldBeRemovedLazily(): Unit = {
-    val token = repository.generate(ACCOUNT_ID, BLOB_ID).block()
+    val token = repository.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     advanceClockAfterTtl()
     repository.check(ACCOUNT_ID, BLOB_ID, token).block()

--- a/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadTokenRepositoryContract.scala
+++ b/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobDownloadTokenRepositoryContract.scala
@@ -20,8 +20,9 @@ package com.linagora.tmail.james.jmap.blob
 
 import java.util.UUID
 
-import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobDownloadTokenRepositoryContract.{ACCOUNT_ID, ACCOUNT_ID_2, BLOB_ID, BLOB_ID_2, RANDOM_TOKEN}
+import com.linagora.tmail.james.jmap.blob.UnauthenticatedBlobDownloadTokenRepositoryContract.{ACCOUNT_ID, ACCOUNT_ID_2, BLOB_ID, BLOB_ID_2, RANDOM_TOKEN, USERNAME, USERNAME_2}
 import org.apache.james.blob.api.PlainBlobId
+import org.apache.james.core.Username
 import org.apache.james.jmap.api.model.AccountId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -31,6 +32,8 @@ object UnauthenticatedBlobDownloadTokenRepositoryContract {
   val ACCOUNT_ID_2: AccountId = AccountId.fromString("accountId2")
   val BLOB_ID: PlainBlobId = new PlainBlobId.Factory().parse("blobId")
   val BLOB_ID_2: PlainBlobId = new PlainBlobId.Factory().parse("blobId2")
+  val USERNAME: Username = Username.of("bob@domain.tld")
+  val USERNAME_2: Username = Username.of("alice@domain.tld")
   val RANDOM_TOKEN: UnauthenticatedBlobDownloadToken = new UnauthenticatedBlobDownloadToken(UUID.fromString("54b372bb-106c-46e3-a5f3-307eaf37b363"))
 }
 
@@ -39,92 +42,92 @@ trait UnauthenticatedBlobDownloadTokenRepositoryContract {
   def advanceClockAfterTtl(): Unit
 
   @Test
-  def unknownTokenShouldReturnFalse(): Unit =
+  def unknownTokenShouldReturnEmpty(): Unit =
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, RANDOM_TOKEN).block())
-      .isFalse
+      .isEmpty
 
   @Test
-  def generatedTokenShouldValidate(): Unit = {
-    val token = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+  def generatedTokenShouldReturnUsername(): Unit = {
+    val token = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, token).block())
-      .isTrue
+      .contains(USERNAME)
   }
 
   @Test
-  def wrongTokenShouldReturnFalse(): Unit = {
-    testee.generate(ACCOUNT_ID, BLOB_ID).block()
+  def wrongTokenShouldReturnEmpty(): Unit = {
+    testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, RANDOM_TOKEN).block())
-      .isFalse
+      .isEmpty
   }
 
   @Test
-  def correctTokenWithWrongAccountShouldReturnFalse(): Unit = {
-    val token = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+  def correctTokenWithWrongAccountShouldReturnEmpty(): Unit = {
+    val token = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID_2, BLOB_ID, token).block())
-      .isFalse
+      .isEmpty
   }
 
   @Test
-  def correctTokenWithWrongBlobShouldReturnFalse(): Unit = {
-    val token = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+  def correctTokenWithWrongBlobShouldReturnEmpty(): Unit = {
+    val token = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID_2, token).block())
-      .isFalse
+      .isEmpty
   }
 
   @Test
   def generatingANewTokenShouldInvalidatePreviousTokenForSameBlob(): Unit = {
-    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID).block()
-    val secondToken = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
+    val secondToken = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, firstToken).block())
-      .isFalse
+      .isEmpty
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, secondToken).block())
-      .isTrue
+      .contains(USERNAME)
   }
 
   @Test
   def tokensForDifferentBlobsShouldBeIndependent(): Unit = {
-    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID).block()
-    val secondToken = testee.generate(ACCOUNT_ID, BLOB_ID_2).block()
+    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
+    val secondToken = testee.generate(ACCOUNT_ID, BLOB_ID_2, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, firstToken).block())
-      .isTrue
+      .contains(USERNAME)
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID_2, secondToken).block())
-      .isTrue
+      .contains(USERNAME)
   }
 
   @Test
   def tokensForDifferentAccountsShouldBeIndependent(): Unit = {
-    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID).block()
-    val secondToken = testee.generate(ACCOUNT_ID_2, BLOB_ID).block()
+    val firstToken = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
+    val secondToken = testee.generate(ACCOUNT_ID_2, BLOB_ID, USERNAME_2).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, firstToken).block())
-      .isTrue
+      .contains(USERNAME)
     assertThat(testee.check(ACCOUNT_ID_2, BLOB_ID, secondToken).block())
-      .isTrue
+      .contains(USERNAME_2)
   }
 
   @Test
   def tokenShouldBeReusableDuringTtl(): Unit = {
-    val token = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+    val token = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, token).block())
-      .isTrue
+      .contains(USERNAME)
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, token).block())
-      .isTrue
+      .contains(USERNAME)
   }
 
   @Test
   def tokenShouldRejectAfterTtl(): Unit = {
-    val token = testee.generate(ACCOUNT_ID, BLOB_ID).block()
+    val token = testee.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block()
 
     advanceClockAfterTtl()
 
     assertThat(testee.check(ACCOUNT_ID, BLOB_ID, token).block())
-      .isFalse
+      .isEmpty
   }
 }

--- a/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
+++ b/tmail-backend/jmap/extensions-redis/src/main/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepository.java
@@ -20,10 +20,13 @@ package com.linagora.tmail.james.jmap.blob;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
 import org.apache.james.blob.api.BlobId;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +37,10 @@ import com.linagora.tmail.james.jmap.UnauthenticatedBlobAccessConfiguration;
 import reactor.core.publisher.Mono;
 
 public class RedisUnauthenticatedBlobDownloadTokenRepository implements UnauthenticatedBlobDownloadTokenRepository {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisUnauthenticatedBlobDownloadTokenRepository.class);
+    private static final String KEY_PREFIX = "tmail_unauthenticated_blob_access_blob_";
+    private static final String VALUE_DELIMITER = ":";
+
     public static String resolveKey(AccountId accountId, BlobId blobId) {
         return KEY_PREFIX + hash(accountId.getIdentifier()) + "_" + hash(blobId.asString());
     }
@@ -42,12 +49,30 @@ public class RedisUnauthenticatedBlobDownloadTokenRepository implements Unauthen
         return hash(token.value().toString());
     }
 
+    static String encodeUsername(Username username) {
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(username.asString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String formatValue(UnauthenticatedBlobDownloadToken token, Username username) {
+        return hashToken(token) + VALUE_DELIMITER + encodeUsername(username);
+    }
+
     private static String hash(String value) {
         return Hashing.sha512().hashString(value, StandardCharsets.UTF_8).toString();
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RedisUnauthenticatedBlobDownloadTokenRepository.class);
-    private static final String KEY_PREFIX = "tmail_unauthenticated_blob_access_blob_";
+    private static Optional<Username> parseUsername(String value) {
+        String[] parts = value.split(VALUE_DELIMITER, -1);
+        if (parts.length != 2) {
+            LOGGER.warn("Malformed unauthenticated blob download token stored value: {}", value);
+            return Optional.empty();
+        }
+
+        String username = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+        return Optional.of(Username.of(username));
+    }
 
     private final RedisUnauthenticatedBlobDownloadTokenRepositoryCommands redisCommands;
     private final Duration tokenTtl;
@@ -60,21 +85,21 @@ public class RedisUnauthenticatedBlobDownloadTokenRepository implements Unauthen
     }
 
     @Override
-    public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId) {
+    public Mono<UnauthenticatedBlobDownloadToken> generate(AccountId accountId, BlobId blobId, Username username) {
         return Mono.fromCallable(UnauthenticatedBlobDownloadToken::generate)
-            .flatMap(token -> redisCommands.set(resolveKey(accountId, blobId), hashToken(token), tokenTtl)
+            .flatMap(token -> redisCommands.set(resolveKey(accountId, blobId), formatValue(token, username), tokenTtl)
                 .thenReturn(token));
     }
 
     @Override
-    public Mono<Boolean> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token) {
+    public Mono<Optional<Username>> check(AccountId accountId, BlobId blobId, UnauthenticatedBlobDownloadToken token) {
         return redisCommands.get(resolveKey(accountId, blobId))
-            .map(storedTokenHash -> storedTokenHash
-                .map(hashToken(token)::equals)
-                .orElse(false))
+            .map(storedValue -> storedValue
+                .filter(value -> value.startsWith(hashToken(token) + VALUE_DELIMITER))
+                .flatMap(RedisUnauthenticatedBlobDownloadTokenRepository::parseUsername))
             .onErrorResume(error -> {
                 LOGGER.warn("Failed to validate unauthenticated blob download token for accountId={} blobId={}", accountId.getIdentifier(), blobId.asString(), error);
-                return Mono.just(false);
+                return Mono.just(Optional.empty());
             });
     }
 }

--- a/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
+++ b/tmail-backend/jmap/extensions-redis/src/test/java/com/linagora/tmail/james/jmap/blob/RedisUnauthenticatedBlobDownloadTokenRepositoryContract.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import org.apache.james.backends.redis.RedisClientFactory;
 import org.apache.james.backends.redis.RedisConfiguration;
 import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import com.linagora.tmail.james.jmap.redis.RedisReactiveCommandsFactory;
 public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract implements UnauthenticatedBlobDownloadTokenRepositoryContract {
     protected static final AccountId ACCOUNT_ID = AccountId.fromString("accountId");
     protected static final PlainBlobId BLOB_ID = new PlainBlobId.Factory().parse("blobId");
+    protected static final Username USERNAME = Username.of("bob@domain.tld");
 
     private static final Duration TOKEN_TTL = Duration.ofSeconds(1);
 
@@ -71,25 +73,35 @@ public abstract class RedisUnauthenticatedBlobDownloadTokenRepositoryContract im
     }
 
     @Test
-    public void generateShouldStoreHashedTokenWithTtl() {
-        UnauthenticatedBlobDownloadToken token = repository.generate(ACCOUNT_ID, BLOB_ID).block();
+    public void generateShouldStoreHashedTokenAndEncodedUsernameWithTtl() {
+        UnauthenticatedBlobDownloadToken token = repository.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block();
         String redisKey = RedisUnauthenticatedBlobDownloadTokenRepository.resolveKey(ACCOUNT_ID, BLOB_ID);
 
-        String storedTokenHash = redisCommands.get(redisKey).block().orElseThrow();
+        String storedValue = redisCommands.get(redisKey).block().orElseThrow();
 
-        assertThat(storedTokenHash)
-            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.hashToken(token));
+        assertThat(storedValue)
+            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.formatValue(token, USERNAME));
         assertThat(redisCommands.ttl(redisKey).block())
             .isPositive();
     }
 
     @Test
     public void generateShouldOverwriteStoredHashForSameBlob() {
-        repository.generate(ACCOUNT_ID, BLOB_ID).block();
-        UnauthenticatedBlobDownloadToken secondToken = repository.generate(ACCOUNT_ID, BLOB_ID).block();
+        repository.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block();
+        UnauthenticatedBlobDownloadToken secondToken = repository.generate(ACCOUNT_ID, BLOB_ID, USERNAME).block();
         String redisKey = RedisUnauthenticatedBlobDownloadTokenRepository.resolveKey(ACCOUNT_ID, BLOB_ID);
 
         assertThat(redisCommands.get(redisKey).block().orElseThrow())
-            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.hashToken(secondToken));
+            .isEqualTo(RedisUnauthenticatedBlobDownloadTokenRepository.formatValue(secondToken, USERNAME));
+    }
+
+    @Test
+    public void checkShouldReturnEmptyWhenStoredUsernameIsMalformed() {
+        UnauthenticatedBlobDownloadToken token = UnauthenticatedBlobDownloadToken.generate();
+        String redisKey = RedisUnauthenticatedBlobDownloadTokenRepository.resolveKey(ACCOUNT_ID, BLOB_ID);
+        redisCommands.set(redisKey, RedisUnauthenticatedBlobDownloadTokenRepository.hashToken(token) + ":not valid base64", TOKEN_TTL).block();
+
+        assertThat(repository.check(ACCOUNT_ID, BLOB_ID, token).block())
+            .isEmpty();
     }
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/method/UnauthenticatedBlobAccessSetMethod.scala
@@ -114,7 +114,7 @@ class UnauthenticatedBlobAccessSetCreatePerformer @Inject()(val tokenRepository:
       case Left(error) => SMono.just(UnauthenticatedBlobAccessCreationFailure(blobIdAsString, error))
       case Right(blobIds) => blobResolvers.validateAccess(blobIds.jmapBlobId, mailboxSession)
         .flatMap {
-          case hasAccess if hasAccess.booleanValue() => SMono(tokenRepository.generate(toJavaAccountId(accountId), blobIds.blobStoreBlobId))
+          case hasAccess if hasAccess.booleanValue() => SMono(tokenRepository.generate(toJavaAccountId(accountId), blobIds.blobStoreBlobId, mailboxSession.getUser))
           case _ => SMono.error(BlobNotFoundException(blobIds.jmapBlobId))
         }
         .map(token => UnauthenticatedBlobAccessCreationSuccess(blobIdAsString, UnauthenticatedBlobAccessCreationResponse(token.value().toString)): UnauthenticatedBlobAccessCreationResult)


### PR DESCRIPTION
We need `MailboxSession` to use `BlobResolver`.

However, given that the unauthenticated download route only has `AccountId`, it is impossible to resolve the `Username`.
Upon generating a token, we should store the corresponding `Username` to the `AccountId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration and unit tests for unauthenticated blob token validation to verify username associations and delegated access scenarios.

* **Refactor**
  * Updated blob token validation to return username information instead of boolean validity checks, with implementations updated across all storage backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-backend/pull/2421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->