### PR TITLE
[ENHANCEMENT] Configurable language for on-prem deployments

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/opensearch.adoc
@@ -42,4 +42,11 @@ Specified to TMail backend, we can configure the following configurations in the
 | attachment.filename.ngram.heuristic.enabled
 | Allows a heuristic search when ngram is enabled. It will do the ngram search for attachment filename only if the number of characters in the search is less than 6 characters. If disabled there is no limit (but could have a significant performance cost). Optional. Defaults to false.
 
+| opensearch.mailbox.body.language
+| Language analyzer to use for message body and attachment text content indexing (`text_body`, `html_body`, `attachments.text_content`).
+Enables stemming and language-specific stopwords for the configured language, improving search recall for morphologically rich languages.
+Accepted values: any built-in OpenSearch language analyzer name — `arabic`, `armenian`, `basque`, `bengali`, `brazilian`, `bulgarian`, `catalan`, `cjk`, `czech`, `danish`, `dutch`, `english`, `estonian`, `finnish`, `french`, `galician`, `german`, `greek`, `hindi`, `hungarian`, `indonesian`, `irish`, `italian`, `latvian`, `lithuanian`, `norwegian`, `persian`, `portuguese`, `romanian`, `russian`, `sorani`, `spanish`, `swedish`, `thai`, `turkish`.
+Optional. Defaults to `standard` (no stemming, language-agnostic).
+*Changing this setting requires a full reindex of all mailboxes.*
+
 |===

--- a/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/opensearch.properties
@@ -93,3 +93,10 @@ opensearch.indexAttachments=true
 # It will do the ngram search for attachment filename only if the number of characters in the search is less than 6 characters
 # If disabled there is no limit (but could have a significant performance cost)
 # attachment.filename.ngram.heuristic.enabled=false
+
+# Optional. Language analyzer for message body and attachment content indexing.
+# Enables stemming and language-specific stopwords, improving recall for the configured language.
+# Accepted values: any OpenSearch built-in language analyzer (e.g. french, english, german, spanish...).
+# Defaults to `standard` (language-agnostic, no stemming).
+# WARNING: changing this setting requires a full reindex of all mailboxes.
+# opensearch.mailbox.body.language=french

--- a/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/distributed/opensearch.properties
@@ -119,3 +119,10 @@ opensearch.indexAttachments=false
 # It will do the ngram search for attachment filename only if the number of characters in the search is less than 6 characters
 # If disabled there is no limit (but could have a significant performance cost)
 # attachment.filename.ngram.heuristic.enabled=false
+
+# Optional. Language analyzer for message body and attachment content indexing.
+# Enables stemming and language-specific stopwords, improving recall for the configured language.
+# Accepted values: any OpenSearch built-in language analyzer (e.g. french, english, german, spanish...).
+# Defaults to `standard` (language-agnostic, no stemming).
+# WARNING: changing this setting requires a full reindex of all mailboxes.
+# opensearch.mailbox.body.language=french

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailMailboxMappingFactory.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailMailboxMappingFactory.java
@@ -300,10 +300,10 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                 .keyword(new KeywordProperty.Builder().build())
                 .build())
             .put(JsonMessageConstants.TEXT_BODY, new Property.Builder()
-                .text(new TextProperty.Builder().analyzer(STANDARD).build())
+                .text(new TextProperty.Builder().analyzer(tmailOpenSearchMailboxConfiguration.bodyAnalyzer()).build())
                 .build())
             .put(JsonMessageConstants.HTML_BODY, new Property.Builder()
-                .text(new TextProperty.Builder().analyzer(STANDARD).build())
+                .text(new TextProperty.Builder().analyzer(tmailOpenSearchMailboxConfiguration.bodyAnalyzer()).build())
                 .build())
             .put(JsonMessageConstants.HAS_ATTACHMENT, new Property.Builder()
                 .boolean_(new BooleanProperty.Builder().build())
@@ -313,7 +313,7 @@ public class TmailMailboxMappingFactory implements MailboxMappingFactory {
                     .properties(ImmutableMap.of(
                         JsonMessageConstants.Attachment.FILENAME, buildAttachmentFilenameProperty(),
                         JsonMessageConstants.Attachment.TEXT_CONTENT, new Property.Builder()
-                            .text(new TextProperty.Builder().analyzer(STANDARD).build())
+                            .text(new TextProperty.Builder().analyzer(tmailOpenSearchMailboxConfiguration.bodyAnalyzer()).build())
                             .build(),
                         JsonMessageConstants.Attachment.MEDIA_TYPE, new Property.Builder()
                             .keyword(new KeywordProperty.Builder().build())

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
@@ -37,12 +37,14 @@ public class TmailOpenSearchMailboxConfiguration {
         private Optional<Boolean> subjectNgramHeuristicEnabled;
         private Optional<Boolean> attachmentFilenameNgramEnabled;
         private Optional<Boolean> attachmentFilenameNgramHeuristicEnabled;
+        private Optional<String> bodyLanguage;
 
         Builder() {
             subjectNgramEnabled = Optional.empty();
             subjectNgramHeuristicEnabled = Optional.empty();
             attachmentFilenameNgramEnabled = Optional.empty();
             attachmentFilenameNgramHeuristicEnabled = Optional.empty();
+            bodyLanguage = Optional.empty();
         }
 
         public Builder subjectNgramEnabled(Boolean subjectNgramEnabled) {
@@ -65,12 +67,18 @@ public class TmailOpenSearchMailboxConfiguration {
             return this;
         }
 
+        public Builder bodyLanguage(String bodyLanguage) {
+            this.bodyLanguage = Optional.ofNullable(bodyLanguage);
+            return this;
+        }
+
         public TmailOpenSearchMailboxConfiguration build() {
             return new TmailOpenSearchMailboxConfiguration(
                 subjectNgramEnabled.orElse(DEFAULT_SUBJECT_NGRAM_DISABLED),
                 subjectNgramHeuristicEnabled.orElse(DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED),
                 attachmentFilenameNgramEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED),
-                attachmentFilenameNgramHeuristicEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED)
+                attachmentFilenameNgramHeuristicEnabled.orElse(DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED),
+                bodyLanguage
             );
         }
     }
@@ -85,6 +93,7 @@ public class TmailOpenSearchMailboxConfiguration {
             .subjectNgramHeuristicEnabled(configuration.getBoolean(SUBJECT_NGRAM_HEURISTIC_ENABLED, null))
             .attachmentFilenameNgramEnabled(configuration.getBoolean(ATTACHMENT_FILENAME_NGRAM_ENABLED, null))
             .attachmentFilenameNgramHeuristicEnabled(configuration.getBoolean(ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED, null))
+            .bodyLanguage(configuration.getString(BODY_LANGUAGE, null))
             .build();
     }
 
@@ -92,6 +101,7 @@ public class TmailOpenSearchMailboxConfiguration {
     private static final String SUBJECT_NGRAM_HEURISTIC_ENABLED = "subject.ngram.heuristic.enabled";
     private static final String ATTACHMENT_FILENAME_NGRAM_ENABLED = "attachment.filename.ngram.enabled";
     private static final String ATTACHMENT_FILENAME_NGRAM_HEURISTIC_ENABLED = "attachment.filename.ngram.heuristic.enabled";
+    public static final String BODY_LANGUAGE = "opensearch.mailbox.body.language";
     private static final boolean DEFAULT_SUBJECT_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED = false;
@@ -103,13 +113,16 @@ public class TmailOpenSearchMailboxConfiguration {
     private final boolean subjectNgramHeuristicEnabled;
     private final boolean attachmentFilenameNgramEnabled;
     private final boolean attachmentFilenameNgramHeuristicEnabled;
+    private final Optional<String> bodyLanguage;
 
     private TmailOpenSearchMailboxConfiguration(boolean subjectNgramEnabled, boolean subjectNgramHeuristicEnabled,
-                                                boolean attachmentFilenameNgramEnabled, boolean attachmentFilenameNgramHeuristicEnabled) {
+                                                boolean attachmentFilenameNgramEnabled, boolean attachmentFilenameNgramHeuristicEnabled,
+                                                Optional<String> bodyLanguage) {
         this.subjectNgramEnabled = subjectNgramEnabled;
         this.subjectNgramHeuristicEnabled = subjectNgramHeuristicEnabled;
         this.attachmentFilenameNgramEnabled = attachmentFilenameNgramEnabled;
         this.attachmentFilenameNgramHeuristicEnabled = attachmentFilenameNgramHeuristicEnabled;
+        this.bodyLanguage = bodyLanguage;
     }
 
     public boolean subjectNgramEnabled() {
@@ -128,6 +141,12 @@ public class TmailOpenSearchMailboxConfiguration {
         return attachmentFilenameNgramHeuristicEnabled;
     }
 
+    public String bodyAnalyzer() {
+        return bodyLanguage.orElse(STANDARD_ANALYZER);
+    }
+
+    private static final String STANDARD_ANALYZER = "standard";
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof TmailOpenSearchMailboxConfiguration) {
@@ -136,13 +155,15 @@ public class TmailOpenSearchMailboxConfiguration {
             return Objects.equals(this.subjectNgramEnabled, that.subjectNgramEnabled)
                 && Objects.equals(this.subjectNgramHeuristicEnabled, that.subjectNgramHeuristicEnabled)
                 && Objects.equals(this.attachmentFilenameNgramEnabled, that.attachmentFilenameNgramEnabled)
-                && Objects.equals(this.attachmentFilenameNgramHeuristicEnabled, that.attachmentFilenameNgramHeuristicEnabled);
+                && Objects.equals(this.attachmentFilenameNgramHeuristicEnabled, that.attachmentFilenameNgramHeuristicEnabled)
+                && Objects.equals(this.bodyLanguage, that.bodyLanguage);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(subjectNgramEnabled, subjectNgramHeuristicEnabled, attachmentFilenameNgramEnabled, attachmentFilenameNgramHeuristicEnabled);
+        return Objects.hash(subjectNgramEnabled, subjectNgramHeuristicEnabled, attachmentFilenameNgramEnabled,
+            attachmentFilenameNgramHeuristicEnabled, bodyLanguage);
     }
 }

--- a/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
+++ b/tmail-backend/mailbox/opensearch/src/main/java/com/linagora/tmail/mailbox/opensearch/TmailOpenSearchMailboxConfiguration.java
@@ -106,6 +106,7 @@ public class TmailOpenSearchMailboxConfiguration {
     private static final boolean DEFAULT_SUBJECT_NGRAM_HEURISTIC_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_DISABLED = false;
     private static final boolean DEFAULT_ATTACHMENT_FILENAME_NGRAM_HEURISTIC_DISABLED = false;
+    private static final String STANDARD_ANALYZER = "standard";
 
     public static final TmailOpenSearchMailboxConfiguration DEFAULT_CONFIGURATION = builder().build();
 
@@ -144,8 +145,6 @@ public class TmailOpenSearchMailboxConfiguration {
     public String bodyAnalyzer() {
         return bodyLanguage.orElse(STANDARD_ANALYZER);
     }
-
-    private static final String STANDARD_ANALYZER = "standard";
 
     @Override
     public final boolean equals(Object o) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable language analyzer support for OpenSearch indexing of message body and attachment content. Users can now select their preferred analyzer through a new optional configuration property, which defaults to the standard analyzer. Changing this setting requires a full reindex of all mailboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->