### PR TITLE
ISSUE-2374 Add suspiciousDisplayName + SuspiciousDomainInDisplayName matcher

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
@@ -211,7 +211,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 *Minimal — uses configured userBase and default stop words:*
 
 ....
-<mailet matcher="SuspiciousDisplayName" class="AddHeader">
+<mailet match="SuspiciousDisplayName" class="AddHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
 </mailet>
@@ -220,7 +220,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 *Explicit userBase:*
 
 ....
-<mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader">
+<mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
 </mailet>
@@ -229,17 +229,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 *Custom stop words (replaces defaults):*
 
 ....
-<mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr,Prof"
-        class="AddHeader">
-  <name>X-Suspicious-DisplayName</name>
-  <value>true</value>
-</mailet>
-....
-
-*Typical security pipeline — combine with a local-sender exclusion:*
-
-....
-<mailet matcher="And(Not(HostIsLocal),SuspiciousDisplayName=ou=people,dc=james,dc=org)"
+<mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr,Prof"
         class="AddHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
@@ -280,17 +270,10 @@ No condition parameter is required. The list of local domains is taken directly 
 server's configured domain list.
 
 ....
-<mailet matcher="SuspiciousDomainInDisplayName" class="AddHeader">
+<mailet match="SuspiciousDomainInDisplayName" class="AddHeader">
   <name>X-Suspicious-Domain</name>
   <value>true</value>
 </mailet>
 ....
 
-*Typical security pipeline — combine with a local-sender exclusion:*
-
-....
-<mailet matcher="And(Not(HostIsLocal),SuspiciousDomainInDisplayName)" class="AddHeader">
-  <name>X-Suspicious-Domain</name>
-  <value>true</value>
-</mailet>
 ....

--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
@@ -152,3 +152,145 @@ To gradually increase sending volume when warming up a new IP address:
   <gateway>established-smtp-gateway.example.com</gateway>
 </mailet>
 ....
+
+== SuspiciousDisplayName
+
+=== Purpose
+
+The `SuspiciousDisplayName` matcher detects display name usurpation: an external sender sets a
+`From` display name that matches the LDAP `displayName` of a local user, making the email appear
+to come from a trusted colleague.
+
+Use cases:
+
+* *Phishing detection*: Flag inbound emails where the display name impersonates a known internal
+  user
+* *Security pipeline*: Route suspicious emails to a quarantine processor or add a warning header
+  before delivery
+
+=== How it works
+
+For each email the matcher:
+
+1. Parses the `From` header display name using MIME4J
+2. Strips punctuation (`()[]{}.,<>:;`) from each token, removes tokens shorter than 3 characters
+   and removes configurable stop words (default: `Mr`, `Mme`, `Mrs`, `Ms`, `Dr`, `M`, `Me`, `Prof`)
+3. Builds an LDAP AND-substring filter: `(&(displayName=*token1*)(displayName=*token2*)...)`
+4. Searches the configured user base — because the filter applies to a *single* LDAP entry,
+   partial token combinations such as `Alice Doe` or `John Martin` do not match a user named
+   `John Doe`
+5. If a match is found, additionally checks that the sender's envelope address does not correspond
+   to that LDAP user — a legitimate user sending with their own display name is not flagged
+
+=== Configuration
+
+The matcher condition has the following optional syntax:
+
+....
+SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
+....
+
+[cols="1,1,3", options="header"]
+|===
+|Part
+|Default
+|Description
+
+|`<userBase>`
+|`userBase` from `usersrepository.xml`
+|LDAP DN under which to search for users, e.g. `ou=people,dc=james,dc=org`
+
+|`stopWords`
+|`Mr,Mme,Mrs,Ms,Dr,M,Me,Prof`
+|Comma-separated list of tokens to ignore during tokenization (case-insensitive).
+ Providing this parameter *replaces* the default list entirely.
+|===
+
+==== Examples
+
+*Minimal — uses configured userBase and default stop words:*
+
+....
+<mailet matcher="SuspiciousDisplayName" class="AddHeader">
+  <name>X-Suspicious-DisplayName</name>
+  <value>true</value>
+</mailet>
+....
+
+*Explicit userBase:*
+
+....
+<mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader">
+  <name>X-Suspicious-DisplayName</name>
+  <value>true</value>
+</mailet>
+....
+
+*Custom stop words (replaces defaults):*
+
+....
+<mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr,Prof"
+        class="AddHeader">
+  <name>X-Suspicious-DisplayName</name>
+  <value>true</value>
+</mailet>
+....
+
+*Typical security pipeline — combine with a local-sender exclusion:*
+
+....
+<mailet matcher="And(Not(HostIsLocal),SuspiciousDisplayName=ou=people,dc=james,dc=org)"
+        class="AddHeader">
+  <name>X-Suspicious-DisplayName</name>
+  <value>true</value>
+</mailet>
+....
+
+== SuspiciousDomainInDisplayName
+
+=== Purpose
+
+The `SuspiciousDomainInDisplayName` matcher flags emails whose `From` display name contains a
+reference to a local domain (either as a bare domain or embedded in an email address), which is
+a common trick to make an external email appear to originate from inside the organisation.
+
+Examples of suspicious display names when `linagora.com` is a local domain:
+
+* `"John from linagora.com" <attacker@evil.org>`
+* `"john@linagora.com" <attacker@evil.org>`
+* `"John (linagora.com)" <attacker@evil.org>`
+
+=== How it works
+
+For each email the matcher:
+
+1. Parses the `From` header display name using MIME4J
+2. Splits the display name on whitespace, common punctuation and `@` using Guava `CharMatcher`;
+   leading/trailing dots and commas are trimmed from each token
+3. Retains only tokens that contain a dot (domain-like candidates)
+4. Attempts `Domain.of(token)` on each candidate — invalid tokens are silently ignored
+5. Skips any domain that equals the sender's own envelope domain (a sender legitimately
+   referencing their own domain is not suspicious)
+6. Checks the remaining candidates against `MailetContext.isLocalServer` — the first local
+   domain found triggers a match
+
+=== Configuration
+
+No condition parameter is required. The list of local domains is taken directly from the
+server's configured domain list.
+
+....
+<mailet matcher="SuspiciousDomainInDisplayName" class="AddHeader">
+  <name>X-Suspicious-Domain</name>
+  <value>true</value>
+</mailet>
+....
+
+*Typical security pipeline — combine with a local-sender exclusion:*
+
+....
+<mailet matcher="And(Not(HostIsLocal),SuspiciousDomainInDisplayName)" class="AddHeader">
+  <name>X-Suspicious-Domain</name>
+  <value>true</value>
+</mailet>
+....

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
@@ -1,0 +1,194 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Inject;
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.mime4j.field.address.LenientAddressParser;
+import org.apache.james.user.ldap.LDAPConnectionFactory;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.LDAPSearchException;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import com.unboundid.ldap.sdk.SearchScope;
+
+/**
+ * Matcher detecting display name usurpation: flags emails whose From header display name
+ * matches a local user's LDAP displayName, suggesting identity spoofing by an external sender.
+ *
+ * <p>The display name is tokenized (punctuation stripped, stop words removed, tokens &lt; 3 chars
+ * ignored) and an AND substring search is performed against the LDAP {@code displayName} attribute.
+ * Because the filter applies to a single LDAP entry, partial combinations like "Alice Doe" or
+ * "John Martin" do not match a user named "John Doe".</p>
+ *
+ * <p>Configuration:</p>
+ * <pre><code>
+ * &lt;!-- userBase from LdapRepositoryConfiguration, default stop words --&gt;
+ * &lt;mailet matcher="SuspiciousDisplayName" class="AddHeader"&gt;
+ *   &lt;name&gt;X-Suspicious-DisplayName&lt;/name&gt;&lt;value&gt;true&lt;/value&gt;
+ * &lt;/mailet&gt;
+ *
+ * &lt;!-- explicit userBase --&gt;
+ * &lt;mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader"&gt; ... &lt;/mailet&gt;
+ *
+ * &lt;!-- explicit userBase + custom stop words --&gt;
+ * &lt;mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr" class="AddHeader"&gt;
+ *   ...
+ * &lt;/mailet&gt;
+ * </code></pre>
+ *
+ * <p>Default stop words: Mr, Mme, Mrs, Ms, Dr, M, Me, Prof</p>
+ */
+public class SuspiciousDisplayName extends GenericMatcher {
+    private static final String DISPLAY_NAME_ATTRIBUTE = "displayName";
+    private static final ImmutableSet<String> DEFAULT_STOP_WORDS =
+        ImmutableSet.of("mr", "mme", "mrs", "ms", "dr", "m", "me", "prof");
+    private static final Pattern PUNCTUATION = Pattern.compile("[()\\[\\]{}.,<>:;]");
+
+    private final LDAPConnectionPool ldapConnectionPool;
+    private final LdapRepositoryConfiguration configuration;
+    private String userBase;
+    private ImmutableSet<String> stopWords;
+
+    @Inject
+    public SuspiciousDisplayName(LDAPConnectionPool ldapConnectionPool,
+                                  LdapRepositoryConfiguration configuration) {
+        this.ldapConnectionPool = ldapConnectionPool;
+        this.configuration = configuration;
+    }
+
+    @VisibleForTesting
+    public SuspiciousDisplayName(LdapRepositoryConfiguration configuration) throws LDAPException {
+        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool(), configuration);
+    }
+
+    @Override
+    public void init() throws MessagingException {
+        String condition = getCondition() != null ? getCondition().trim() : "";
+        int queryStart = condition.indexOf('?');
+
+        String basePart = (queryStart == -1 ? condition : condition.substring(0, queryStart)).trim();
+        userBase = basePart.isEmpty() ? configuration.getUserBase() : basePart;
+
+        stopWords = parseStopWords(queryStart == -1 ? "" : condition.substring(queryStart + 1));
+    }
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        List<String> tokens = extractFromDisplayName(mail)
+            .map(this::tokenize)
+            .orElse(ImmutableList.of());
+
+        if (tokens.isEmpty()) {
+            return ImmutableList.of();
+        }
+        if (isSuspicious(tokens, mail.getMaybeSender().asOptional())) {
+            return mail.getRecipients();
+        }
+        return ImmutableList.of();
+    }
+
+    private Optional<String> extractFromDisplayName(Mail mail) throws MessagingException {
+        String[] fromHeaders = mail.getMessage().getHeader("From");
+        if (fromHeaders == null || fromHeaders.length == 0) {
+            return Optional.empty();
+        }
+        return LenientAddressParser.DEFAULT
+            .parseAddressList(fromHeaders[0])
+            .flatten()
+            .stream()
+            .findFirst()
+            .map(mailbox -> mailbox.getName())
+            .filter(name -> name != null && !name.isBlank());
+    }
+
+    private List<String> tokenize(String displayName) {
+        return Splitter.on(' ').trimResults().omitEmptyStrings()
+            .splitToStream(PUNCTUATION.matcher(displayName).replaceAll(" "))
+            .filter(token -> token.length() >= 3)
+            .filter(token -> !stopWords.contains(token.toLowerCase(Locale.ROOT)))
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private boolean isSuspicious(List<String> tokens, Optional<MailAddress> sender) {
+        try {
+            Filter[] subFilters = tokens.stream()
+                .map(token -> Filter.createSubstringFilter(
+                    DISPLAY_NAME_ATTRIBUTE, null, new String[]{token}, null))
+                .toArray(Filter[]::new);
+
+            Filter filter = subFilters.length == 1
+                ? subFilters[0]
+                : Filter.createANDFilter(subFilters);
+
+            List<SearchResultEntry> entries = ldapConnectionPool
+                .search(userBase, SearchScope.SUB, filter,
+                    DISPLAY_NAME_ATTRIBUTE, configuration.getUserIdAttribute())
+                .getSearchEntries();
+
+            if (entries.isEmpty()) {
+                return false;
+            }
+            // Not suspicious if the sender is the actual LDAP user whose displayName matched
+            return sender
+                .map(senderAddress -> entries.stream()
+                    .noneMatch(entry -> senderMatchesEntry(senderAddress, entry)))
+                .orElse(true);
+        } catch (LDAPSearchException e) {
+            throw new RuntimeException("Failed searching LDAP for suspicious display name", e);
+        }
+    }
+
+    private boolean senderMatchesEntry(MailAddress sender, SearchResultEntry entry) {
+        return Optional.ofNullable(entry.getAttributeValue(configuration.getUserIdAttribute()))
+            .map(value -> value.equalsIgnoreCase(sender.asString()))
+            .orElse(false);
+    }
+
+    private ImmutableSet<String> parseStopWords(String queryString) {
+        return Splitter.on('&').trimResults().omitEmptyStrings()
+            .splitToStream(queryString)
+            .filter(pair -> pair.toLowerCase(Locale.ROOT).startsWith("stopwords="))
+            .findFirst()
+            .map(pair -> pair.substring(pair.indexOf('=') + 1))
+            .filter(csv -> !csv.isBlank())
+            .map(csv -> Splitter.on(',').trimResults().omitEmptyStrings()
+                .splitToStream(csv)
+                .map(w -> w.toLowerCase(Locale.ROOT))
+                .collect(ImmutableSet.toImmutableSet()))
+            .orElse(DEFAULT_STOP_WORDS);
+    }
+}

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
@@ -57,15 +57,15 @@ import com.unboundid.ldap.sdk.SearchScope;
  * <p>Configuration:</p>
  * <pre><code>
  * &lt;!-- userBase from LdapRepositoryConfiguration, default stop words --&gt;
- * &lt;mailet matcher="SuspiciousDisplayName" class="AddHeader"&gt;
+ * &lt;mailet match="SuspiciousDisplayName" class="AddHeader"&gt;
  *   &lt;name&gt;X-Suspicious-DisplayName&lt;/name&gt;&lt;value&gt;true&lt;/value&gt;
  * &lt;/mailet&gt;
  *
  * &lt;!-- explicit userBase --&gt;
- * &lt;mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader"&gt; ... &lt;/mailet&gt;
+ * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader"&gt; ... &lt;/mailet&gt;
  *
  * &lt;!-- explicit userBase + custom stop words --&gt;
- * &lt;mailet matcher="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr" class="AddHeader"&gt;
+ * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr" class="AddHeader"&gt;
  *   ...
  * &lt;/mailet&gt;
  * </code></pre>
@@ -145,14 +145,7 @@ public class SuspiciousDisplayName extends GenericMatcher {
 
     private boolean isSuspicious(List<String> tokens, Optional<MailAddress> sender) {
         try {
-            Filter[] subFilters = tokens.stream()
-                .map(token -> Filter.createSubstringFilter(
-                    DISPLAY_NAME_ATTRIBUTE, null, new String[]{token}, null))
-                .toArray(Filter[]::new);
-
-            Filter filter = subFilters.length == 1
-                ? subFilters[0]
-                : Filter.createANDFilter(subFilters);
+            Filter filter = createLdapFilter(tokens);
 
             List<SearchResultEntry> entries = ldapConnectionPool
                 .search(userBase, SearchScope.SUB, filter,
@@ -169,6 +162,19 @@ public class SuspiciousDisplayName extends GenericMatcher {
                 .orElse(true);
         } catch (LDAPSearchException e) {
             throw new RuntimeException("Failed searching LDAP for suspicious display name", e);
+        }
+    }
+
+    private Filter createLdapFilter(List<String> tokens) {
+        Filter[] subFilters = tokens.stream()
+            .map(token -> Filter.createSubstringFilter(
+                DISPLAY_NAME_ATTRIBUTE, null, new String[]{token}, null))
+            .toArray(Filter[]::new);
+
+        if (subFilters.length == 1) {
+            return subFilters[0];
+        } else {
+            return Filter.createANDFilter(subFilters);
         }
     }
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
@@ -26,6 +26,7 @@ import jakarta.mail.MessagingException;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.field.address.LenientAddressParser;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
@@ -68,19 +69,27 @@ public class SuspiciousDomainInDisplayName extends GenericMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) throws MessagingException {
-        Optional<Domain> senderDomain = mail.getMaybeSender().asOptional()
-            .map(MailAddress::getDomain);
+        Optional<Mailbox> fromMailbox = extractFromMailbox(mail);
 
-        boolean suspicious = extractFromDisplayName(mail)
+        Optional<Domain> fromAddressDomain = fromMailbox
+            .map(Mailbox::getDomain)
+            .filter(domain -> domain != null && !domain.isBlank())
+            .flatMap(this::tryParseDomain);
+
+        boolean suspicious = fromMailbox
+            .map(Mailbox::getName)
+            .filter(name -> name != null && !name.isBlank())
             .map(this::extractDomains)
             .orElse(Stream.empty())
-            .filter(domain -> senderDomain.map(sd -> !sd.equals(domain)).orElse(true))
+            .filter(domain -> fromAddressDomain.map(fromDomain -> !fromDomain.equals(domain)).orElse(true))
             .anyMatch(domain -> getMailetContext().isLocalServer(domain));
 
-        return suspicious ? mail.getRecipients() : ImmutableList.of();
+        return Optional.of(mail.getRecipients())
+            .filter(recipients -> suspicious)
+            .orElse(ImmutableList.of());
     }
 
-    private Optional<String> extractFromDisplayName(Mail mail) throws MessagingException {
+    private Optional<Mailbox> extractFromMailbox(Mail mail) throws MessagingException {
         String[] fromHeaders = mail.getMessage().getHeader("From");
         if (fromHeaders == null || fromHeaders.length == 0) {
             return Optional.empty();
@@ -89,9 +98,7 @@ public class SuspiciousDomainInDisplayName extends GenericMatcher {
             .parseAddressList(fromHeaders[0])
             .flatten()
             .stream()
-            .findFirst()
-            .map(mailbox -> mailbox.getName())
-            .filter(name -> name != null && !name.isBlank());
+            .findFirst();
     }
 
     private Stream<Domain> extractDomains(String displayName) {

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
@@ -1,0 +1,110 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+import org.apache.james.mime4j.field.address.LenientAddressParser;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Matcher detecting a local domain referenced inside the From header display name.
+ *
+ * <p>An attacker may include a local domain in their display name (bare or as part of an email
+ * address) to fool the recipient into thinking the message originates from inside the
+ * organisation. This matcher flags such emails so they can be quarantined or labelled.</p>
+ *
+ * <p>Examples that match when {@code linagora.com} is a local domain:</p>
+ * <ul>
+ *   <li>{@code "John from linagora.com" <attacker@evil.org>} — bare domain</li>
+ *   <li>{@code "john@linagora.com" <attacker@evil.org>} — domain inside email address</li>
+ *   <li>{@code "John (linagora.com)" <attacker@evil.org>} — domain in parentheses</li>
+ * </ul>
+ *
+ * <p>No configuration parameter is required:</p>
+ * <pre><code>
+ * &lt;mailet matcher="SuspiciousDomainInDisplayName" class="AddHeader"&gt;
+ *   &lt;name&gt;X-Suspicious-Domain&lt;/name&gt;&lt;value&gt;true&lt;/value&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ */
+public class SuspiciousDomainInDisplayName extends GenericMatcher {
+    // Split on whitespace, common punctuation, and @ (to separate local-part from domain in
+    // email-like patterns). Dots are NOT separators — they must stay within domain tokens.
+    // trimResults strips leading/trailing dots and commas left on token edges (e.g. "linagora.com,").
+    private static final CharMatcher SEPARATORS =
+        CharMatcher.anyOf("()[]{},<>:;@").or(CharMatcher.whitespace());
+    private static final Splitter TOKEN_SPLITTER = Splitter
+        .on(SEPARATORS)
+        .trimResults(CharMatcher.anyOf(".,"))
+        .omitEmptyStrings();
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        Optional<Domain> senderDomain = mail.getMaybeSender().asOptional()
+            .map(MailAddress::getDomain);
+
+        boolean suspicious = extractFromDisplayName(mail)
+            .map(this::extractDomains)
+            .orElse(Stream.empty())
+            .filter(domain -> senderDomain.map(sd -> !sd.equals(domain)).orElse(true))
+            .anyMatch(domain -> getMailetContext().isLocalServer(domain));
+
+        return suspicious ? mail.getRecipients() : ImmutableList.of();
+    }
+
+    private Optional<String> extractFromDisplayName(Mail mail) throws MessagingException {
+        String[] fromHeaders = mail.getMessage().getHeader("From");
+        if (fromHeaders == null || fromHeaders.length == 0) {
+            return Optional.empty();
+        }
+        return LenientAddressParser.DEFAULT
+            .parseAddressList(fromHeaders[0])
+            .flatten()
+            .stream()
+            .findFirst()
+            .map(mailbox -> mailbox.getName())
+            .filter(name -> name != null && !name.isBlank());
+    }
+
+    private Stream<Domain> extractDomains(String displayName) {
+        return TOKEN_SPLITTER.splitToStream(displayName)
+            .filter(token -> token.contains("."))
+            .flatMap(token -> tryParseDomain(token).stream());
+    }
+
+    private Optional<Domain> tryParseDomain(String value) {
+        try {
+            return Optional.of(Domain.of(value));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDisplayNameTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDisplayNameTest.java
@@ -1,0 +1,312 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.plist.PropertyListConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.user.ldap.DockerLdapSingleton;
+import org.apache.james.user.ldap.LdapGenericContainer;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class SuspiciousDisplayNameTest {
+    static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
+
+    private static final String USER_BASE = "ou=people,dc=james,dc=org";
+    private static final String EMPTY_BASE = "ou=empty,dc=james,dc=org";
+    private static final MailAddress RECIPIENT = newAddress("recipient@james.org");
+    private static final MailAddress SENDER = newAddress("attacker@external.org");
+
+    @BeforeAll
+    static void setUpAll() {
+        ldapContainer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        ldapContainer.stop();
+    }
+
+    // --- match cases ---
+
+    @Test
+    void shouldMatchWhenDisplayNameMatchesLdapUser() throws Exception {
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameHasLeadingStopWord() throws Exception {
+        // "Mr" is filtered → remaining tokens [John, Doe] → match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Mr John Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameHasParentheses() throws Exception {
+        // "(John Doe)" → punctuation stripped → [John, Doe] → match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("(John Doe)", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameHasComma() throws Exception {
+        // "John, Doe" → comma stripped → [John, Doe] → match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John, Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameHasDot() throws Exception {
+        // "John. Doe." → dots stripped → [John, Doe] → match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John. Doe.", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenShortTokenFiltered() throws Exception {
+        // "Jo Doe" → "Jo" < 3 chars filtered → tokens [Doe] → substring match on "John Doe"
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Jo Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWithCustomStopWords() throws Exception {
+        // "Dr" added as stop word via condition → "Dr John Doe" → [John, Doe] → match
+        SuspiciousDisplayName testee = buildTesteeWithCondition(USER_BASE + "?stopWords=Dr");
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Dr John Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenConditionIsEmpty() throws Exception {
+        // empty condition → falls back to configuration.getUserBase() = ou=people,dc=james,dc=org
+        SuspiciousDisplayName testee = buildTesteeWithCondition("");
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Doe", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldNotMatchWhenSenderIsTheLdapUser() throws Exception {
+        // john-doe@james.org sends with his own display name "John Doe" → not suspicious
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+        MailAddress johnDoe = newAddress("john-doe@james.org");
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Doe", johnDoe));
+
+        assertThat(matched).isEmpty();
+    }
+
+    // --- no-match cases ---
+
+    @Test
+    void shouldNotMatchWhenOnlyFirstTokenMatchesAnEntry() throws Exception {
+        // "Alice Doe" → (&(displayName=*Alice*)(displayName=*Doe*)) → "John Doe" lacks "Alice" → no match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Alice Doe", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenOnlyLastTokenMatchesAnEntry() throws Exception {
+        // "John Martin" → (&(displayName=*John*)(displayName=*Martin*)) → "John Doe" lacks "Martin" → no match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Martin", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenDisplayNameUnknownInLdap() throws Exception {
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Alice Martin", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenNoDisplayName() throws Exception {
+        // From: <attacker@external.org> — no personal name
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("attacker@external.org"))
+            .build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(SENDER)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        Collection<MailAddress> matched = testee.match(mail);
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenNoFromHeader() throws Exception {
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder().build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(SENDER)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        Collection<MailAddress> matched = testee.match(mail);
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenUserBasePointsToEmptyOU() throws Exception {
+        SuspiciousDisplayName testee = buildTestee(EMPTY_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Doe", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenAllTokensShorterThanThreeChars() throws Exception {
+        // "Jo Do" → both < 3 chars → no tokens → no match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Jo Do", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenOnlyStopWordsRemainAfterTokenizing() throws Exception {
+        // "Mr Mme" → both are stop words → no tokens → no match
+        SuspiciousDisplayName testee = buildTestee(USER_BASE);
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Mr Mme", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenCustomStopWordsDoNotFilterDefaultOnes() throws Exception {
+        // condition replaces stop words with only "Dr" → "Mme" is no longer a stop word
+        // "Mme John Doe" → tokens [Mme, John, Doe] → (&(*Mme*)(*John*)(*Doe*)) → "John Doe" lacks "Mme" → no match
+        SuspiciousDisplayName testee = buildTesteeWithCondition(USER_BASE + "?stopWords=Dr");
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Mme John Doe", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    // --- helpers ---
+
+    private SuspiciousDisplayName buildTestee(String userBase) throws Exception {
+        return buildTesteeWithCondition(userBase);
+    }
+
+    private SuspiciousDisplayName buildTesteeWithCondition(String condition) throws Exception {
+        SuspiciousDisplayName testee = new SuspiciousDisplayName(
+            LdapRepositoryConfiguration.from(ldapRepositoryConfiguration(ldapContainer)));
+        testee.init(FakeMatcherConfig.builder()
+            .matcherName("SuspiciousDisplayName")
+            .condition(condition)
+            .build());
+        return testee;
+    }
+
+    private FakeMail mailWithFromDisplayName(String displayName, MailAddress sender) throws Exception {
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress(sender.asString(), displayName))
+            .build();
+        return FakeMail.builder()
+            .name("test")
+            .sender(sender)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+    }
+
+    static HierarchicalConfiguration<ImmutableNode> ldapRepositoryConfiguration(LdapGenericContainer ldapContainer) {
+        PropertyListConfiguration configuration = new PropertyListConfiguration();
+        configuration.addProperty("[@ldapHost]", ldapContainer.getLdapHost());
+        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
+        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
+        configuration.addProperty("[@userBase]", USER_BASE);
+        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
+        configuration.addProperty("[@userIdAttribute]", "mail");
+        configuration.addProperty("supportsVirtualHosting", true);
+        configuration.addProperty("[@administratorId]", ADMIN.asString());
+        configuration.addProperty("[@connectionTimeout]", "2000");
+        configuration.addProperty("[@readTimeout]", "2000");
+        return configuration;
+    }
+
+    private static MailAddress newAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayNameTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayNameTest.java
@@ -1,0 +1,190 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.mailet.MailetContext;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SuspiciousDomainInDisplayNameTest {
+
+    private static final MailAddress RECIPIENT = newAddress("recipient@james.org");
+    private static final MailAddress SENDER = newAddress("attacker@evil.org");
+    private static final Domain LOCAL_DOMAIN = Domain.of("linagora.com");
+    private static final Domain OTHER_DOMAIN = Domain.of("gmail.com");
+
+    private SuspiciousDomainInDisplayName testee;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MailetContext mailetContext = mock(MailetContext.class);
+        when(mailetContext.isLocalServer(LOCAL_DOMAIN)).thenReturn(true);
+        when(mailetContext.isLocalServer(OTHER_DOMAIN)).thenReturn(false);
+
+        testee = new SuspiciousDomainInDisplayName();
+        testee.init(FakeMatcherConfig.builder()
+            .matcherName("SuspiciousDomainInDisplayName")
+            .mailetContext(mailetContext)
+            .build());
+    }
+
+    // --- match cases ---
+
+    @Test
+    void shouldMatchWhenDisplayNameContainsLocalDomain() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from linagora.com", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameContainsEmailWithLocalDomain() throws Exception {
+        // attacker puts a local-domain email address in his display name
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("john@linagora.com", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenLocalDomainIsInParentheses() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John (linagora.com)", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenLocalDomainAppearsAmongOtherText() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("Support linagora.com team", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameContainsBothLocalAndExternalDomain() throws Exception {
+        // local domain anywhere in the display name is enough to flag
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John gmail.com linagora.com", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldNotMatchWhenDomainInDisplayNameMatchesSenderDomain() throws Exception {
+        // john@linagora.com legitimately mentions his own domain in his display name
+        MailAddress localSender = newAddress("john@linagora.com");
+
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from linagora.com", localSender));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldMatchWhenDisplayNameDomainIsLocalButDifferentFromSenderDomain() throws Exception {
+        // attacker@evil.org puts a local domain that is not their own → suspicious
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from linagora.com", SENDER));
+
+        assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    // --- no-match cases ---
+
+    @Test
+    void shouldNotMatchWhenDisplayNameContainsOnlyExternalDomain() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from gmail.com", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenDisplayNameContainsEmailWithExternalDomain() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("john@gmail.com", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenDisplayNameHasNoDomain() throws Exception {
+        Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John Doe", SENDER));
+
+        assertThat(matched).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenNoDisplayName() throws Exception {
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress(SENDER.asString()))
+            .build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(SENDER)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        assertThat(testee.match(mail)).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenNoFromHeader() throws Exception {
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder().build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(SENDER)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        assertThat(testee.match(mail)).isEmpty();
+    }
+
+    // --- helpers ---
+
+    private FakeMail mailWithFromDisplayName(String displayName, MailAddress sender) throws Exception {
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress(sender.asString(), displayName))
+            .build();
+        return FakeMail.builder()
+            .name("test")
+            .sender(sender)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+    }
+
+    private static MailAddress newAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayNameTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayNameTest.java
@@ -98,8 +98,8 @@ class SuspiciousDomainInDisplayNameTest {
     }
 
     @Test
-    void shouldNotMatchWhenDomainInDisplayNameMatchesSenderDomain() throws Exception {
-        // john@linagora.com legitimately mentions his own domain in his display name
+    void shouldNotMatchWhenFromHeaderAddressDomainMatchesDomainInDisplayName() throws Exception {
+        // From: "John from linagora.com" <john@linagora.com> — From address domain == display name domain
         MailAddress localSender = newAddress("john@linagora.com");
 
         Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from linagora.com", localSender));
@@ -108,11 +108,47 @@ class SuspiciousDomainInDisplayNameTest {
     }
 
     @Test
-    void shouldMatchWhenDisplayNameDomainIsLocalButDifferentFromSenderDomain() throws Exception {
-        // attacker@evil.org puts a local domain that is not their own → suspicious
+    void shouldMatchWhenFromHeaderAddressDomainDiffersFromDisplayNameDomain() throws Exception {
+        // From: "John from linagora.com" <attacker@evil.org> — From address domain != display name domain
         Collection<MailAddress> matched = testee.match(mailWithFromDisplayName("John from linagora.com", SENDER));
 
         assertThat(matched).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenEnvelopeDomainIsLocalButFromHeaderDomainIsNot() throws Exception {
+        // MAIL FROM: attacker@linagora.com, From: "John from linagora.com" <attacker@evil.org>
+        // Envelope domain matches, but From header address domain doesn't → suspicious
+        MailAddress envelopeSender = newAddress("attacker@linagora.com");
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("attacker@evil.org", "John from linagora.com"))
+            .build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(envelopeSender)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        assertThat(testee.match(mail)).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldNotMatchWhenFromHeaderDomainIsLocalEvenIfEnvelopeDomainDiffers() throws Exception {
+        // MAIL FROM: forwarder@other.com (forwarding), From: "John from linagora.com" <john@linagora.com>
+        // From header address domain matches display name domain → not suspicious
+        MailAddress envelopeSender = newAddress("forwarder@other.com");
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom(new InternetAddress("john@linagora.com", "John from linagora.com"))
+            .build();
+        FakeMail mail = FakeMail.builder()
+            .name("test")
+            .sender(envelopeSender)
+            .recipient(RECIPIENT)
+            .mimeMessage(message)
+            .build();
+
+        assertThat(testee.match(mail)).isEmpty();
     }
 
     // --- no-match cases ---

--- a/tmail-backend/mailets/src/test/resources/ldif-files/populate.ldif
+++ b/tmail-backend/mailets/src/test/resources/ldif-files/populate.ldif
@@ -73,6 +73,16 @@ mail: bob@james.org
 userPassword: secret
 description: Extra user
 
+dn: uid=john-doe, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: john-doe
+cn: john-doe
+sn: Doe
+givenName: John
+displayName: John Doe
+mail: john-doe@james.org
+userPassword: secret
+
 dn: cn=mygroup, ou=lists, dc=james,dc=org
 objectclass: groupofnames
 cn: mygroup


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two display-name security matchers: one flags when a display name matches known users but the sender differs; another flags when a display name contains local-domain references.
* **Documentation**
  * Extended mailet configuration guide with detailed examples and usage for the new matchers.
* **Tests**
  * Added unit/integration tests and sample LDAP data validating matcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->