### PR TITLE
[ENHANCEMENT] Add Gaussian date decay to default sort in order to pen…

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
@@ -49,4 +49,9 @@ Accepted values: any built-in OpenSearch language analyzer name — `arabic`, `a
 Optional. Defaults to `standard` (no stemming, language-agnostic).
 *Changing this setting requires a full reindex of all mailboxes.*
 
+| opensearch.mailbox.score.date.based.decay.enabled
+| When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date field,
+favouring recent messages. Messages newer than 30 days are not penalised; the decay factor reaches 0.5 at one year old.
+Optional. Defaults to false.
+
 |===

--- a/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
@@ -51,7 +51,22 @@ Optional. Defaults to `standard` (no stemming, language-agnostic).
 
 | opensearch.mailbox.score.date.based.decay.enabled
 | When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date field,
-favouring recent messages. Messages newer than 30 days are not penalised; the decay factor reaches 0.5 at one year old.
+favouring recent messages. Messages newer than 30 days are not penalised.
 Optional. Defaults to false.
+
+| opensearch.mailbox.score.date.based.decay.scale
+| Duration at which the decay factor is reached, measured from the 30-day offset. Accepts OpenSearch time units (e.g. `180d`, `365d`).
+The shorter the scale, the more aggressively older messages are penalised.
+Optional. Defaults to `365d`.
+
+| opensearch.mailbox.score.date.based.decay.factor
+| Score multiplier applied at `scale` distance from today. A value of `0.5` means a message one year old scores half as much as a recent one.
+Must be between 0 (exclusive) and 1 (exclusive).
+Optional. Defaults to `0.5`.
+
+| opensearch.mailbox.score.date.based.decay.boost.mode
+| How the decay score combines with the text relevance score. Accepted values: `multiply`, `sum`, `replace`, `avg`, `max`, `min`.
+Use `multiply` (default) to scale relevance proportionally by recency. Use `sum` to add a recency bonus without suppressing old-but-relevant results.
+Optional. Defaults to `multiply`.
 
 |===

--- a/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
@@ -104,5 +104,15 @@ opensearch.indexAttachments=true
 # Optional. Default is `false`
 # When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date,
 # favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
-# opensearch.mailbox.score.date.based.decay.enabled=falseo
-
+# opensearch.mailbox.score.date.based.decay.enabled=false
+# favouring recent messages. Messages newer than 30 days are not penalised.
+# opensearch.mailbox.score.date.based.decay.enabled=false
+# Optional. Default is `365d`. Duration at which the decay factor is reached (from the 30-day offset).
+# Shorter values penalise old messages more aggressively. Accepts OpenSearch time units (e.g. 180d, 730d).
+# opensearch.mailbox.score.date.based.decay.scale=365d
+# Optional. Default is `0.5`. Score multiplier applied at scale distance from today (0 < factor < 1).
+# opensearch.mailbox.score.date.based.decay.factor=0.5
+# Optional. Default is `multiply`. How the decay score combines with text relevance.
+# multiply: scales relevance by recency. sum: adds a recency bonus without suppressing relevant old messages.
+# Accepted values: multiply, sum, replace, avg, max, min.
+# opensearch.mailbox.score.date.based.decay.boost.mode=multiply

--- a/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
@@ -100,3 +100,9 @@ opensearch.indexAttachments=true
 # Defaults to `standard` (language-agnostic, no stemming).
 # WARNING: changing this setting requires a full reindex of all mailboxes.
 # opensearch.mailbox.body.language=french
+
+# Optional. Default is `false`
+# When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date,
+# favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
+# opensearch.mailbox.score.date.based.decay.enabled=falseo
+

--- a/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
@@ -105,8 +105,6 @@ opensearch.indexAttachments=true
 # When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date,
 # favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
 # opensearch.mailbox.score.date.based.decay.enabled=false
-# favouring recent messages. Messages newer than 30 days are not penalised.
-# opensearch.mailbox.score.date.based.decay.enabled=false
 # Optional. Default is `365d`. Duration at which the decay factor is reached (from the 30-day offset).
 # Shorter values penalise old messages more aggressively. Accepts OpenSearch time units (e.g. 180d, 730d).
 # opensearch.mailbox.score.date.based.decay.scale=365d

--- a/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
@@ -126,3 +126,8 @@ opensearch.indexAttachments=false
 # Defaults to `standard` (language-agnostic, no stemming).
 # WARNING: changing this setting requires a full reindex of all mailboxes.
 # opensearch.mailbox.body.language=french
+
+# Optional. Default is `false`
+# When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date,
+# favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
+# opensearch.mailbox.score.date.based.decay.enabled=false

--- a/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
@@ -129,5 +129,17 @@ opensearch.indexAttachments=false
 
 # Optional. Default is `false`
 # When enabled, relevance-based searches (no explicit sort) apply a Gaussian date decay on the message date,
+
 # favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
 # opensearch.mailbox.score.date.based.decay.enabled=false
+# favouring recent messages. Messages newer than 30 days are not penalised.
+# opensearch.mailbox.score.date.based.decay.enabled=false
+# Optional. Default is `365d`. Duration at which the decay factor is reached (from the 30-day offset).
+# Shorter values penalise old messages more aggressively. Accepts OpenSearch time units (e.g. 180d, 730d).
+# opensearch.mailbox.score.date.based.decay.scale=365d
+# Optional. Default is `0.5`. Score multiplier applied at scale distance from today (0 < factor < 1).
+# opensearch.mailbox.score.date.based.decay.factor=0.5
+# Optional. Default is `multiply`. How the decay score combines with text relevance.
+# multiply: scales relevance by recency. sum: adds a recency bonus without suppressing relevant old messages.
+# Accepted values: multiply, sum, replace, avg, max, min.
+# opensearch.mailbox.score.date.based.decay.boost.mode=multiply

--- a/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
@@ -132,8 +132,6 @@ opensearch.indexAttachments=false
 
 # favouring recent messages. Messages newer than 30 days are not penalised; decay factor reaches 0.5 at one year.
 # opensearch.mailbox.score.date.based.decay.enabled=false
-# favouring recent messages. Messages newer than 30 days are not penalised.
-# opensearch.mailbox.score.date.based.decay.enabled=false
 # Optional. Default is `365d`. Duration at which the decay factor is reached (from the 30-day offset).
 # Shorter values penalise old messages more aggressively. Accepts OpenSearch time units (e.g. 180d, 730d).
 # opensearch.mailbox.score.date.based.decay.scale=365d

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
@@ -26,10 +26,12 @@
 
 package com.linagora.tmail.mailbox.opensearch;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.configuration2.Configuration;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionBoostMode;
 
 public class TmailOpenSearchMailboxConfiguration {
     public static class Builder {
@@ -39,6 +41,9 @@ public class TmailOpenSearchMailboxConfiguration {
         private Optional<Boolean> attachmentFilenameNgramHeuristicEnabled;
         private Optional<String> bodyLanguage;
         private Optional<Boolean> dateBasedDecayEnabled;
+        private Optional<String> decayScale;
+        private Optional<Double> decayFactor;
+        private Optional<FunctionBoostMode> decayBoostMode;
 
         Builder() {
             subjectNgramEnabled = Optional.empty();
@@ -47,6 +52,9 @@ public class TmailOpenSearchMailboxConfiguration {
             attachmentFilenameNgramHeuristicEnabled = Optional.empty();
             bodyLanguage = Optional.empty();
             dateBasedDecayEnabled = Optional.empty();
+            decayScale = Optional.empty();
+            decayFactor = Optional.empty();
+            decayBoostMode = Optional.empty();
         }
 
         public Builder subjectNgramEnabled(Boolean subjectNgramEnabled) {
@@ -79,6 +87,21 @@ public class TmailOpenSearchMailboxConfiguration {
             return this;
         }
 
+        public Builder decayScale(String decayScale) {
+            this.decayScale = Optional.ofNullable(decayScale);
+            return this;
+        }
+
+        public Builder decayFactor(Double decayFactor) {
+            this.decayFactor = Optional.ofNullable(decayFactor);
+            return this;
+        }
+
+        public Builder decayBoostMode(FunctionBoostMode decayBoostMode) {
+            this.decayBoostMode = Optional.ofNullable(decayBoostMode);
+            return this;
+        }
+
         public TmailOpenSearchMailboxConfiguration build() {
             return new TmailOpenSearchMailboxConfiguration(
                 subjectNgramEnabled.orElse(DEFAULT_SUBJECT_NGRAM_DISABLED),
@@ -86,7 +109,10 @@ public class TmailOpenSearchMailboxConfiguration {
                 attachmentFilenameNgramEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED),
                 attachmentFilenameNgramHeuristicEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED),
                 bodyLanguage,
-                dateBasedDecayEnabled.orElse(DEFAULT_DATE_BASED_DECAY_DISABLED)
+                dateBasedDecayEnabled.orElse(DEFAULT_DATE_BASED_DECAY_DISABLED),
+                decayScale.orElse(DEFAULT_DECAY_SCALE),
+                decayFactor.orElse(DEFAULT_DECAY_FACTOR),
+                decayBoostMode.orElse(DEFAULT_DECAY_BOOST_MODE)
             );
         }
     }
@@ -103,7 +129,20 @@ public class TmailOpenSearchMailboxConfiguration {
             .attachmentFilenameNgramHeuristicEnabled(configuration.getBoolean(ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED, null))
             .bodyLanguage(configuration.getString(BODY_LANGUAGE, null))
             .dateBasedDecayEnabled(configuration.getBoolean(DATE_BASED_DECAY_ENABLED, null))
+            .decayScale(configuration.getString(DECAY_SCALE, null))
+            .decayFactor(configuration.getDouble(DECAY_FACTOR, null))
+            .decayBoostMode(Optional.ofNullable(configuration.getString(DECAY_BOOST_MODE, null))
+                .map(TmailOpenSearchMailboxConfiguration::parseBoostMode)
+                .orElse(null))
             .build();
+    }
+
+    private static FunctionBoostMode parseBoostMode(String value) {
+        return Arrays.stream(FunctionBoostMode.values())
+            .filter(m -> m.jsonValue().equalsIgnoreCase(value))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Unknown decay boost mode: '" + value + "'. Accepted values: multiply, replace, sum, avg, max, min"));
     }
 
     private static final String SUBJECT_NGRAM_ENABLED = "subject.ngram.enabled";
@@ -112,12 +151,19 @@ public class TmailOpenSearchMailboxConfiguration {
     private static final String ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED = "attachment.filename.ngram.heuristic.enabled";
     public static final String BODY_LANGUAGE = "opensearch.mailbox.body.language";
     public static final String DATE_BASED_DECAY_ENABLED = "opensearch.mailbox.score.date.based.decay.enabled";
+    public static final String DECAY_SCALE = "opensearch.mailbox.score.date.based.decay.scale";
+    public static final String DECAY_FACTOR = "opensearch.mailbox.score.date.based.decay.factor";
+    public static final String DECAY_BOOST_MODE = "opensearch.mailbox.score.date.based.decay.boost.mode";
+
     private static final boolean DEFAULT_SUBJECT_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED = false;
     private static final String STANDARD_ANALYZER = "standard";
     public static final boolean DEFAULT_DATE_BASED_DECAY_DISABLED = false;
+    public static final String DEFAULT_DECAY_SCALE = "365d";
+    public static final double DEFAULT_DECAY_FACTOR = 0.5;
+    public static final FunctionBoostMode DEFAULT_DECAY_BOOST_MODE = FunctionBoostMode.Multiply;
 
     public static final TmailOpenSearchMailboxConfiguration DEFAULT_CONFIGURATION = builder().build();
 
@@ -127,16 +173,23 @@ public class TmailOpenSearchMailboxConfiguration {
     private final boolean attachmentFilenameNgramHeuristicEnabled;
     private final Optional<String> bodyLanguage;
     private final boolean dateBasedDecayEnabled;
+    private final String decayScale;
+    private final double decayFactor;
+    private final FunctionBoostMode decayBoostMode;
 
     private TmailOpenSearchMailboxConfiguration(boolean subjectNgramEnabled, boolean subjectNgramHeuristicEnabled,
                                                 boolean attachmentFilenameNgramEnabled, boolean attachmentFilenameNgramHeuristicEnabled,
-                                                Optional<String> bodyLanguage, boolean dateBasedDecayEnabled) {
+                                                Optional<String> bodyLanguage, boolean dateBasedDecayEnabled,
+                                                String decayScale, double decayFactor, FunctionBoostMode decayBoostMode) {
         this.subjectNgramEnabled = subjectNgramEnabled;
         this.subjectNgramHeuristicEnabled = subjectNgramHeuristicEnabled;
         this.attachmentFilenameNgramEnabled = attachmentFilenameNgramEnabled;
         this.attachmentFilenameNgramHeuristicEnabled = attachmentFilenameNgramHeuristicEnabled;
         this.bodyLanguage = bodyLanguage;
         this.dateBasedDecayEnabled = dateBasedDecayEnabled;
+        this.decayScale = decayScale;
+        this.decayFactor = decayFactor;
+        this.decayBoostMode = decayBoostMode;
     }
 
     public boolean subjectNgramEnabled() {
@@ -163,6 +216,18 @@ public class TmailOpenSearchMailboxConfiguration {
         return dateBasedDecayEnabled;
     }
 
+    public String decayScale() {
+        return decayScale;
+    }
+
+    public double decayFactor() {
+        return decayFactor;
+    }
+
+    public FunctionBoostMode decayBoostMode() {
+        return decayBoostMode;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof TmailOpenSearchMailboxConfiguration) {
@@ -173,7 +238,10 @@ public class TmailOpenSearchMailboxConfiguration {
                 && Objects.equals(this.attachmentFilenameNgramEnabled, that.attachmentFilenameNgramEnabled)
                 && Objects.equals(this.attachmentFilenameNgramHeuristicEnabled, that.attachmentFilenameNgramHeuristicEnabled)
                 && Objects.equals(this.bodyLanguage, that.bodyLanguage)
-                && Objects.equals(this.dateBasedDecayEnabled, that.dateBasedDecayEnabled);
+                && Objects.equals(this.dateBasedDecayEnabled, that.dateBasedDecayEnabled)
+                && Objects.equals(this.decayScale, that.decayScale)
+                && Objects.equals(this.decayFactor, that.decayFactor)
+                && Objects.equals(this.decayBoostMode, that.decayBoostMode);
         }
         return false;
     }
@@ -181,6 +249,6 @@ public class TmailOpenSearchMailboxConfiguration {
     @Override
     public final int hashCode() {
         return Objects.hash(subjectNgramEnabled, subjectNgramHeuristicEnabled, attachmentFilenameNgramEnabled,
-            attachmentFilenameNgramHeuristicEnabled, bodyLanguage, dateBasedDecayEnabled);
+            attachmentFilenameNgramHeuristicEnabled, bodyLanguage, dateBasedDecayEnabled, decayScale, decayFactor, decayBoostMode);
     }
 }

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
@@ -38,6 +38,7 @@ public class TmailOpenSearchMailboxConfiguration {
         private Optional<Boolean> attachmentFilenameNgramEnabled;
         private Optional<Boolean> attachmentFilenameNgramHeuristicEnabled;
         private Optional<String> bodyLanguage;
+        private Optional<Boolean> dateBasedDecayEnabled;
 
         Builder() {
             subjectNgramEnabled = Optional.empty();
@@ -45,6 +46,7 @@ public class TmailOpenSearchMailboxConfiguration {
             attachmentFilenameNgramEnabled = Optional.empty();
             attachmentFilenameNgramHeuristicEnabled = Optional.empty();
             bodyLanguage = Optional.empty();
+            dateBasedDecayEnabled = Optional.empty();
         }
 
         public Builder subjectNgramEnabled(Boolean subjectNgramEnabled) {
@@ -72,13 +74,19 @@ public class TmailOpenSearchMailboxConfiguration {
             return this;
         }
 
+        public Builder dateBasedDecayEnabled(Boolean dateBasedDecayEnabled) {
+            this.dateBasedDecayEnabled = Optional.ofNullable(dateBasedDecayEnabled);
+            return this;
+        }
+
         public TmailOpenSearchMailboxConfiguration build() {
             return new TmailOpenSearchMailboxConfiguration(
                 subjectNgramEnabled.orElse(DEFAULT_SUBJECT_NGRAM_DISABLED),
                 subjectNgramHeuristicEnabled.orElse(DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED),
                 attachmentFilenameNgramEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED),
                 attachmentFilenameNgramHeuristicEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED),
-                bodyLanguage
+                bodyLanguage,
+                dateBasedDecayEnabled.orElse(DEFAULT_DATE_BASED_DECAY_DISABLED)
             );
         }
     }
@@ -94,6 +102,7 @@ public class TmailOpenSearchMailboxConfiguration {
             .attachmentFilenameNgramEnabled(configuration.getBoolean(ATTACHMENT_FILENAME_NGRAM_ENABLED, null))
             .attachmentFilenameNgramHeuristicEnabled(configuration.getBoolean(ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED, null))
             .bodyLanguage(configuration.getString(BODY_LANGUAGE, null))
+            .dateBasedDecayEnabled(configuration.getBoolean(DATE_BASED_DECAY_ENABLED, null))
             .build();
     }
 
@@ -102,11 +111,13 @@ public class TmailOpenSearchMailboxConfiguration {
     private static final String ATTACHMENT_FILENAME_NGRAM_ENABLED = "attachment.filename.ngram.enabled";
     private static final String ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED = "attachment.filename.ngram.heuristic.enabled";
     public static final String BODY_LANGUAGE = "opensearch.mailbox.body.language";
+    public static final String DATE_BASED_DECAY_ENABLED = "opensearch.mailbox.score.date.based.decay.enabled";
     private static final boolean DEFAULT_SUBJECT_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED = false;
     private static final String STANDARD_ANALYZER = "standard";
+    public static final boolean DEFAULT_DATE_BASED_DECAY_DISABLED = false;
 
     public static final TmailOpenSearchMailboxConfiguration DEFAULT_CONFIGURATION = builder().build();
 
@@ -115,15 +126,17 @@ public class TmailOpenSearchMailboxConfiguration {
     private final boolean attachmentFilenameNgramEnabled;
     private final boolean attachmentFilenameNgramHeuristicEnabled;
     private final Optional<String> bodyLanguage;
+    private final boolean dateBasedDecayEnabled;
 
     private TmailOpenSearchMailboxConfiguration(boolean subjectNgramEnabled, boolean subjectNgramHeuristicEnabled,
                                                 boolean attachmentFilenameNgramEnabled, boolean attachmentFilenameNgramHeuristicEnabled,
-                                                Optional<String> bodyLanguage) {
+                                                Optional<String> bodyLanguage, boolean dateBasedDecayEnabled) {
         this.subjectNgramEnabled = subjectNgramEnabled;
         this.subjectNgramHeuristicEnabled = subjectNgramHeuristicEnabled;
         this.attachmentFilenameNgramEnabled = attachmentFilenameNgramEnabled;
         this.attachmentFilenameNgramHeuristicEnabled = attachmentFilenameNgramHeuristicEnabled;
         this.bodyLanguage = bodyLanguage;
+        this.dateBasedDecayEnabled = dateBasedDecayEnabled;
     }
 
     public boolean subjectNgramEnabled() {
@@ -146,6 +159,10 @@ public class TmailOpenSearchMailboxConfiguration {
         return bodyLanguage.orElse(STANDARD_ANALYZER);
     }
 
+    public boolean dateBasedDecayEnabled() {
+        return dateBasedDecayEnabled;
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof TmailOpenSearchMailboxConfiguration) {
@@ -155,7 +172,8 @@ public class TmailOpenSearchMailboxConfiguration {
                 && Objects.equals(this.subjectNgramHeuristicEnabled, that.subjectNgramHeuristicEnabled)
                 && Objects.equals(this.attachmentFilenameNgramEnabled, that.attachmentFilenameNgramEnabled)
                 && Objects.equals(this.attachmentFilenameNgramHeuristicEnabled, that.attachmentFilenameNgramHeuristicEnabled)
-                && Objects.equals(this.bodyLanguage, that.bodyLanguage);
+                && Objects.equals(this.bodyLanguage, that.bodyLanguage)
+                && Objects.equals(this.dateBasedDecayEnabled, that.dateBasedDecayEnabled);
         }
         return false;
     }
@@ -163,6 +181,6 @@ public class TmailOpenSearchMailboxConfiguration {
     @Override
     public final int hashCode() {
         return Objects.hash(subjectNgramEnabled, subjectNgramHeuristicEnabled, attachmentFilenameNgramEnabled,
-            attachmentFilenameNgramHeuristicEnabled, bodyLanguage);
+            attachmentFilenameNgramHeuristicEnabled, bodyLanguage, dateBasedDecayEnabled);
     }
 }

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxMappingModule.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxMappingModule.java
@@ -32,6 +32,7 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.mailbox.opensearch.MailboxMappingFactory;
 import org.apache.james.mailbox.opensearch.query.CriterionConverter;
+import org.apache.james.mailbox.opensearch.query.QueryConverter;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,9 @@ public class TmailOpenSearchMailboxMappingModule extends AbstractModule {
 
         bind(TmailCriterionConverter.class).in(Scopes.SINGLETON);
         bind(CriterionConverter.class).to(TmailCriterionConverter.class);
+
+        bind(TmailQueryConverter.class).in(Scopes.SINGLETON);
+        bind(QueryConverter.class).to(TmailQueryConverter.class);
     }
 
     @Provides

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
@@ -1,0 +1,75 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *                                                                  *
+ ********************************************************************/
+
+package com.linagora.tmail.mailbox.opensearch;
+
+import java.util.Collection;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.SearchQuery;
+import org.apache.james.mailbox.opensearch.json.JsonMessageConstants;
+import org.apache.james.mailbox.opensearch.query.CriterionConverter;
+import org.apache.james.mailbox.opensearch.query.QueryConverter;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.query_dsl.DecayFunction;
+import org.opensearch.client.opensearch._types.query_dsl.DecayPlacement;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScore;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class TmailQueryConverter extends QueryConverter {
+    private final boolean dateBasedDecayEnabled;
+
+    @Inject
+    public TmailQueryConverter(CriterionConverter criterionConverter,
+                               TmailOpenSearchMailboxConfiguration tmailConfiguration) {
+        super(criterionConverter);
+        this.dateBasedDecayEnabled = tmailConfiguration.dateBasedDecayEnabled();
+    }
+
+    @Override
+    public Query from(Collection<MailboxId> mailboxIds, SearchQuery query) {
+        Query baseQuery = super.from(mailboxIds, query);
+        if (dateBasedDecayEnabled && query.getSorts().isEmpty()) {
+            return wrapWithDateDecay(baseQuery);
+        }
+        return baseQuery;
+    }
+
+    private Query wrapWithDateDecay(Query baseQuery) {
+        FunctionScore dateDecay = new FunctionScore.Builder()
+            .gauss(new DecayFunction.Builder()
+                .field(JsonMessageConstants.DATE)
+                .placement(new DecayPlacement.Builder()
+                    .origin(JsonData.of("now"))
+                    .scale(JsonData.of("365d"))
+                    .offset(JsonData.of("30d"))
+                    .decay(0.5)
+                    .build())
+                .build())
+            .build();
+        return new FunctionScoreQuery.Builder()
+            .query(baseQuery)
+            .functions(dateDecay)
+            .build()
+            .toQuery();
+    }
+}

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
@@ -19,8 +19,6 @@
 
 package com.linagora.tmail.mailbox.opensearch;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.Collection;
 
 import jakarta.inject.Inject;
@@ -33,18 +31,25 @@ import org.apache.james.mailbox.opensearch.query.QueryConverter;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.query_dsl.DecayFunction;
 import org.opensearch.client.opensearch._types.query_dsl.DecayPlacement;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionBoostMode;
 import org.opensearch.client.opensearch._types.query_dsl.FunctionScore;
 import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 
 public class TmailQueryConverter extends QueryConverter {
     private final boolean dateBasedDecayEnabled;
+    private final String decayScale;
+    private final double decayFactor;
+    private final FunctionBoostMode decayBoostMode;
 
     @Inject
     public TmailQueryConverter(CriterionConverter criterionConverter,
                                TmailOpenSearchMailboxConfiguration tmailConfiguration) {
         super(criterionConverter);
         this.dateBasedDecayEnabled = tmailConfiguration.dateBasedDecayEnabled();
+        this.decayScale = tmailConfiguration.decayScale();
+        this.decayFactor = tmailConfiguration.decayFactor();
+        this.decayBoostMode = tmailConfiguration.decayBoostMode();
     }
 
     @Override
@@ -61,16 +66,17 @@ public class TmailQueryConverter extends QueryConverter {
             .gauss(new DecayFunction.Builder()
                 .field(JsonMessageConstants.DATE)
                 .placement(new DecayPlacement.Builder()
-                    .origin(JsonData.of(LocalDate.now(ZoneOffset.UTC).toString()))
-                    .scale(JsonData.of("365d"))
+                    .origin(JsonData.of("now/d"))
+                    .scale(JsonData.of(decayScale))
                     .offset(JsonData.of("30d"))
-                    .decay(0.5)
+                    .decay(decayFactor)
                     .build())
                 .build())
             .build();
         return new FunctionScoreQuery.Builder()
             .query(baseQuery)
             .functions(dateDecay)
+            .boostMode(decayBoostMode)
             .build()
             .toQuery();
     }

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailQueryConverter.java
@@ -19,6 +19,8 @@
 
 package com.linagora.tmail.mailbox.opensearch;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collection;
 
 import jakarta.inject.Inject;
@@ -59,7 +61,7 @@ public class TmailQueryConverter extends QueryConverter {
             .gauss(new DecayFunction.Builder()
                 .field(JsonMessageConstants.DATE)
                 .placement(new DecayPlacement.Builder()
-                    .origin(JsonData.of("now"))
+                    .origin(JsonData.of(LocalDate.now(ZoneOffset.UTC).toString()))
                     .scale(JsonData.of("365d"))
                     .offset(JsonData.of("30d"))
                     .decay(0.5)

--- a/tmail-backend/mailbox/opensearch/src/test/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchIntegrationTest.java
+++ b/tmail-backend/mailbox/opensearch/src/test/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchIntegrationTest.java
@@ -38,10 +38,14 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.james.backends.opensearch.DockerOpenSearchExtension;
@@ -71,6 +75,7 @@ import org.apache.james.mailbox.opensearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.opensearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.opensearch.OpenSearchMailboxConfiguration;
 import org.apache.james.mailbox.opensearch.events.OpenSearchListeningMessageSearchIndex;
+import org.apache.james.mailbox.opensearch.json.JsonMessageConstants;
 import org.apache.james.mailbox.opensearch.json.MessageToOpenSearchJson;
 import org.apache.james.mailbox.opensearch.query.QueryConverter;
 import org.apache.james.mailbox.opensearch.search.OpenSearchSearcher;
@@ -110,6 +115,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.opensearch.client.json.JsonData;
 import reactor.core.publisher.Flux;
 
 public class TmailOpenSearchIntegrationTest extends AbstractMessageSearchIndexTest {
@@ -957,6 +963,57 @@ public class TmailOpenSearchIntegrationTest extends AbstractMessageSearchIndexTe
                 .of()
                 .setBody("testmail", StandardCharsets.UTF_8)
                 .addField(new RawField("Subject", subject)));
+    }
+
+    @Test
+    void dateDecayShouldFavorRecentMessagesWhenEnabled() throws Exception {
+        MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "dateDecayTestMailbox");
+        MailboxId mailboxId = storeMailboxManager.createMailbox(mailboxPath, session).get();
+        MessageManager messageManager = storeMailboxManager.getMailbox(mailboxId, session);
+
+        String uniqueBody = "unique_decay_test_body_" + UUID.randomUUID();
+
+        ComposedMessageId oldMessage = messageManager.appendMessage(
+            MessageManager.AppendCommand.builder()
+                .withInternalDate(Date.from(Instant.now().minus(3 * 365, ChronoUnit.DAYS)))
+                .build(Message.Builder.of().setBody(uniqueBody, StandardCharsets.UTF_8)),
+            session).getId();
+
+        ComposedMessageId recentMessage = messageManager.appendMessage(
+            MessageManager.AppendCommand.from(
+                Message.Builder.of().setBody(uniqueBody, StandardCharsets.UTF_8)),
+            session).getId();
+
+        awaitMessageCount(List.of(mailboxId), SearchQuery.matchAll(), 2);
+
+        TmailOpenSearchMailboxConfiguration decayConfig = TmailOpenSearchMailboxConfiguration.builder()
+            .dateBasedDecayEnabled(true)
+            .build();
+        TmailQueryConverter decayQueryConverter = new TmailQueryConverter(
+            new TmailCriterionConverter(openSearchMailboxConfiguration(), decayConfig),
+            decayConfig);
+        OpenSearchSearcher decaySearcher = new OpenSearchSearcher(
+            client, decayQueryConverter, 10,
+            readAliasName, new MailboxIdRoutingKeyFactory());
+
+        List<MessageId> results = decaySearcher.search(
+                ImmutableList.of(mailboxId),
+                SearchQuery.of(SearchQuery.bodyContains(uniqueBody)),
+                Optional.empty(),
+                ImmutableList.of(JsonMessageConstants.MESSAGE_ID),
+                false)
+            .<MessageId>handle((hit, sink) -> {
+                JsonData messageId = hit.fields().get(JsonMessageConstants.MESSAGE_ID);
+                if (messageId != null) {
+                    sink.next(messageIdFactory.fromString(messageId.toJson().asJsonArray().getString(0)));
+                }
+            })
+            .collectList()
+            .block();
+
+        assertThat(results).containsExactly(
+            recentMessage.getMessageId(),
+            oldMessage.getMessageId());
     }
 
     protected void awaitForOpenSearch(Query query, long totalHits) {

--- a/tmail-backend/mailbox/opensearch/src/test/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchIntegrationTest.java
+++ b/tmail-backend/mailbox/opensearch/src/test/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchIntegrationTest.java
@@ -998,7 +998,7 @@ public class TmailOpenSearchIntegrationTest extends AbstractMessageSearchIndexTe
 
         List<MessageId> results = decaySearcher.search(
                 ImmutableList.of(mailboxId),
-                SearchQuery.of(SearchQuery.bodyContains(uniqueBody)),
+                SearchQuery.builder().andCriteria(SearchQuery.bodyContains(uniqueBody)).build(),
                 Optional.empty(),
                 ImmutableList.of(JsonMessageConstants.MESSAGE_ID),
                 false)


### PR DESCRIPTION
…alize older matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional date-based Gaussian decay for relevance searches to favor newer messages (30‑day offset; configurable scale, factor, and boost mode; default ~0.5 decay at one year).

* **Documentation**
  * Expanded OpenSearch configuration docs with new date-decay settings, defaults, and usage examples.

* **Tests**
  * Added integration test confirming recent messages rank higher when date-decay is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->