### PR TITLE
ISSUE-2407 [FIX] Naming strategy isolation for Redis Event bus notification path

### DIFF
--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RabbitMQAndRedisEventBus.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RabbitMQAndRedisEventBus.java
@@ -254,8 +254,8 @@ public class RabbitMQAndRedisEventBus implements EventBus, Startable {
             redisSetReactiveCommands, redisEventBusConfiguration);
         groupRegistrationHandler = new AggregatedTmailGroupRegistrationHandler(namingStrategies, eventSerializer, channelPool,
             sender, receiverProvider, eventDeadLetters, listenerExecutor, configurations);
-        RedisKeyEventDispatcher redisKeyEventDispatcher = new RedisKeyEventDispatcher(eventBusId, eventSerializer, redisPublisher,
-            redisSetReactiveCommands, redisEventBusConfiguration);
+        RedisKeyEventDispatcher redisKeyEventDispatcher = new RedisKeyEventDispatcher(eventBusId, namingStrategy, eventSerializer,
+            redisPublisher, redisSetReactiveCommands, redisEventBusConfiguration);
         TmailGroupEventDispatcher groupEventDispatcher = new AggregatedTmailGroupEventDispatcher(namingStrategies, eventBusId,
             sender, eventDeadLetters, configurations.rabbitMQConfiguration());
         eventDispatcher = new TMailEventDispatcher(eventSerializer, groupRegistrationHandler, groupEventDispatcher,

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
@@ -47,9 +47,14 @@ public class RedisKeyEventDispatcher {
     static EventBusName baseEventBusName(NamingStrategy namingStrategy, EventBusId eventBusId) {
         String registrationChannel = namingStrategy.queueName(eventBusId).asString();
         String eventBusIdAsString = eventBusId.asString();
+        String expectedSuffix = EVENTBUS_CHANNEL_SEPARATOR + eventBusIdAsString;
 
-        return new EventBusName(registrationChannel.substring(0,
-            registrationChannel.length() - EVENTBUS_CHANNEL_SEPARATOR.length() - eventBusIdAsString.length()));
+        if (registrationChannel.length() <= expectedSuffix.length() || !registrationChannel.endsWith(expectedSuffix)) {
+            throw new IllegalArgumentException("""
+                Registration channel %s should end with %s""".formatted(registrationChannel, expectedSuffix));
+        }
+
+        return new EventBusName(registrationChannel.substring(0, registrationChannel.length() - expectedSuffix.length()));
     }
 
     private final EventSerializer eventSerializer;
@@ -134,6 +139,6 @@ public class RedisKeyEventDispatcher {
     }
 
     private boolean targetSameEventBus(String channel) {
-        return channel.contains(baseEventBusName);
+        return channel.startsWith(baseEventBusName + EVENTBUS_CHANNEL_SEPARATOR);
     }
 }

--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyEventDispatcher.java
@@ -37,19 +37,30 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class RedisKeyEventDispatcher {
+    private static final String EVENTBUS_CHANNEL_SEPARATOR = "-eventbus-";
 
     private static final Predicate<? super Throwable> REDIS_ERROR_PREDICATE =
         throwable -> throwable instanceof RedisException || throwable instanceof TimeoutException;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisKeyEventDispatcher.class);
 
+    static EventBusName baseEventBusName(NamingStrategy namingStrategy, EventBusId eventBusId) {
+        String registrationChannel = namingStrategy.queueName(eventBusId).asString();
+        String eventBusIdAsString = eventBusId.asString();
+
+        return new EventBusName(registrationChannel.substring(0,
+            registrationChannel.length() - EVENTBUS_CHANNEL_SEPARATOR.length() - eventBusIdAsString.length()));
+    }
+
     private final EventSerializer eventSerializer;
     private final RedisPubSubReactiveCommands<String, String> redisPublisher;
     private final RedisSetReactiveCommands<String, String> redisSetReactiveCommands;
     private final EventBusId eventBusId;
     private final RedisEventBusConfiguration redisEventBusConfiguration;
+    private final String baseEventBusName;
 
     public RedisKeyEventDispatcher(EventBusId eventBusId,
+                                   NamingStrategy namingStrategy,
                                    EventSerializer eventSerializer,
                                    RedisPubSubReactiveCommands<String, String> redisPublisher,
                                    RedisSetReactiveCommands<String, String> redisSetReactiveCommands,
@@ -59,6 +70,7 @@ public class RedisKeyEventDispatcher {
         this.redisSetReactiveCommands = redisSetReactiveCommands;
         this.eventBusId = eventBusId;
         this.redisEventBusConfiguration = redisEventBusConfiguration;
+        this.baseEventBusName = baseEventBusName(namingStrategy, eventBusId).value();
     }
 
     public Mono<Void> dispatch(Event event, Set<RegistrationKey> keys) {
@@ -105,6 +117,7 @@ public class RedisKeyEventDispatcher {
         return Flux.fromIterable(routingKeys)
             .flatMap(routingKey ->
                 getTargetChannels(routingKey)
+                    .filter(this::targetSameEventBus) // e.g. tmail notification should not be published to jmap event bus
                     .flatMap(channel -> redisPublisher.publish(channel, KeyChannelMessage.from(eventBusId, routingKey, eventAsJson).serialize()))
                     .timeout(redisEventBusConfiguration.durationTimeout())
                     .onErrorResume(REDIS_ERROR_PREDICATE.and(e -> redisEventBusConfiguration.failureIgnore()),
@@ -118,5 +131,9 @@ public class RedisKeyEventDispatcher {
 
     private Flux<String> getTargetChannels(RoutingKey routingKey) {
         return redisSetReactiveCommands.smembers(routingKey.asString());
+    }
+
+    private boolean targetSameEventBus(String channel) {
+        return channel.contains(baseEventBusName);
     }
 }

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusContractTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RabbitMQAndRedisEventBusContractTest.java
@@ -61,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -201,7 +202,15 @@ abstract class RabbitMQAndRedisEventBusContractTest implements GroupContract.Sin
         return newEventBus(List.of(namingStrategy), sender, receiverProvider);
     }
 
+    private RabbitMQAndRedisEventBus newEventBus(NamingStrategy namingStrategy, Sender sender, ReceiverProvider receiverProvider, EventSerializer eventSerializer) throws Exception {
+        return newEventBus(List.of(namingStrategy), sender, receiverProvider, eventSerializer);
+    }
+
     private RabbitMQAndRedisEventBus newEventBus(List<NamingStrategy> namingStrategies, Sender sender, ReceiverProvider receiverProvider) throws Exception {
+        return newEventBus(namingStrategies, sender, receiverProvider, eventSerializer);
+    }
+
+    private RabbitMQAndRedisEventBus newEventBus(List<NamingStrategy> namingStrategies, Sender sender, ReceiverProvider receiverProvider, EventSerializer eventSerializer) throws Exception {
         return new RabbitMQAndRedisEventBus(namingStrategies, sender, receiverProvider, eventSerializer, routingKeyConverter,
             memoryEventDeadLetters, new RecordingMetricFactory(),
             rabbitMQExtension.getRabbitChannelPool(), EventBusId.random(),
@@ -803,10 +812,15 @@ abstract class RabbitMQAndRedisEventBusContractTest implements GroupContract.Sin
     @Nested
     class IsolationTest {
         private RabbitMQAndRedisEventBus otherEventBus;
+        private FailingDeserializationEventSerializer otherEventSerializer;
 
         @BeforeEach
         void beforeEach() throws Exception {
-            otherEventBus = newEventBus(new DefaultNamingStrategy(new EventBusName("other")), rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider());
+            otherEventSerializer = new FailingDeserializationEventSerializer();
+            otherEventBus = newEventBus(new DefaultNamingStrategy(new EventBusName("other")),
+                rabbitMQExtension.getSender(),
+                rabbitMQExtension.getReceiverProvider(),
+                otherEventSerializer);
             otherEventBus.start();
         }
 
@@ -833,18 +847,72 @@ abstract class RabbitMQAndRedisEventBusContractTest implements GroupContract.Sin
 
         @Test
         void eventBusPubSubWithDistinctNamingStrategiesShouldBeIsolated() throws Exception {
-            EventCollector listener = new EventCollector();
-            EventCollector otherListener = new EventCollector();
-            eventBus.register(listener, KEY_1);
-            otherEventBus.register(otherListener, KEY_1);
+            // Register the listener on eventBus, using KEY_1 registration key
+            CountingAsyncEventListener listener = new CountingAsyncEventListener();
+            Mono.from(eventBus.register(listener, KEY_1)).block();
 
+            // Another event bus registers a listener for the same AccountId-like key.
+            EventCollector otherListener = new EventCollector();
+            Mono.from(otherEventBus.register(otherListener, KEY_1)).block();
+
+            // The source bus dispatches an event with that key, using its own serializer.
             eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
-            TimeUnit.SECONDS.sleep(1);
+            boolean eventReceived = listener.awaitEvent();
+            boolean otherDeserializationAttempt = otherEventSerializer.awaitDeserializationAttempt();
+
+            // The other event bus must not receive nor deserialize source bus events.
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(listener.getEvents()).hasSize(1);
+                softly.assertThat(eventReceived).isTrue();
+                softly.assertThat(otherDeserializationAttempt).isFalse();
                 softly.assertThat(otherListener.getEvents()).isEmpty();
+                softly.assertThat(otherEventSerializer.deserializationAttempts()).isZero();
             });
+        }
+    }
+
+    private static class CountingAsyncEventListener implements EventListener {
+        private final CountDownLatch eventLatch = new CountDownLatch(1);
+
+        @Override
+        public ExecutionMode getExecutionMode() {
+            return ExecutionMode.ASYNCHRONOUS;
+        }
+
+        @Override
+        public void event(Event event) {
+            eventLatch.countDown();
+        }
+
+        boolean awaitEvent() throws InterruptedException {
+            return eventLatch.await(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class FailingDeserializationEventSerializer extends TestEventSerializer {
+        private final AtomicInteger deserializationAttempts = new AtomicInteger();
+        private final CountDownLatch deserializationAttemptLatch = new CountDownLatch(1);
+
+        @Override
+        public DeserializationResult asEvent(String serialized) {
+            deserializationAttempts.incrementAndGet();
+            deserializationAttemptLatch.countDown();
+            return new DeserializationResult.Failure("Cannot deserialize event from another event bus");
+        }
+
+        @Override
+        public DeserializationResult asEvents(String serialized) {
+            deserializationAttempts.incrementAndGet();
+            deserializationAttemptLatch.countDown();
+            return new DeserializationResult.Failure("Cannot deserialize events from another event bus");
+        }
+
+        int deserializationAttempts() {
+            return deserializationAttempts.get();
+        }
+
+        boolean awaitDeserializationAttempt() throws InterruptedException {
+            return deserializationAttemptLatch.await(1, TimeUnit.SECONDS);
         }
     }
 

--- a/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RedisKeyEventDispatcherTest.java
+++ b/tmail-backend/event-bus-redis/src/test/java/org/apache/james/events/RedisKeyEventDispatcherTest.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ *******************************************************************/
+
+package org.apache.james.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RedisKeyEventDispatcherTest {
+    private static final EventBusId EVENT_BUS_ID = EventBusId.of("00000000-0000-0000-0000-000000000123");
+
+    @Test
+    void baseEventBusNameShouldBeExtractedFromDefaultNamingStrategy() {
+        EventBusName baseEventBusName = RedisKeyEventDispatcher.baseEventBusName(
+            new DefaultNamingStrategy(new EventBusName("tmailEvent")),
+            EVENT_BUS_ID);
+
+        assertThat(baseEventBusName).isEqualTo(new EventBusName("tmailEvent"));
+    }
+
+    @Test
+    void baseEventBusNameShouldBeExtractedFromPartitionAwareNamingStrategy() {
+        EventBusName baseEventBusName = RedisKeyEventDispatcher.baseEventBusName(
+            new PartitionAwareNamingStrategy(new EventBusName("mailboxEvent"), 1),
+            EVENT_BUS_ID);
+
+        assertThat(baseEventBusName).isEqualTo(new EventBusName("mailboxEvent"));
+    }
+}


### PR DESCRIPTION
resolve #2407

Before, with the same Registration key, if Tmail event bus dispatches a notification, it reaches both tmail event bus and jmap event bus's Redis pub/sub channel(s). Thus JMAP event bus attempts to deserialize the Label event, which it can't.

Now, RedisKeyEventDispatcher would be event bus aware: if tmail eventBus dispatches the notification, RedisKeyEventDispatcher would dispatch the notification only to tmail event bus channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event buses are now properly isolated when using distinct naming strategies, preventing events from being incorrectly dispatched across different event bus instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->