### PR TITLE
[Refactoring] Should be able to configure queues names for saas subsc…

### DIFF
--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumer.java
@@ -54,10 +54,12 @@ import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
 
 public class SaaSDomainSubscriptionConsumer implements Closeable, Startable {
+    public record DomainSubscriptionConsumerConfig(String queue, String deadLetterQueue) {
+        public static DomainSubscriptionConsumerConfig DEFAULT = new DomainSubscriptionConsumerConfig("tmail-saas-domain-subscription", "tmail-saas-domain-subscription-dead-letter");
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SaaSDomainSubscriptionConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
-    public static final String SAAS_DOMAIN_SUBSCRIPTION_QUEUE = "tmail-saas-domain-subscription";
-    public static final String SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE = "tmail-saas-domain-subscription-dead-letter";
 
     private final ReceiverProvider receiverProvider;
     private final Sender sender;
@@ -65,19 +67,22 @@ public class SaaSDomainSubscriptionConsumer implements Closeable, Startable {
     private final TWPCommonRabbitMQConfiguration twpCommonRabbitMQConfiguration;
     private final SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration;
     private final SaaSMessageHandler saasDomainSubscriptionHandler;
+    private final DomainSubscriptionConsumerConfig consumerConfig;
     private Disposable consumeSubscriptionDisposable;
 
     public SaaSDomainSubscriptionConsumer(@Named(TWP_INJECTION_KEY) ReactorRabbitMQChannelPool channelPool,
                                           @Named(TWP_INJECTION_KEY) RabbitMQConfiguration rabbitMQConfiguration,
                                           TWPCommonRabbitMQConfiguration twpCommonRabbitMQConfiguration,
                                           SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration,
-                                          SaaSMessageHandler saasDomainSubscriptionHandler) {
+                                          SaaSMessageHandler saasDomainSubscriptionHandler,
+                                          DomainSubscriptionConsumerConfig consumerConfig) {
         this.receiverProvider = channelPool::createReceiver;
         this.sender = channelPool.getSender();
         this.rabbitMQConfiguration = rabbitMQConfiguration;
         this.twpCommonRabbitMQConfiguration = twpCommonRabbitMQConfiguration;
         this.saasSubscriptionRabbitMQConfiguration = saasSubscriptionRabbitMQConfiguration;
         this.saasDomainSubscriptionHandler = saasDomainSubscriptionHandler;
+        this.consumerConfig = consumerConfig;
     }
 
     public void init() {
@@ -85,36 +90,40 @@ public class SaaSDomainSubscriptionConsumer implements Closeable, Startable {
         startConsumer();
     }
 
+    protected DomainSubscriptionConsumerConfig getConsumerConfig() {
+        return consumerConfig;
+    }
+
     public void declareExchangeAndQueue() {
         Flux.concat(
                 declareExchange(saasSubscriptionRabbitMQConfiguration.exchange()),
                 declareExchange(saasSubscriptionRabbitMQConfiguration.configurationExchange()),
-                sender.declareExchange(ExchangeSpecification.exchange(SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE)
+                sender.declareExchange(ExchangeSpecification.exchange(consumerConfig.deadLetterQueue())
                     .durable(DURABLE).type(BuiltinExchangeType.FANOUT.getType())),
                 sender.declareQueue(QueueSpecification
-                    .queue(SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE)
+                    .queue(consumerConfig.deadLetterQueue())
                     .durable(DURABLE)
                     .arguments(queueArgumentSupplier()
                         .build())),
                 sender.bind(BindingSpecification.binding()
-                    .exchange(SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE)
-                    .queue(SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE)
+                    .exchange(consumerConfig.deadLetterQueue())
+                    .queue(consumerConfig.deadLetterQueue())
                     .routingKey("")),
                 sender.declareQueue(QueueSpecification
-                    .queue(SAAS_DOMAIN_SUBSCRIPTION_QUEUE)
+                    .queue(consumerConfig.queue())
                     .durable(DURABLE)
                     .arguments(queueArgumentSupplier()
-                        .deadLetter(SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE)
+                        .deadLetter(consumerConfig.deadLetterQueue())
                         .singleActiveConsumer()
                         .consumerTimeout(Duration.ofMinutes(10L).toMillis())
                         .build())),
                 sender.bind(BindingSpecification.binding()
                     .exchange(saasSubscriptionRabbitMQConfiguration.exchange())
-                    .queue(SAAS_DOMAIN_SUBSCRIPTION_QUEUE)
+                    .queue(consumerConfig.queue())
                     .routingKey(saasSubscriptionRabbitMQConfiguration.domainRoutingKey())),
                 sender.bind(BindingSpecification.binding()
                     .exchange(saasSubscriptionRabbitMQConfiguration.configurationExchange())
-                    .queue(SAAS_DOMAIN_SUBSCRIPTION_QUEUE)
+                    .queue(consumerConfig.queue())
                     .routingKey(saasSubscriptionRabbitMQConfiguration.domainConfigurationRoutingKey())))
             .then()
             .block();
@@ -149,7 +158,7 @@ public class SaaSDomainSubscriptionConsumer implements Closeable, Startable {
     }
 
     private Disposable consumeDomainSubscriptionQueue() {
-        return delivery(SAAS_DOMAIN_SUBSCRIPTION_QUEUE)
+        return delivery(consumerConfig.queue())
             .concatMap(delivery -> consumeDomainSubscriptionUpdate(delivery, delivery.getBody()))
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe();

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
@@ -54,10 +54,12 @@ import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
 
 public class SaaSSubscriptionConsumer implements Closeable, Startable {
+    public record SubscriptionConsumerConfig(String queue, String deadLetterQueue) {
+        public static SubscriptionConsumerConfig DEFAULT = new SubscriptionConsumerConfig("tmail-saas-subscription", "tmail-saas-subscription-dead-letter");
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SaaSSubscriptionConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
-    public static final String SAAS_SUBSCRIPTION_QUEUE = "tmail-saas-subscription";
-    public static final String SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE = "tmail-saas-subscription-dead-letter";
 
     private final ReceiverProvider receiverProvider;
     private final Sender sender;
@@ -65,23 +67,30 @@ public class SaaSSubscriptionConsumer implements Closeable, Startable {
     private final TWPCommonRabbitMQConfiguration twpCommonRabbitMQConfiguration;
     private final SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration;
     private final SaaSMessageHandler saasSubscriptionHandler;
+    private final SubscriptionConsumerConfig consumerConfig;
     private Disposable consumeSubscriptionDisposable;
 
     public SaaSSubscriptionConsumer(@Named(TWP_INJECTION_KEY) ReactorRabbitMQChannelPool channelPool,
                                     @Named(TWP_INJECTION_KEY) RabbitMQConfiguration rabbitMQConfiguration,
                                     TWPCommonRabbitMQConfiguration twpCommonRabbitMQConfiguration,
-                                    SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration, SaaSMessageHandler saasSubscriptionHandler) {
+                                    SaaSSubscriptionRabbitMQConfiguration saasSubscriptionRabbitMQConfiguration, SaaSMessageHandler saasSubscriptionHandler,
+                                    SubscriptionConsumerConfig consumerConfig) {
         this.receiverProvider = channelPool::createReceiver;
         this.sender = channelPool.getSender();
         this.rabbitMQConfiguration = rabbitMQConfiguration;
         this.twpCommonRabbitMQConfiguration = twpCommonRabbitMQConfiguration;
         this.saasSubscriptionRabbitMQConfiguration = saasSubscriptionRabbitMQConfiguration;
         this.saasSubscriptionHandler = saasSubscriptionHandler;
+        this.consumerConfig = consumerConfig;
     }
 
     public void init() {
-        declareExchangeAndQueue(saasSubscriptionRabbitMQConfiguration.exchange(), SAAS_SUBSCRIPTION_QUEUE, SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE);
+        declareExchangeAndQueue(saasSubscriptionRabbitMQConfiguration.exchange(), consumerConfig.queue(), consumerConfig.deadLetterQueue());
         startConsumer();
+    }
+
+    public SubscriptionConsumerConfig getConsumerConfig() {
+        return consumerConfig;
     }
 
     public void declareExchangeAndQueue(String exchange, String queue, String deadLetter) {
@@ -143,7 +152,7 @@ public class SaaSSubscriptionConsumer implements Closeable, Startable {
     }
 
     private Disposable consumeSubscriptionQueue() {
-        return delivery(SAAS_SUBSCRIPTION_QUEUE)
+        return delivery(consumerConfig.queue())
             .concatMap(delivery -> consumeSubscriptionUpdate(delivery, delivery.getBody()))
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe();

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
@@ -89,7 +89,7 @@ public class SaaSSubscriptionConsumer implements Closeable, Startable {
         startConsumer();
     }
 
-    public SubscriptionConsumerConfig getConsumerConfig() {
+    protected SubscriptionConsumerConfig getConsumerConfig() {
         return consumerConfig;
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionDeadLetterQueueHealthCheck.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionDeadLetterQueueHealthCheck.java
@@ -19,8 +19,6 @@
 package com.linagora.tmail.saas.rabbitmq.subscription;
 
 import static com.linagora.tmail.saas.rabbitmq.TWPConstants.TWP_INJECTION_KEY;
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE;
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE;
 
 import java.util.List;
 
@@ -34,8 +32,6 @@ import org.apache.james.core.healthcheck.ComponentName;
 import org.apache.james.core.healthcheck.HealthCheck;
 import org.apache.james.core.healthcheck.Result;
 
-import com.google.common.collect.ImmutableList;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -43,17 +39,17 @@ import reactor.core.scheduler.Schedulers;
 public class SaaSSubscriptionDeadLetterQueueHealthCheck implements HealthCheck {
     public static final ComponentName COMPONENT_NAME = new ComponentName("SaaSSubscriptionDeadLetterQueueHealthCheck");
     private static final String DEFAULT_VHOST = "/";
-    private static final List<String> DEAD_LETTER_QUEUES = ImmutableList.of(
-        SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE,
-        SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE);
 
     private final RabbitMQConfiguration twpRabbitMQConfiguration;
     private final RabbitMQManagementAPI api;
+    private final List<String> deadLetterQueues;
 
     @Inject
-    public SaaSSubscriptionDeadLetterQueueHealthCheck(@Named(TWP_INJECTION_KEY) RabbitMQConfiguration twpRabbitMQConfiguration) {
+    public SaaSSubscriptionDeadLetterQueueHealthCheck(@Named(TWP_INJECTION_KEY) RabbitMQConfiguration twpRabbitMQConfiguration,
+                                                      List<String> deadLetterQueues) {
         this.twpRabbitMQConfiguration = twpRabbitMQConfiguration;
         this.api = RabbitMQManagementAPI.from(twpRabbitMQConfiguration);
+        this.deadLetterQueues = deadLetterQueues;
     }
 
     @Override
@@ -63,7 +59,7 @@ public class SaaSSubscriptionDeadLetterQueueHealthCheck implements HealthCheck {
 
     @Override
     public Mono<Result> check() {
-        return Flux.fromIterable(DEAD_LETTER_QUEUES)
+        return Flux.fromIterable(deadLetterQueues)
             .map(this::checkQueueLength)
             .map(queueDetails -> {
                 if (queueDetails.getRight() != 0) {

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionModule.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionModule.java
@@ -21,6 +21,7 @@ package com.linagora.tmail.saas.rabbitmq.subscription;
 import static com.linagora.tmail.saas.rabbitmq.TWPConstants.TWP_INJECTION_KEY;
 
 import java.io.FileNotFoundException;
+import java.util.List;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -36,6 +37,7 @@ import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
 import org.apache.james.utils.PropertiesProvider;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.Multibinder;
@@ -43,8 +45,12 @@ import com.google.inject.multibindings.ProvidesIntoSet;
 import com.linagora.tmail.rate.limiter.api.RateLimitingRepository;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.TWPCommonRabbitMQConfiguration;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.DomainSubscriptionConsumerConfig;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SubscriptionConsumerConfig;
 
 public class SaaSSubscriptionModule extends AbstractModule {
+    private static final List<String> SUBSCRIPTION_QUEUES = ImmutableList.of(SubscriptionConsumerConfig.DEFAULT.queue(), DomainSubscriptionConsumerConfig.DEFAULT.queue());
+    private static final List<String> SUBSCRIPTION_DEAD_LETTER_QUEUES = ImmutableList.of(SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue());
 
     @Override
     protected void configure() {
@@ -69,7 +75,8 @@ public class SaaSSubscriptionModule extends AbstractModule {
             new SaaSSubscriptionHandlerImpl(saasAccountRepository,
                 maxQuotaManager,
                 userQuotaRootResolver,
-                rateLimitingRepository));
+                rateLimitingRepository),
+            SubscriptionConsumerConfig.DEFAULT);
     }
 
     @Provides
@@ -87,7 +94,22 @@ public class SaaSSubscriptionModule extends AbstractModule {
             new SaaSDomainSubscriptionHandlerImpl(domainList,
                 maxQuotaManager,
                 rateLimitingRepository,
-                saasAccountRepository));
+                saasAccountRepository),
+            DomainSubscriptionConsumerConfig.DEFAULT);
+    }
+
+    @Provides
+    @Singleton
+    SaaSSubscriptionQueueConsumerHealthCheck provideSaaSSubscriptionQueueConsumerHealthCheck(@Named(TWP_INJECTION_KEY) RabbitMQConfiguration twpRabbitMQConfiguration,
+                                                                                             SaaSSubscriptionConsumer saaSSubscriptionConsumer,
+                                                                                             SaaSDomainSubscriptionConsumer saaSDomainSubscriptionConsumer) {
+        return new SaaSSubscriptionQueueConsumerHealthCheck(twpRabbitMQConfiguration, saaSSubscriptionConsumer, saaSDomainSubscriptionConsumer, SUBSCRIPTION_QUEUES);
+    }
+
+    @Provides
+    @Singleton
+    SaaSSubscriptionDeadLetterQueueHealthCheck provideSaaSSubscriptionDeadLetterQueueHealthCheck(@Named(TWP_INJECTION_KEY) RabbitMQConfiguration twpRabbitMQConfiguration) {
+        return new SaaSSubscriptionDeadLetterQueueHealthCheck(twpRabbitMQConfiguration, SUBSCRIPTION_DEAD_LETTER_QUEUES);
     }
 
     @ProvidesIntoSet

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionQueueConsumerHealthCheck.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionQueueConsumerHealthCheck.java
@@ -19,8 +19,6 @@
 package com.linagora.tmail.saas.rabbitmq.subscription;
 
 import static com.linagora.tmail.saas.rabbitmq.TWPConstants.TWP_INJECTION_KEY;
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.SAAS_DOMAIN_SUBSCRIPTION_QUEUE;
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SAAS_SUBSCRIPTION_QUEUE;
 
 import java.util.List;
 
@@ -35,7 +33,6 @@ import org.apache.james.core.healthcheck.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
 import com.linagora.tmail.RabbitMQManagementAPI;
 
 import reactor.core.publisher.Flux;
@@ -46,23 +43,23 @@ public class SaaSSubscriptionQueueConsumerHealthCheck implements HealthCheck {
     private static final Logger LOGGER = LoggerFactory.getLogger(SaaSSubscriptionQueueConsumerHealthCheck.class);
     public static final ComponentName COMPONENT_NAME = new ComponentName("SaaSSubscriptionQueueConsumerHealthCheck");
     private static final String DEFAULT_VHOST = "/";
-    private static final List<String> SAAS_SUBSCRIPTION_QUEUES = ImmutableList.of(
-        SAAS_SUBSCRIPTION_QUEUE,
-        SAAS_DOMAIN_SUBSCRIPTION_QUEUE);
 
     private final RabbitMQConfiguration twpRabbitMQConfiguration;
     private final SaaSSubscriptionConsumer saaSSubscriptionConsumer;
     private final SaaSDomainSubscriptionConsumer saaSDomainSubscriptionConsumer;
     private final RabbitMQManagementAPI api;
+    private final List<String> saasSubscriptionQueues;
 
     @Inject
     public SaaSSubscriptionQueueConsumerHealthCheck(@Named(TWP_INJECTION_KEY) RabbitMQConfiguration twpRabbitMQConfiguration,
                                                     SaaSSubscriptionConsumer saaSSubscriptionConsumer,
-                                                    SaaSDomainSubscriptionConsumer saaSDomainSubscriptionConsumer) {
+                                                    SaaSDomainSubscriptionConsumer saaSDomainSubscriptionConsumer,
+                                                    List<String> saasSubscriptionQueues) {
         this.twpRabbitMQConfiguration = twpRabbitMQConfiguration;
         this.api = RabbitMQManagementAPI.from(twpRabbitMQConfiguration);
         this.saaSSubscriptionConsumer = saaSSubscriptionConsumer;
         this.saaSDomainSubscriptionConsumer = saaSDomainSubscriptionConsumer;
+        this.saasSubscriptionQueues = saasSubscriptionQueues;
     }
 
     @Override
@@ -72,7 +69,7 @@ public class SaaSSubscriptionQueueConsumerHealthCheck implements HealthCheck {
 
     @Override
     public Mono<Result> check() {
-        return Flux.fromIterable(SAAS_SUBSCRIPTION_QUEUES)
+        return Flux.fromIterable(saasSubscriptionQueues)
             .map(this::checkQueueConsumer)
             .flatMap(queueConsumerDetails -> {
                 if (queueConsumerDetails.getRight().isEmpty()) {
@@ -102,10 +99,10 @@ public class SaaSSubscriptionQueueConsumerHealthCheck implements HealthCheck {
     }
 
     private void restartQueueConsumer(String queue) {
-        if (queue.equalsIgnoreCase(SAAS_SUBSCRIPTION_QUEUE)) {
+        if (queue.equalsIgnoreCase(saaSSubscriptionConsumer.getConsumerConfig().queue())) {
             saaSSubscriptionConsumer.restartConsumer();
         }
-        if (queue.equalsIgnoreCase(SAAS_DOMAIN_SUBSCRIPTION_QUEUE)) {
+        if (queue.equalsIgnoreCase(saaSDomainSubscriptionConsumer.getConsumerConfig().queue())) {
             saaSDomainSubscriptionConsumer.restartConsumer();
         }
     }

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/MemorySaaSDomainSubscriptionConsumerTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/MemorySaaSDomainSubscriptionConsumerTest.java
@@ -35,6 +35,7 @@ import com.linagora.tmail.rate.limiter.api.memory.MemoryRateLimitingRepository;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.TWPCommonRabbitMQConfiguration;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.DomainSubscriptionConsumerConfig;
 
 class MemorySaaSDomainSubscriptionConsumerTest implements SaaSDomainSubscriptionConsumerContract {
     private DomainList domainList;
@@ -69,7 +70,8 @@ class MemorySaaSDomainSubscriptionConsumerTest implements SaaSDomainSubscription
             new SaaSDomainSubscriptionHandlerImpl(domainList,
                 maxQuotaManager,
                 rateLimitingRepository,
-                saasAccountRepository));
+                saasAccountRepository),
+            DomainSubscriptionConsumerConfig.DEFAULT);
         testee.init();
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/MemorySaaSSubscriptionConsumerTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/MemorySaaSSubscriptionConsumerTest.java
@@ -36,6 +36,7 @@ import com.linagora.tmail.rate.limiter.api.memory.MemoryRateLimitingRepository;
 import com.linagora.tmail.saas.api.SaaSAccountRepository;
 import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
 import com.linagora.tmail.saas.rabbitmq.TWPCommonRabbitMQConfiguration;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SubscriptionConsumerConfig;
 
 class MemorySaaSSubscriptionConsumerTest implements SaaSSubscriptionConsumerContract {
     private SaaSSubscriptionConsumer testee;
@@ -72,7 +73,8 @@ class MemorySaaSSubscriptionConsumerTest implements SaaSSubscriptionConsumerCont
             new SaaSSubscriptionHandlerImpl(saasAccountRepository,
                 maxQuotaManager,
                 userQuotaRootResolver,
-                rateLimitingRepository));
+                rateLimitingRepository),
+            SubscriptionConsumerConfig.DEFAULT);
         testee.init();
     }
 

--- a/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionDeadLetterQueueHealthCheckTest.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/test/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionDeadLetterQueueHealthCheckTest.java
@@ -18,8 +18,6 @@
 
 package com.linagora.tmail.saas.rabbitmq.subscription;
 
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE;
-import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE;
 import static com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionRabbitMQConfiguration.TWP_SAAS_SUBSCRIPTION_EXCHANGE_DEFAULT;
 import static com.rabbitmq.client.BuiltinExchangeType.DIRECT;
 import static com.rabbitmq.client.MessageProperties.PERSISTENT_TEXT_PLAIN;
@@ -44,7 +42,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSDomainSubscriptionConsumer.DomainSubscriptionConsumerConfig;
+import com.linagora.tmail.saas.rabbitmq.subscription.SaaSSubscriptionConsumer.SubscriptionConsumerConfig;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -60,6 +61,9 @@ class SaaSSubscriptionDeadLetterQueueHealthCheckTest {
 
     public static final String TWP_VHOST = "twp-test";
     public static final ImmutableMap<String, Object> NO_QUEUE_DECLARE_ARGUMENTS = ImmutableMap.of();
+    public static final ImmutableList<String> DEAD_LETTER_QUEUES = ImmutableList.of(
+        SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(),
+        DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue());
 
     private Connection connection;
     private Channel channel;
@@ -76,8 +80,9 @@ class SaaSSubscriptionDeadLetterQueueHealthCheckTest {
         connection = connectionFactory.newConnection();
         channel = connection.createChannel();
         testee = new SaaSSubscriptionDeadLetterQueueHealthCheck(rabbitMQ.getConfigurationBuilder()
-            .vhost(Optional.of(TWP_VHOST))
-            .build());
+                .vhost(Optional.of(TWP_VHOST))
+                .build(),
+            DEAD_LETTER_QUEUES);
     }
 
     @AfterEach
@@ -96,8 +101,8 @@ class SaaSSubscriptionDeadLetterQueueHealthCheckTest {
     @Test
     void healthCheckShouldReturnHealthyWhenSaaSSubscriptionDeadLetterQueuesAreEmpty() throws Exception {
         createDeadLetterQueues(ImmutableMap.of(
-            SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_USER,
-            SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_DOMAIN));
+            SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_USER,
+            DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_DOMAIN));
 
         assertThat(testee.check().block().isHealthy()).isTrue();
     }
@@ -110,22 +115,22 @@ class SaaSSubscriptionDeadLetterQueueHealthCheckTest {
     @Test
     void healthCheckShouldReturnUnhealthyWhenOnlySubscriptionDeadLetterQueueIsDeclared() throws Exception {
         createDeadLetterQueues(ImmutableMap.of(
-            SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_USER));
+            SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_USER));
         assertThat(testee.check().block().isUnHealthy()).isTrue();
     }
 
     @Test
     void healthCheckShouldReturnUnhealthyWhenOnlyDomainSubscriptionDeadLetterQueueIsDeclared() throws Exception {
         createDeadLetterQueues(ImmutableMap.of(
-            SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_DOMAIN));
+            DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_DOMAIN));
         assertThat(testee.check().block().isUnHealthy()).isTrue();
     }
 
     @Test
     void healthCheckShouldReturnDegradedWhenSaaSSubscriptionDeadLetterQueueIsNotEmpty() throws Exception {
         createDeadLetterQueues(ImmutableMap.of(
-            SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_USER,
-            SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_DOMAIN));
+            SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_USER,
+            DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_DOMAIN));
         publishAMessage(ROUTING_KEY_USER);
 
         awaitAtMostOneMinute.until(() -> testee.check().block().isDegraded());
@@ -134,8 +139,8 @@ class SaaSSubscriptionDeadLetterQueueHealthCheckTest {
     @Test
     void healthCheckShouldReturnDegradedWhenSaaSDomainSubscriptionDeadLetterQueueIsNotEmpty() throws Exception {
         createDeadLetterQueues(ImmutableMap.of(
-            SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_USER,
-            SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE, ROUTING_KEY_DOMAIN));
+            SubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_USER,
+            DomainSubscriptionConsumerConfig.DEFAULT.deadLetterQueue(), ROUTING_KEY_DOMAIN));
         publishAMessage(ROUTING_KEY_DOMAIN);
 
         awaitAtMostOneMinute.until(() -> testee.check().block().isDegraded());


### PR DESCRIPTION
…riptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made RabbitMQ queue and dead-letter queue names configurable instead of hardcoded, improving flexibility.
  * Updated subscription consumers and health checks to use injected queue settings and lists for queue declarations, consumption, and restart checks.
  * Removed the previously exposed static queue-name constants.
* **Tests**
  * Updated unit tests to construct consumers and health checks using the new default configurable queue settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->