### PR TITLE
ISSUE-2349 Implement UnauthenticatedBlobAccessDownloadRoutes

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/UnauthenticatedBlobAccessSetMethodContract.scala
@@ -32,7 +32,7 @@ import io.restassured.http.ContentType.JSON
 import io.restassured.specification.RequestSpecification
 import jakarta.inject.Inject
 import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
-import org.apache.http.HttpStatus.{SC_CREATED, SC_OK}
+import org.apache.http.HttpStatus.{SC_CREATED, SC_OK, SC_UNAUTHORIZED}
 import org.apache.james.GuiceJamesServer
 import org.apache.james.blob.api.BlobId
 import org.apache.james.core.Username
@@ -48,6 +48,7 @@ import org.apache.james.modules.MailboxProbeImpl
 import org.apache.james.util.ClassLoaderUtils
 import org.apache.james.utils.{DataProbeImpl, GuiceProbe}
 import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.{containsString, equalTo}
 import org.junit.jupiter.api.{BeforeEach, Tag, Test}
 import play.api.libs.json.{JsObject, Json}
 
@@ -160,7 +161,8 @@ trait UnauthenticatedBlobAccessSetMethodContract {
 
   @Test
   def shouldGrantAccessForUploadBlob(server: GuiceJamesServer): Unit = {
-    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val content: String = UUID.randomUUID().toString
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId, content = content)
     val response: String = createAccess(server, bobAccountId, blobId)
     val token: String = createdToken(response, blobId)
 
@@ -181,6 +183,17 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |]""".stripMargin)
     assertThat(tokenProbe(server).isValid(bobAccountId, blobId, token)).isTrue
     assertThat(tokenProbe(server).username(bobAccountId, blobId, token)).contains(bobUsername)
+
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(s"/unauthenticatedDownload/$bobAccountId/$blobId?token=$token")
+    .`then`()
+      .statusCode(SC_OK)
+      .header("content-type", containsString("text/plain"))
+      .header("cache-control", equalTo("private, immutable, max-age=31536000"))
+      .body(equalTo(content))
   }
 
   @Test
@@ -198,6 +211,17 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |    }
            |}""".stripMargin)
     assertThat(tokenProbe(server).isValid(bobAccountId, messageBlobId, token)).isTrue
+
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(s"/unauthenticatedDownload/$bobAccountId/$messageBlobId?token=$token")
+    .`then`()
+      .statusCode(SC_OK)
+      .header("content-type", containsString("message/rfc822"))
+      .header("cache-control", equalTo("private, immutable, max-age=31536000"))
+      .body(containsString("Subject: subject"))
   }
 
   @Test
@@ -235,6 +259,17 @@ trait UnauthenticatedBlobAccessSetMethodContract {
            |    }
            |}""".stripMargin)
     assertThat(tokenProbe(server).isValid(bobAccountId, attachmentBlobId, token)).isTrue
+
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(s"/unauthenticatedDownload/$bobAccountId/$attachmentBlobId?token=$token")
+    .`then`()
+      .statusCode(SC_OK)
+      .header("content-type", containsString("text/plain"))
+      .header("cache-control", equalTo("private, immutable, max-age=31536000"))
+      .body(equalTo("This is a beautiful banana.\n"))
   }
 
   @Test
@@ -427,6 +462,19 @@ trait UnauthenticatedBlobAccessSetMethodContract {
     assertThat(tokenProbe(server).isValid(andreAccountId, andreBlobId, token)).isTrue
     assertThat(tokenProbe(server).username(andreAccountId, andreBlobId, token)).contains(andreUsername)
     assertThat(tokenProbe(server).isValid(bobAccountId, andreBlobId, token)).isFalse
+
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(s"/unauthenticatedDownload/$andreAccountId/$andreBlobId?token=$token")
+    .`then`()
+      .statusCode(SC_OK)
+      .header("content-type", containsString("message/rfc822"))
+      .header("cache-control", equalTo("private, immutable, max-age=31536000"))
+      .body(containsString("Subject: subject"))
+
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = andreBlobId, token = Some(token))
   }
 
   @Test
@@ -508,6 +556,47 @@ trait UnauthenticatedBlobAccessSetMethodContract {
     assertThat(firstToken).isNotEqualTo(secondToken)
     assertThat(tokenProbe(server).isValid(bobAccountId, blobId, firstToken)).isFalse
     assertThat(tokenProbe(server).isValid(bobAccountId, blobId, secondToken)).isTrue
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = blobId, token = Some(firstToken))
+
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(s"/unauthenticatedDownload/$bobAccountId/$blobId?token=$secondToken")
+    .`then`()
+      .statusCode(SC_OK)
+      .header("content-type", containsString("text/plain"))
+      .header("cache-control", equalTo("private, immutable, max-age=31536000"))
+  }
+
+  @Test
+  def downloadWithoutTokenShouldReturnUnauthorized(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = blobId, token = None)
+  }
+
+  @Test
+  def downloadWithInvalidTokenShouldReturnUnauthorized(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = blobId, token = Some("not-a-uuid"))
+  }
+
+  @Test
+  def downloadExistingBlobWithUnknownTokenShouldReturnUnauthorized(server: GuiceJamesServer): Unit = {
+    val blobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = blobId, token = Some(UUID.randomUUID().toString))
+  }
+
+  @Test
+  def downloadWithTokenForAnotherBlobShouldReturnUnauthorized(server: GuiceJamesServer): Unit = {
+    val firstBlobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val secondBlobId: String = uploadBlob(server, bobUsername, BOB_PASSWORD, bobAccountId)
+    val firstBlobToken: String = createdToken(createAccess(server, bobAccountId, firstBlobId), firstBlobId)
+
+    assertUnauthorizedDownload(accountId = bobAccountId, blobId = secondBlobId, token = Some(firstBlobToken))
   }
 
   @Test
@@ -679,11 +768,12 @@ trait UnauthenticatedBlobAccessSetMethodContract {
                          username: Username,
                          password: String,
                          accountId: String,
-                         contentType: String = "text/plain"): String =
+                         contentType: String = "text/plain",
+                         content: String = UUID.randomUUID().toString): String =
     `given`(authenticatedSpec(server, username, password))
       .basePath("")
       .contentType(contentType)
-      .body(UUID.randomUUID().toString)
+      .body(content)
     .when()
       .post(s"/upload/$accountId")
     .`then`()
@@ -805,6 +895,17 @@ trait UnauthenticatedBlobAccessSetMethodContract {
 
   private def createdToken(response: String, blobId: String): String =
     (firstArguments(response) \ "created" \ blobId \ "token").as[String]
+
+  private def assertUnauthorizedDownload(accountId: String, blobId: String, token: Option[String]): Unit =
+    `given`()
+      .basePath("")
+      .auth().none()
+    .when()
+      .get(token
+        .map(value => s"/unauthenticatedDownload/$accountId/$blobId?token=$value")
+        .getOrElse(s"/unauthenticatedDownload/$accountId/$blobId"))
+    .`then`()
+      .statusCode(SC_UNAUTHORIZED)
 
   private def tokenProbe(server: GuiceJamesServer): UnauthenticatedBlobAccessTokenRepositoryProbe =
     server.getProbe(classOf[UnauthenticatedBlobAccessTokenRepositoryProbe])

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobAccessJmapModule.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/blob/UnauthenticatedBlobAccessJmapModule.scala
@@ -21,6 +21,8 @@ package com.linagora.tmail.james.jmap.blob
 import com.google.inject.AbstractModule
 import com.google.inject.multibindings.Multibinder
 import com.linagora.tmail.james.jmap.method.{UnauthenticatedBlobAccessCapabilityFactory, UnauthenticatedBlobAccessSetMethod}
+import com.linagora.tmail.james.jmap.routes.UnauthenticatedBlobAccessDownloadRoutes
+import org.apache.james.jmap.JMAPRoutes
 import org.apache.james.jmap.core.CapabilityFactory
 import org.apache.james.jmap.method.Method
 
@@ -33,5 +35,9 @@ class UnauthenticatedBlobAccessJmapModule extends AbstractModule {
     Multibinder.newSetBinder(binder(), classOf[Method])
       .addBinding()
       .to(classOf[UnauthenticatedBlobAccessSetMethod])
+
+    Multibinder.newSetBinder(binder(), classOf[JMAPRoutes])
+      .addBinding()
+      .to(classOf[UnauthenticatedBlobAccessDownloadRoutes])
   }
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
@@ -54,7 +54,7 @@ import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object UnauthenticatedBlobAccessDownloadRoutes {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnauthenticatedBlobAccessDownloadRoutes])
@@ -106,7 +106,7 @@ class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: Una
             Option(request.param(accountIdParam)).getOrElse(""),
             Option(request.param(blobIdParam)).getOrElse(""),
             e)
-          respondDetails(response, ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = e.getMessage))
+          respondDetails(response, ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = "Internal server error"))
       }
       .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
       .asJava()
@@ -123,18 +123,20 @@ class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: Una
       }
 
   private def parseRequest(request: HttpServerRequest): (JavaAccountId, BlobStoreBlobId, JmapBlobId, UnauthenticatedBlobDownloadToken) = {
-    val accountId: AccountId = Id.validate(request.param(accountIdParam))
-      .fold(_ => throw InvalidUnauthenticatedBlobAccessTokenException(), id => AccountId(id))
-    val blobIdAsString: String = request.param(blobIdParam)
-    val blobStoreBlobId: BlobStoreBlobId = Try(blobIdFactory.parse(blobIdAsString))
-      .getOrElse(throw InvalidUnauthenticatedBlobAccessTokenException())
-    val jmapBlobId: JmapBlobId = JmapBlobId.of(blobIdAsString)
-      .fold(_ => throw InvalidUnauthenticatedBlobAccessTokenException(), blobId => blobId)
-    val token: UnauthenticatedBlobDownloadToken = queryParam(request, tokenParam)
-      .flatMap(value => Try(new UnauthenticatedBlobDownloadToken(UUID.fromString(value))).toOption)
-      .getOrElse(throw InvalidUnauthenticatedBlobAccessTokenException())
+    val parsedRequest: Try[(JavaAccountId, BlobStoreBlobId, JmapBlobId, UnauthenticatedBlobDownloadToken)] = for {
+      accountId <- Id.validate(request.param(accountIdParam))
+        .fold(_ => Failure(InvalidUnauthenticatedBlobAccessTokenException()), id => Success(AccountId(id)))
+      blobIdAsString = request.param(blobIdParam)
+      blobStoreBlobId <- Try(blobIdFactory.parse(blobIdAsString))
+      jmapBlobId <- JmapBlobId.of(blobIdAsString)
+        .fold(_ => Failure(InvalidUnauthenticatedBlobAccessTokenException()), blobId => Success(blobId))
+      token <- queryParam(request, tokenParam)
+        .map(value => Try(new UnauthenticatedBlobDownloadToken(UUID.fromString(value))))
+        .getOrElse(Failure(InvalidUnauthenticatedBlobAccessTokenException()))
+    } yield (JavaAccountId.fromString(accountId.id.value), blobStoreBlobId, jmapBlobId, token)
 
-    (JavaAccountId.fromString(accountId.id.value), blobStoreBlobId, jmapBlobId, token)
+    parsedRequest
+      .getOrElse(throw InvalidUnauthenticatedBlobAccessTokenException())
   }
 
   private def resolveSession(username: Username): SMono[MailboxSession] =
@@ -159,9 +161,9 @@ class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: Una
       .`then`
   }
 
-  private def sanitizeHeaderValue(s: String): String =
-    if (HttpHeaderValidationUtil.validateValidHeaderValue(s) == -1) {
-      s
+  private def sanitizeHeaderValue(value: String): String =
+    if (HttpHeaderValidationUtil.validateValidHeaderValue(value) == -1) {
+      value
     } else {
       "application/octet-stream"
     }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
@@ -1,0 +1,193 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.routes
+
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Callable
+import java.util.function.Consumer
+import java.util.stream.Stream
+import java.util.{UUID, stream}
+
+import com.linagora.tmail.james.jmap.blob.{UnauthenticatedBlobDownloadToken, UnauthenticatedBlobDownloadTokenRepository}
+import io.netty.buffer.Unpooled
+import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
+import io.netty.handler.codec.http.HttpResponseStatus.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK, UNAUTHORIZED}
+import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValidationUtil, HttpMethod, QueryStringDecoder}
+import jakarta.inject.Inject
+import org.apache.james.blob.api.{BlobId => BlobStoreBlobId}
+import org.apache.james.core.Username
+import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
+import org.apache.james.jmap.api.model.Size.Size
+import org.apache.james.jmap.api.model.{AccountId => JavaAccountId}
+import org.apache.james.jmap.core.{AccountId, Id, ProblemDetails}
+import org.apache.james.jmap.json.ResponseSerializer
+import org.apache.james.jmap.mail.{BlobId => JmapBlobId}
+import org.apache.james.jmap.routes.DownloadRoutes.BUFFER_SIZE
+import org.apache.james.jmap.routes.{Blob, BlobNotFoundException, BlobResolvers}
+import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes}
+import org.apache.james.mailbox.{MailboxSession, SessionProvider}
+import org.apache.james.metrics.api.{Metric, MetricFactory}
+import org.apache.james.util.ReactorUtils
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.json.Json
+import reactor.core.publisher.Mono
+import reactor.core.scala.publisher.SMono
+import reactor.core.scheduler.Schedulers
+import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+import scala.util.Try
+
+object UnauthenticatedBlobAccessDownloadRoutes {
+  val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnauthenticatedBlobAccessDownloadRoutes])
+}
+
+case class InvalidUnauthenticatedBlobAccessTokenException() extends RuntimeException
+
+case class ValidatedUnauthenticatedBlobDownload(jmapBlobId: JmapBlobId,
+                                                username: Username)
+
+class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: UnauthenticatedBlobDownloadTokenRepository,
+                                                        val blobResolvers: BlobResolvers,
+                                                        val blobIdFactory: BlobStoreBlobId.Factory,
+                                                        val sessionProvider: SessionProvider,
+                                                        val metricFactory: MetricFactory) extends JMAPRoutes {
+  import UnauthenticatedBlobAccessDownloadRoutes.LOGGER
+
+  private val accountIdParam: String = "accountId"
+  private val blobIdParam: String = "blobId"
+  private val tokenParam: String = "token"
+  private val unauthenticatedDownloadUri = s"/unauthenticatedDownload/{$accountIdParam}/{$blobIdParam}"
+  private val pendingDownloadMetric: Metric = metricFactory.generate("jmap_pending_unauthenticated_blob_downloads")
+
+  override def routes(): stream.Stream[JMAPRoute] = Stream.of(
+    JMAPRoute.builder
+      .endpoint(new Endpoint(HttpMethod.GET, unauthenticatedDownloadUri))
+      .action(this.get)
+      .corsHeaders,
+    JMAPRoute.builder
+      .endpoint(new Endpoint(HttpMethod.OPTIONS, unauthenticatedDownloadUri))
+      .action(JMAPRoutes.CORS_CONTROL)
+      .noCorsHeaders)
+
+  private def get(request: HttpServerRequest, response: HttpServerResponse): Mono[Void] =
+    validateToken(request)
+      .flatMap(validated => resolveSession(validated.username)
+        .flatMap(session => blobResolvers.resolve(validated.jmapBlobId, session))
+        .flatMap(blob => downloadBlob(response, blob)
+          .doOnSubscribe(_ => pendingDownloadMetric.increment())
+          .doFinally(_ => pendingDownloadMetric.decrement())
+          .`then`()))
+      .onErrorResume {
+        case _: InvalidUnauthenticatedBlobAccessTokenException =>
+          respondDetails(response, ProblemDetails(status = UNAUTHORIZED, detail = "Invalid token"))
+        case _: BlobNotFoundException =>
+          respondDetails(response, ProblemDetails(status = NOT_FOUND, detail = "The resource could not be found"))
+        case e =>
+          LOGGER.error("Unexpected error upon unauthenticated blob download for accountId={} blobId={}",
+            Option(request.param(accountIdParam)).getOrElse(""),
+            Option(request.param(blobIdParam)).getOrElse(""),
+            e)
+          respondDetails(response, ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = e.getMessage))
+      }
+      .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER)
+      .asJava()
+      .`then`
+
+  private def validateToken(request: HttpServerRequest): SMono[ValidatedUnauthenticatedBlobDownload] =
+    SMono.fromCallable(() => parseRequest(request))
+      .flatMap {
+        case (javaAccountId, blobStoreBlobId, jmapBlobId, token) =>
+          SMono(tokenRepository.check(javaAccountId, blobStoreBlobId, token))
+            .flatMap(optionalUsername => optionalUsername.toScala
+              .map(username => SMono.fromCallable(() => ValidatedUnauthenticatedBlobDownload(jmapBlobId, username)))
+              .getOrElse(SMono.error(InvalidUnauthenticatedBlobAccessTokenException())))
+      }
+
+  private def parseRequest(request: HttpServerRequest): (JavaAccountId, BlobStoreBlobId, JmapBlobId, UnauthenticatedBlobDownloadToken) = {
+    val accountId: AccountId = Id.validate(request.param(accountIdParam))
+      .fold(_ => throw InvalidUnauthenticatedBlobAccessTokenException(), id => AccountId(id))
+    val blobIdAsString: String = request.param(blobIdParam)
+    val blobStoreBlobId: BlobStoreBlobId = Try(blobIdFactory.parse(blobIdAsString))
+      .getOrElse(throw InvalidUnauthenticatedBlobAccessTokenException())
+    val jmapBlobId: JmapBlobId = JmapBlobId.of(blobIdAsString)
+      .fold(_ => throw InvalidUnauthenticatedBlobAccessTokenException(), blobId => blobId)
+    val token: UnauthenticatedBlobDownloadToken = queryParam(request, tokenParam)
+      .flatMap(value => Try(new UnauthenticatedBlobDownloadToken(UUID.fromString(value))).toOption)
+      .getOrElse(throw InvalidUnauthenticatedBlobAccessTokenException())
+
+    (JavaAccountId.fromString(accountId.id.value), blobStoreBlobId, jmapBlobId, token)
+  }
+
+  private def resolveSession(username: Username): SMono[MailboxSession] =
+    SMono.fromCallable(() => sessionProvider.createSystemSession(username))
+
+  private def downloadBlob(response: HttpServerResponse, blob: Blob): SMono[Unit] = {
+    val resourceSupplier: Callable[InputStream] = () => blob.content
+    val sourceSupplier: java.util.function.Function[InputStream, Mono[Void]] = stream => SMono(addContentLengthHeader(blob.size)
+      .compose(addCacheControlHeader())
+      .apply(response)
+      .header(CONTENT_TYPE, sanitizeHeaderValue(blob.contentType.asString))
+      .status(OK)
+      .send(ReactorUtils.toChunks(stream, BUFFER_SIZE)
+        .map(Unpooled.wrappedBuffer(_))
+        .subscribeOn(Schedulers.boundedElastic()))).asJava()
+    val resourceRelease: Consumer[InputStream] = (stream: InputStream) => stream.close()
+
+    SMono.fromPublisher(Mono.using(
+        resourceSupplier,
+        sourceSupplier,
+        resourceRelease))
+      .`then`
+  }
+
+  private def sanitizeHeaderValue(s: String): String =
+    if (HttpHeaderValidationUtil.validateValidHeaderValue(s) == -1) {
+      s
+    } else {
+      "application/octet-stream"
+    }
+
+  private def addContentLengthHeader(sizeTry: Try[Size]): HttpServerResponse => HttpServerResponse =
+    resp => sizeTry
+      .map(size => resp.header("Content-Length", size.value.toString))
+      .getOrElse(resp)
+
+  private def addCacheControlHeader(): HttpServerResponse => HttpServerResponse =
+    resp => resp.header(HttpHeaderNames.CACHE_CONTROL, "private, immutable, max-age=31536000")
+
+  private def queryParam(httpRequest: HttpServerRequest, parameterName: String): Option[String] =
+    Option(new QueryStringDecoder(httpRequest.uri).parameters.get(parameterName))
+      .toList
+      .flatMap(_.asScala)
+      .headOption
+
+  private def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
+    SMono.fromCallable(() => ResponseSerializer.serialize(details))
+      .map(Json.stringify)
+      .map(_.getBytes(StandardCharsets.UTF_8))
+      .flatMap(bytes =>
+        SMono.fromPublisher(httpServerResponse.status(details.status)
+          .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
+          .header(CONTENT_LENGTH, Integer.toString(bytes.length))
+          .sendByteArray(SMono.just(bytes))
+          .`then`).`then`)
+}


### PR DESCRIPTION
resolve #2349 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated HTTP download endpoint that allows token-based blob retrieval with content-type handling, content-length when available, and immutable cache-control. Metrics track pending downloads and errors return standard HTTP problem responses.

* **Tests**
  * Expanded integration tests for token lifecycle, custom content uploads, download flows (including attachments/messages), and cross-account access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->