### PR TITLE
Feat: respect team aliases in allowed from addresses and valid recipient handler

### DIFF
--- a/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TMailCanSendFrom.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TMailCanSendFrom.scala
@@ -27,46 +27,12 @@ import org.apache.james.mailbox.model.MailboxACL
 import org.apache.james.mailbox.model.MailboxACL.Right
 import org.apache.james.rrt.api.AliasReverseResolver
 import org.apache.james.rrt.lib.CanSendFromImpl
-import org.reactivestreams.Publisher
-import reactor.core.publisher.Flux
+import reactor.core.publisher.{Flux, Mono}
 import reactor.core.scala.publisher.{SFlux, SMono}
-
-import scala.util.Try
 
 class TMailCanSendFrom @Inject()(aliasReverseResolver: AliasReverseResolver,
                                  teamMailboxRepository: TeamMailboxRepository,
                                  @Named("mailboxmanager") mailboxManager: MailboxManager) extends CanSendFromImpl(aliasReverseResolver) {
-  override def userCanSendFrom(connectedUser: Username, fromUser: Username): Boolean =
-    super.userCanSendFrom(connectedUser, fromUser) || validTeamMailbox(connectedUser, fromUser)
-
-  override def userCanSendFromReactive(connectedUser: Username, fromUser: Username): Publisher[lang.Boolean] =
-    SFlux.merge(Seq(
-      SMono.fromPublisher(super.userCanSendFromReactive(connectedUser, fromUser)).map(javaPrimitiveBoolean => lang.Boolean.valueOf(javaPrimitiveBoolean)),
-      validTeamMailboxReactive(connectedUser, fromUser).map(boolean2Boolean)))
-      .reduce((bool1: lang.Boolean, bool2: lang.Boolean) => bool1 || bool2)
-
-  private def isExtraSender(user: Username, teamMailbox: TeamMailbox): Boolean = {
-    val session = mailboxManager.createSystemSession(teamMailbox.admin)
-    val userKey = MailboxACL.EntryKey.createUserEntryKey(user)
-    Try(mailboxManager.listRights(teamMailbox.mailboxPath, session))
-      .map(acl => Option(acl.getEntries.get(userKey)).exists(_.contains(Right.Post)))
-      .getOrElse(false)
-  }
-
-  private def validTeamMailbox(connectedUser: Username, fromUser: Username): Boolean =
-    TeamMailbox.asTeamMailbox(fromUser.asMailAddress()) match {
-      case Some(teamMailbox) =>
-        SFlux(teamMailboxRepository.listMembers(teamMailbox))
-          .filter(teamMailboxMember => connectedUser.equals(teamMailboxMember.username))
-          .hasElements
-          .onErrorResume {
-            case _: TeamMailboxNotFoundException => SMono.just(false)
-            case e => SMono.error(e)
-          }
-          .block() || isExtraSender(connectedUser, teamMailbox)
-      case None => false
-    }
-
   private def isExtraSenderReactive(user: Username, teamMailbox: TeamMailbox): SMono[Boolean] = {
     val session = mailboxManager.createSystemSession(teamMailbox.admin)
     val userKey = MailboxACL.EntryKey.createUserEntryKey(user)
@@ -75,33 +41,26 @@ class TMailCanSendFrom @Inject()(aliasReverseResolver: AliasReverseResolver,
       .onErrorResume(_ => SMono.just(false))
   }
 
-  private def validTeamMailboxReactive(connectedUser: Username, fromUser: Username): SMono[Boolean] =
-    TeamMailbox.asTeamMailbox(fromUser.asMailAddress()) match {
-      case Some(teamMailbox) =>
-        SFlux(teamMailboxRepository.listMembers(teamMailbox))
-          .filter(teamMailboxMember => connectedUser.equals(teamMailboxMember.username))
-          .hasElements
-          .onErrorResume {
-            case _: TeamMailboxNotFoundException => SMono.just(false)
-            case e => SMono.error(e)
-          }
-          .flatMap(isMember => if (isMember) SMono.just(true) else isExtraSenderReactive(connectedUser, teamMailbox))
-      case None => SMono.just(false)
-    }
-
   override def allValidFromAddressesForUser(user: Username): Flux[MailAddress] = {
-    val extraSenderAddresses: Flux[MailAddress] =
+    val extraSenderAddresses: Flux[Username] =
       if (user.getDomainPart.isPresent) {
         Flux.from(SFlux.fromPublisher(teamMailboxRepository.listTeamMailboxes(user.getDomainPart.get))
           .filterWhen(teamMailbox => isExtraSenderReactive(user, teamMailbox))
-          .map(_.asMailAddress))
+          .map(_.asMailAddress)
+          .map(Username.fromMailAddress(_)))
       } else {
-        Flux.empty[MailAddress]()
+        Flux.empty[Username]()
       }
     Flux.merge(
-      super.allValidFromAddressesForUser(user),
-      Flux.from(teamMailboxRepository.listTeamMailboxes(user)).map(_.asMailAddress),
-      extraSenderAddresses)
-      .distinct()
+      // The username itself.
+      Mono.just(user),
+      // All team mailboxes of which the user is member (has BASIC_TEAM_MAILBOX_RIGHTS).
+      Flux.from(teamMailboxRepository.listTeamMailboxes(user)).map(_.asMailAddress).map(Username.fromMailAddress(_)),
+      // All team mailboxes on the same domain of which the user is an extra sender (has Post right).
+      extraSenderAddresses
+    )
+    .distinct()
+    .flatMap(super.allValidFromAddressesForUser(_))
+    .distinct()
   }
 }

--- a/tmail-backend/mailbox/team-mailboxes/src/test/scala/com/linagora/tmail/team/TMailCanSendFromTest.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/test/scala/com/linagora/tmail/team/TMailCanSendFromTest.scala
@@ -106,7 +106,7 @@ class TMailCanSendFromTest extends CanSendFromContract {
   }
 
   @Test
-  def allValidFromAddressesForUserShouldListTeamMailboxAlias(): Unit = {
+  def allValidFromAddressesForUserShouldListTeamMailbox(): Unit = {
     val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
     SMono(teamMailboxRepository.addMember(teamMailbox,  TeamMailboxMember.asMember(Username.of("bob@domain.tld")))) .block()
@@ -114,6 +114,18 @@ class TMailCanSendFromTest extends CanSendFromContract {
     assertThat(Flux.from(testee.allValidFromAddressesForUser(Username.of("bob@domain.tld")))
       .collectList().block())
       .containsOnly(new MailAddress("marketing@domain.tld"), new MailAddress("bob@domain.tld"))
+  }
+
+  @Test
+  def allValidFromAddressesForUserShouldListTeamMailboxAlias(): Unit = {
+    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
+    SMono(teamMailboxRepository.addMember(teamMailbox,  TeamMailboxMember.asMember(Username.of("bob@domain.tld")))) .block()
+    addAliasMapping(Username.of("marketing-alias@domain.tld"), Username.of("marketing@domain.tld"))
+
+    assertThat(Flux.from(testee.allValidFromAddressesForUser(Username.of("bob@domain.tld")))
+      .collectList().block())
+      .containsOnly(new MailAddress("marketing@domain.tld"), new MailAddress("marketing-alias@domain.tld"), new MailAddress("bob@domain.tld"))
   }
 
   @Test
@@ -143,6 +155,22 @@ class TMailCanSendFromTest extends CanSendFromContract {
       session)
 
     assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+      .isTrue
+  }
+
+  @Test
+  def extraSenderCanSendAsTeamMailboxAlias(): Unit = {
+    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
+    addAliasMapping(Username.of("marketing-alias@domain.tld"), Username.of("marketing@domain.tld"))
+
+    val session = mailboxManager.createSystemSession(teamMailbox.admin)
+    mailboxManager.applyRightsCommand(
+      teamMailbox.mailboxPath,
+      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Post).asAddition(),
+      session)
+
+    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing-alias@domain.tld")))
       .isTrue
   }
 

--- a/tmail-backend/mailbox/team-mailboxes/src/test/scala/com/linagora/tmail/team/TMailCanSendFromTest.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/test/scala/com/linagora/tmail/team/TMailCanSendFromTest.scala
@@ -88,109 +88,109 @@ class TMailCanSendFromTest extends CanSendFromContract {
 
   @Test
   def teamMailboxMemberCanSend(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
-    SMono(teamMailboxRepository.addMember(teamMailbox,  TeamMailboxMember.asMember(Username.of("bob@domain.tld")))).block()
+    SMono(teamMailboxRepository.addMember(teamMailbox, TeamMailboxMember.asMember(CanSendFromContract.USER))).block()
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN)))
       .isTrue
   }
 
   @Test
   def nonMembersCannotSend(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN)))
       .isFalse
   }
 
   @Test
   def allValidFromAddressesForUserShouldListTeamMailbox(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
-    SMono(teamMailboxRepository.addMember(teamMailbox,  TeamMailboxMember.asMember(Username.of("bob@domain.tld")))) .block()
+    SMono(teamMailboxRepository.addMember(teamMailbox, TeamMailboxMember.asMember(CanSendFromContract.USER))) .block()
 
-    assertThat(Flux.from(testee.allValidFromAddressesForUser(Username.of("bob@domain.tld")))
+    assertThat(Flux.from(testee.allValidFromAddressesForUser(CanSendFromContract.USER))
       .collectList().block())
-      .containsOnly(new MailAddress("marketing@domain.tld"), new MailAddress("bob@domain.tld"))
+      .containsOnly(MailAddress.of("marketing", CanSendFromContract.DOMAIN), new MailAddress(CanSendFromContract.USER.asString()))
   }
 
   @Test
   def allValidFromAddressesForUserShouldListTeamMailboxAlias(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
-    SMono(teamMailboxRepository.addMember(teamMailbox,  TeamMailboxMember.asMember(Username.of("bob@domain.tld")))) .block()
-    addAliasMapping(Username.of("marketing-alias@domain.tld"), Username.of("marketing@domain.tld"))
+    SMono(teamMailboxRepository.addMember(teamMailbox, TeamMailboxMember.asMember(CanSendFromContract.USER))) .block()
+    addAliasMapping(Username.fromLocalPartWithDomain("marketing-alias", CanSendFromContract.DOMAIN), Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN))
 
-    assertThat(Flux.from(testee.allValidFromAddressesForUser(Username.of("bob@domain.tld")))
+    assertThat(Flux.from(testee.allValidFromAddressesForUser(CanSendFromContract.USER))
       .collectList().block())
-      .containsOnly(new MailAddress("marketing@domain.tld"), new MailAddress("marketing-alias@domain.tld"), new MailAddress("bob@domain.tld"))
+      .containsOnly(MailAddress.of("marketing", CanSendFromContract.DOMAIN), MailAddress.of("marketing-alias", CanSendFromContract.DOMAIN), new MailAddress(CanSendFromContract.USER.asString()))
   }
 
   @Test
   def userWithExtraAclOnSubfolderOnlyCannotSend(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
 
     val session = mailboxManager.createSystemSession(teamMailbox.owner)
     mailboxManager.applyRightsCommand(
       teamMailbox.inboxPath,
-      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Lookup, MailboxACL.Right.Read).asAddition(),
+      MailboxACL.command().forUser(CanSendFromContract.USER).rights(MailboxACL.Right.Lookup, MailboxACL.Right.Read).asAddition(),
       session)
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN)))
       .isFalse
   }
 
   @Test
   def extraSenderCanSendAsTeamMailbox(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
 
     val session = mailboxManager.createSystemSession(teamMailbox.admin)
     mailboxManager.applyRightsCommand(
       teamMailbox.mailboxPath,
-      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Post).asAddition(),
+      MailboxACL.command().forUser(CanSendFromContract.USER).rights(MailboxACL.Right.Post).asAddition(),
       session)
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN)))
       .isTrue
   }
 
   @Test
   def extraSenderCanSendAsTeamMailboxAlias(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
-    addAliasMapping(Username.of("marketing-alias@domain.tld"), Username.of("marketing@domain.tld"))
+    addAliasMapping(Username.fromLocalPartWithDomain("marketing-alias", CanSendFromContract.DOMAIN), Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN))
 
     val session = mailboxManager.createSystemSession(teamMailbox.admin)
     mailboxManager.applyRightsCommand(
       teamMailbox.mailboxPath,
-      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Post).asAddition(),
+      MailboxACL.command().forUser(CanSendFromContract.USER).rights(MailboxACL.Right.Post).asAddition(),
       session)
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing-alias@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing-alias", CanSendFromContract.DOMAIN)))
       .isTrue
   }
 
   @Test
   def extraSenderLosesRightAfterRemoval(): Unit = {
-    val teamMailbox = TeamMailbox(Domain.of("domain.tld"), TeamMailboxName("marketing"))
+    val teamMailbox = TeamMailbox(CanSendFromContract.DOMAIN, TeamMailboxName("marketing"))
     SMono(teamMailboxRepository.createTeamMailbox(teamMailbox)).block()
 
     val session = mailboxManager.createSystemSession(teamMailbox.admin)
     mailboxManager.applyRightsCommand(
       teamMailbox.mailboxPath,
-      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Post).asAddition(),
+      MailboxACL.command().forUser(CanSendFromContract.USER).rights(MailboxACL.Right.Post).asAddition(),
       session)
 
     mailboxManager.applyRightsCommand(
       teamMailbox.mailboxPath,
-      MailboxACL.command().forUser(Username.of("bob@domain.tld")).rights(MailboxACL.Right.Post).asRemoval(),
+      MailboxACL.command().forUser(CanSendFromContract.USER).rights(MailboxACL.Right.Post).asRemoval(),
       session)
 
-    assertThat(testee.userCanSendFrom(Username.of("bob@domain.tld"), Username.of("marketing@domain.tld")))
+    assertThat(testee.userCanSendFrom(CanSendFromContract.USER, Username.fromLocalPartWithDomain("marketing", CanSendFromContract.DOMAIN)))
       .isFalse
   }
 }

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
@@ -22,7 +22,9 @@ import jakarta.inject.Inject;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
 import org.apache.james.smtpserver.fastfail.ValidRcptHandler;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
@@ -47,6 +49,12 @@ public class TMailValidRcptHandler extends ValidRcptHandler {
     @Override
     protected boolean mailboxExists(MailAddress recipient) throws UsersRepositoryException {
         return super.mailboxExists(recipient) || isATeamMailbox(recipient);
+    }
+
+    // This is only needed to make James' behavior visible for tests here.
+    @Override
+    protected boolean isValidRecipient(SMTPSession session, MailAddress recipient) throws UsersRepositoryException, RecipientRewriteTableException {
+        return super.isValidRecipient(session, recipient);
     }
 
     private boolean isATeamMailbox(MailAddress recipient) {

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailValidRcptHandler.java
@@ -22,9 +22,7 @@ import jakarta.inject.Inject;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.domainlist.api.DomainList;
-import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.rrt.api.RecipientRewriteTable;
-import org.apache.james.rrt.api.RecipientRewriteTableException;
 import org.apache.james.smtpserver.fastfail.ValidRcptHandler;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
@@ -47,9 +45,8 @@ public class TMailValidRcptHandler extends ValidRcptHandler {
     }
 
     @Override
-    public boolean isValidRecipient(SMTPSession session, MailAddress recipient) throws UsersRepositoryException, RecipientRewriteTableException {
-        return super.isValidRecipient(session, recipient)
-            || isATeamMailbox(recipient);
+    protected boolean mailboxExists(MailAddress recipient) throws UsersRepositoryException {
+        return super.mailboxExists(recipient) || isATeamMailbox(recipient);
     }
 
     private boolean isATeamMailbox(MailAddress recipient) {

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
@@ -37,6 +37,8 @@ import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linagora.tmail.team.TeamMailbox;
 import com.linagora.tmail.team.TeamMailboxCallbackNoop;
@@ -50,6 +52,9 @@ class TMailValidRcptHandlerTest {
     public static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
     public static final Username SALES = Username.fromLocalPartWithDomain("sales", DOMAIN);
     public static final Username NON_EXISTENT = Username.fromLocalPartWithDomain("non-existent", DOMAIN);
+    public static final Username BOB_ALIAS = Username.fromLocalPartWithDomain("bob-alias", DOMAIN);
+    public static final Username ADDRESS_ALIAS = Username.fromLocalPartWithDomain("address-alias", DOMAIN);
+    public static final Username GROUP = Username.fromLocalPartWithDomain("group", DOMAIN);
 
     private TMailValidRcptHandler testee;
 
@@ -60,8 +65,6 @@ class TMailValidRcptHandlerTest {
                 integrationResources.getMailboxManager().getMapperFactory(), integrationResources.getMailboxManager().getEventBus());
 
         TeamMailboxRepositoryImpl teamMailboxRepository = new TeamMailboxRepositoryImpl(integrationResources.getMailboxManager(), subscriptionManager, integrationResources.getMailboxManager().getMapperFactory(), java.util.Set.of(new TeamMailboxCallbackNoop()));
-        TeamMailbox teamMailbox = TeamMailbox.asTeamMailbox(new MailAddress(SALES.asString())).get();
-        Mono.from(teamMailboxRepository.createTeamMailbox(teamMailbox)).block();
 
         MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
         domainList.configure(DomainListConfiguration.DEFAULT);
@@ -74,10 +77,16 @@ class TMailValidRcptHandlerTest {
         rrt.setUsersRepository(usersRepository);
         rrt.setDomainList(domainList);
         rrt.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
+        rrt.addAliasMapping(MappingSource.fromUser(BOB_ALIAS), BOB.asString());
+        rrt.addGroupMapping(MappingSource.fromUser(GROUP), BOB.asString());
+        rrt.addAddressMapping(MappingSource.fromUser(ADDRESS_ALIAS), BOB.asString());
+
+        TeamMailbox teamMailbox = TeamMailbox.asTeamMailbox(new MailAddress(SALES.asString())).get();
+        Mono.from(teamMailboxRepository.createTeamMailbox(teamMailbox)).block();
+        Mono.from(teamMailboxRepository.addMember(teamMailbox, TeamMailboxMember.asMember(BOB))).block();
 
         testee = new TMailValidRcptHandler(usersRepository, rrt, domainList, teamMailboxRepository);
     }
-
 
     @Test
     void shouldHandleUsers() throws Exception {
@@ -92,5 +101,31 @@ class TMailValidRcptHandlerTest {
     @Test
     void shouldNotHandleNonExistentRecipients() throws Exception {
         assertThat(testee.mailboxExists(new MailAddress(NON_EXISTENT.asString()))).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "bob@linagora.com",
+        "bob+detail@linagora.com",
+        "bob-alias@linagora.com",
+        "group@linagora.com",
+        "address-alias@linagora.com",
+        "sales@linagora.com",
+        "sales+detail@linagora.com"
+    })
+    void shouldHandleLocalResources(String address) throws Exception {
+        assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))
+            .isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "notFound@linagora.com",
+        "bob@notFound.com",
+        "not.found@linagora.com"
+    })
+    void shouldNotHandeRemoteResources(String address) throws Exception {
+        assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))
+            .isFalse();
     }
 }

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailValidRcptHandlerTest.java
@@ -36,8 +36,7 @@ import org.apache.james.rrt.lib.MappingSource;
 import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.team.TeamMailbox;
 import com.linagora.tmail.team.TeamMailboxCallbackNoop;
@@ -49,9 +48,8 @@ import reactor.core.publisher.Mono;
 class TMailValidRcptHandlerTest {
     public static final Domain DOMAIN = Domain.of("linagora.com");
     public static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
-    public static final Username BOB_ALIAS = Username.fromLocalPartWithDomain("bob-alias", DOMAIN);
-    public static final Username ADDRESS_ALIAS = Username.fromLocalPartWithDomain("address-alias", DOMAIN);
-    public static final Username GROUP = Username.fromLocalPartWithDomain("group", DOMAIN);
+    public static final Username SALES = Username.fromLocalPartWithDomain("sales", DOMAIN);
+    public static final Username NON_EXISTENT = Username.fromLocalPartWithDomain("non-existent", DOMAIN);
 
     private TMailValidRcptHandler testee;
 
@@ -62,6 +60,8 @@ class TMailValidRcptHandlerTest {
                 integrationResources.getMailboxManager().getMapperFactory(), integrationResources.getMailboxManager().getEventBus());
 
         TeamMailboxRepositoryImpl teamMailboxRepository = new TeamMailboxRepositoryImpl(integrationResources.getMailboxManager(), subscriptionManager, integrationResources.getMailboxManager().getMapperFactory(), java.util.Set.of(new TeamMailboxCallbackNoop()));
+        TeamMailbox teamMailbox = TeamMailbox.asTeamMailbox(new MailAddress(SALES.asString())).get();
+        Mono.from(teamMailboxRepository.createTeamMailbox(teamMailbox)).block();
 
         MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
         domainList.configure(DomainListConfiguration.DEFAULT);
@@ -74,40 +74,23 @@ class TMailValidRcptHandlerTest {
         rrt.setUsersRepository(usersRepository);
         rrt.setDomainList(domainList);
         rrt.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
-        rrt.addAliasMapping(MappingSource.fromUser(BOB_ALIAS), BOB.asString());
-        rrt.addGroupMapping(MappingSource.fromUser(GROUP), BOB.asString());
-        rrt.addAddressMapping(MappingSource.fromUser(ADDRESS_ALIAS), BOB.asString());
-
-        TeamMailbox teamMailboxOption = TeamMailbox.asTeamMailbox(new MailAddress("sales@linagora.com")).get();
-        Mono.from(teamMailboxRepository.createTeamMailbox(teamMailboxOption)).block();
-        Mono.from(teamMailboxRepository.addMember(teamMailboxOption, TeamMailboxMember.asMember(BOB))).block();
 
         testee = new TMailValidRcptHandler(usersRepository, rrt, domainList, teamMailboxRepository);
     }
 
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "bob@linagora.com",
-        "bob-alias@linagora.com",
-        "group@linagora.com",
-        "address-alias@linagora.com",
-        "sales@linagora.com",
-        "sales+detail@linagora.com"
-    })
-    void shouldHandeLocalResources(String address) throws Exception {
-        assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))
-            .isTrue();
+    @Test
+    void shouldHandleUsers() throws Exception {
+        assertThat(testee.mailboxExists(new MailAddress(BOB.asString()))).isTrue();
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "notFound@linagora.com",
-        "bob@notFound.com",
-        "not.found@linagora.com"
-    })
-    void shouldNotHandeRemoteResources(String address) throws Exception {
-        assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))
-            .isFalse();
+    @Test
+    void shouldHandleTeams() throws Exception {
+        assertThat(testee.mailboxExists(new MailAddress(SALES.asString()))).isTrue();
+    }
+
+    @Test
+    void shouldNotHandleNonExistentRecipients() throws Exception {
+        assertThat(testee.mailboxExists(new MailAddress(NON_EXISTENT.asString()))).isFalse();
     }
 }


### PR DESCRIPTION
Closes #2446 

Tests are not adapted, yet.

This relies on https://github.com/apache/james-project/pull/3073.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sender “From” address resolution now supports additional team mailbox addresses and their aliases when authorized.

- **Bug Fixes**
  - Improved authorization for “From” addresses across team mailboxes, including alias scenarios.
  - Recipient validation now correctly recognizes existing team mailbox recipients.

- **Tests**
  - Expanded and renamed test coverage for team mailbox “From” alias resolution and for team-mailbox recipient existence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->