### PR TITLE
ISSUE-2436 Add IsDmarcReportWith/out/Issues matchers

### DIFF
--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -150,61 +150,20 @@ class DmarcReportAnalyzer {
     }
 
     private static Optional<Boolean> scanForIssues(XMLStreamReader reader) throws XMLStreamException {
-        boolean inRecord = false;
-        boolean inPolicyEvaluated = false;
-        String currentElement = null;
-        String dkimResult = null;
-        String spfResult = null;
-
+        RecordState state = new RecordState();
         while (reader.hasNext()) {
             int event = reader.next();
-            switch (event) {
-                case XMLStreamConstants.DTD:
-                    throw new XMLStreamException("DTD declarations are not allowed in DMARC reports");
-                case XMLStreamConstants.START_ELEMENT: {
-                    String name = reader.getLocalName();
-                    if ("record".equals(name)) {
-                        inRecord = true;
-                        dkimResult = null;
-                        spfResult = null;
-                    } else if ("policy_evaluated".equals(name) && inRecord) {
-                        inPolicyEvaluated = true;
-                    } else if (inPolicyEvaluated) {
-                        currentElement = name;
-                    }
-                    break;
+            if (event == XMLStreamConstants.DTD) {
+                throw new XMLStreamException("DTD declarations are not allowed in DMARC reports");
+            }
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                state.onStartElement(reader.getLocalName());
+            } else if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
+                state.onText(reader.getText());
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                if (state.onEndElement(reader.getLocalName())) {
+                    return Optional.of(true);
                 }
-                case XMLStreamConstants.CHARACTERS:
-                case XMLStreamConstants.CDATA: {
-                    if (inPolicyEvaluated && currentElement != null) {
-                        String text = reader.getText();
-                        if ("dkim".equals(currentElement)) {
-                            dkimResult = (dkimResult == null ? "" : dkimResult) + text;
-                        } else if ("spf".equals(currentElement)) {
-                            spfResult = (spfResult == null ? "" : spfResult) + text;
-                        }
-                    }
-                    break;
-                }
-                case XMLStreamConstants.END_ELEMENT: {
-                    String name = reader.getLocalName();
-                    if ("policy_evaluated".equals(name)) {
-                        inPolicyEvaluated = false;
-                        currentElement = null;
-                    } else if ("record".equals(name)) {
-                        inRecord = false;
-                        if (isFail(dkimResult) && isFail(spfResult)) {
-                            return Optional.of(true);
-                        }
-                        dkimResult = null;
-                        spfResult = null;
-                    } else if (inPolicyEvaluated && name.equals(currentElement)) {
-                        currentElement = null;
-                    }
-                    break;
-                }
-                default:
-                    break;
             }
         }
         return Optional.of(false);
@@ -212,6 +171,53 @@ class DmarcReportAnalyzer {
 
     private static boolean isFail(String value) {
         return value != null && "fail".equalsIgnoreCase(value.trim());
+    }
+
+    private static class RecordState {
+        private boolean inRecord = false;
+        private boolean inPolicyEvaluated = false;
+        private String currentElement = null;
+        private String dkimResult = null;
+        private String spfResult = null;
+
+        void onStartElement(String name) {
+            if ("record".equals(name)) {
+                inRecord = true;
+                dkimResult = null;
+                spfResult = null;
+            } else if ("policy_evaluated".equals(name) && inRecord) {
+                inPolicyEvaluated = true;
+            } else if (inPolicyEvaluated) {
+                currentElement = name;
+            }
+        }
+
+        void onText(String text) {
+            if (!inPolicyEvaluated || currentElement == null) {
+                return;
+            }
+            if ("dkim".equals(currentElement)) {
+                dkimResult = (dkimResult == null ? "" : dkimResult) + text;
+            } else if ("spf".equals(currentElement)) {
+                spfResult = (spfResult == null ? "" : spfResult) + text;
+            }
+        }
+
+        boolean onEndElement(String name) {
+            if ("policy_evaluated".equals(name)) {
+                inPolicyEvaluated = false;
+                currentElement = null;
+            } else if ("record".equals(name)) {
+                inRecord = false;
+                boolean hasFailure = isFail(dkimResult) && isFail(spfResult);
+                dkimResult = null;
+                spfResult = null;
+                return hasFailure;
+            } else if (inPolicyEvaluated && name.equals(currentElement)) {
+                currentElement = null;
+            }
+            return false;
+        }
     }
 
     private static InputStream limitedStream(InputStream in, long maxBytes) {

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -104,13 +104,19 @@ class DmarcReportAnalyzer {
         String contentType = part.getContentType().split(";")[0].trim().toLowerCase();
 
         if (isZip(contentType, filename)) {
-            return parseZip(part.getInputStream());
+            try (InputStream inputStream = part.getInputStream()) {
+                return parseZip(inputStream);
+            }
         }
         if (isGzip(contentType, filename)) {
-            return parseGzip(part.getInputStream());
+            try (InputStream inputStream = part.getInputStream()) {
+                return parseGzip(inputStream);
+            }
         }
         if (isXml(contentType, filename)) {
-            return parseXml(limitedStream(part.getInputStream(), MAX_UNCOMPRESSED_BYTES));
+            try (InputStream inputStream = part.getInputStream()) {
+                return parseXml(limitedStream(inputStream, MAX_UNCOMPRESSED_BYTES));
+            }
         }
 
         Object content = part.getContent();
@@ -133,23 +139,26 @@ class DmarcReportAnalyzer {
     }
 
     private static Optional<Boolean> parseZip(InputStream rawInputStream) throws IOException, XMLStreamException {
-        ZipInputStream zipInputStream = new ZipInputStream(rawInputStream);
-        ZipEntry entry;
-        while ((entry = zipInputStream.getNextEntry()) != null) {
-            if (!entry.isDirectory()) {
-                Optional<Boolean> result = parseXml(limitedStream(zipInputStream, MAX_UNCOMPRESSED_BYTES));
-                if (result.isPresent()) {
-                    return result;
+        try (ZipInputStream zipInputStream = new ZipInputStream(rawInputStream)) {
+            ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                if (!entry.isDirectory()) {
+                    Optional<Boolean> result = parseXml(limitedStream(zipInputStream, MAX_UNCOMPRESSED_BYTES));
+                    if (result.isPresent()) {
+                        return result;
+                    }
                 }
+                zipInputStream.closeEntry();
             }
-            zipInputStream.closeEntry();
+            LOGGER.warn("No XML entry found in DMARC ZIP attachment");
+            return Optional.empty();
         }
-        LOGGER.warn("No XML entry found in DMARC ZIP attachment");
-        return Optional.empty();
     }
 
     private static Optional<Boolean> parseGzip(InputStream rawInputStream) throws IOException, XMLStreamException {
-        return parseXml(limitedStream(new GZIPInputStream(rawInputStream), MAX_UNCOMPRESSED_BYTES));
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(rawInputStream)) {
+            return parseXml(limitedStream(gzipInputStream, MAX_UNCOMPRESSED_BYTES));
+        }
     }
 
     private static Optional<Boolean> parseXml(InputStream xmlInputStream) throws XMLStreamException {

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -21,6 +21,7 @@ package com.linagora.tmail.mailet;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
@@ -141,17 +142,22 @@ class DmarcReportAnalyzer {
     private static Optional<Boolean> parseZip(InputStream rawInputStream) throws IOException, XMLStreamException {
         try (ZipInputStream zipInputStream = new ZipInputStream(rawInputStream)) {
             ZipEntry entry;
+            boolean parsedXml = false;
             while ((entry = zipInputStream.getNextEntry()) != null) {
-                if (!entry.isDirectory()) {
-                    Optional<Boolean> result = parseXml(limitedStream(zipInputStream, MAX_UNCOMPRESSED_BYTES));
-                    if (result.isPresent()) {
-                        return result;
+                String entryName = entry.getName().toLowerCase(Locale.ROOT);
+                if (!entry.isDirectory() && entryName.endsWith(".xml")) {
+                    parsedXml = true;
+                    if (parseXml(limitedStream(zipInputStream, MAX_UNCOMPRESSED_BYTES)).orElse(false)) {
+                        return Optional.of(true);
                     }
                 }
                 zipInputStream.closeEntry();
             }
-            LOGGER.warn("No XML entry found in DMARC ZIP attachment");
-            return Optional.empty();
+            if (!parsedXml) {
+                LOGGER.warn("No XML entry found in DMARC ZIP attachment");
+                return Optional.empty();
+            }
+            return Optional.of(false);
         }
     }
 
@@ -181,7 +187,9 @@ class DmarcReportAnalyzer {
                 return Optional.of(true);
             }
         }
-        return Optional.of(false);
+        return state.seenRecord()
+            ? Optional.of(false)
+            : Optional.empty();
     }
 
     private static boolean dispatchXmlEvent(XMLStreamReader reader, RecordState state, int eventType) throws XMLStreamException {
@@ -200,14 +208,20 @@ class DmarcReportAnalyzer {
     }
 
     private static class RecordState {
+        private boolean seenRecord = false;
         private boolean inRecord = false;
         private boolean inPolicyEvaluated = false;
         private String currentElement = null;
         private String dkimResult = null;
         private String spfResult = null;
 
+        boolean seenRecord() {
+            return seenRecord;
+        }
+
         void onStartElement(String name) {
             if ("record".equals(name)) {
+                seenRecord = true;
                 inRecord = true;
                 dkimResult = null;
                 spfResult = null;

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -1,0 +1,243 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.mailet.Mail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DmarcReportAnalyzer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmarcReportAnalyzer.class);
+
+    private static final Pattern DMARC_SUBJECT_PATTERN = Pattern.compile(
+        "(?i)Report\\s+Domain:[^\\r\\n]+Submitter:");
+
+    private static final long MAX_UNCOMPRESSED_BYTES = 50L * 1024 * 1024;
+
+    private static final XMLInputFactory XML_INPUT_FACTORY;
+
+    static {
+        XML_INPUT_FACTORY = XMLInputFactory.newFactory();
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    }
+
+    /**
+     * Analyzes a mail to determine if it is a DMARC aggregate report with authentication failures.
+     *
+     * @return {@code Optional.empty()} if the mail is not a DMARC report or cannot be parsed;
+     *         {@code Optional.of(true)} if at least one record has both dkim=fail and spf=fail;
+     *         {@code Optional.of(false)} if the report has no such failures.
+     */
+    static Optional<Boolean> analyze(Mail mail) throws MessagingException {
+        String subject = mail.getMessage().getSubject();
+        if (subject == null || !DMARC_SUBJECT_PATTERN.matcher(subject).find()) {
+            return Optional.empty();
+        }
+
+        try {
+            return findAndParseAttachment(mail.getMessage());
+        } catch (Exception e) {
+            LOGGER.warn("Failed to analyze DMARC report attachment", e);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Boolean> findAndParseAttachment(MimeMessage msg)
+            throws MessagingException, IOException, XMLStreamException {
+        if (!msg.isMimeType("multipart/*")) {
+            return Optional.empty();
+        }
+        return findAndParseInMultipart((Multipart) msg.getContent());
+    }
+
+    private static Optional<Boolean> findAndParseInMultipart(Multipart mp)
+            throws MessagingException, IOException, XMLStreamException {
+        for (int i = 0; i < mp.getCount(); i++) {
+            BodyPart part = mp.getBodyPart(i);
+            Optional<Boolean> result = tryParsePart(part);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Boolean> tryParsePart(BodyPart part)
+            throws MessagingException, IOException, XMLStreamException {
+        String filename = Optional.ofNullable(part.getFileName()).orElse("").toLowerCase();
+        String ct = part.getContentType().split(";")[0].trim().toLowerCase();
+
+        if (ct.equals("application/zip") || ct.equals("application/x-zip") || filename.endsWith(".zip")) {
+            return parseZip(part.getInputStream());
+        }
+        if (ct.equals("application/gzip") || ct.equals("application/x-gzip") || filename.endsWith(".gz")) {
+            return parseGzip(part.getInputStream());
+        }
+        if (ct.equals("application/xml") || ct.equals("text/xml") || filename.endsWith(".xml")) {
+            return parseXml(limitedStream(part.getInputStream(), MAX_UNCOMPRESSED_BYTES));
+        }
+
+        Object content = part.getContent();
+        if (content instanceof Multipart) {
+            return findAndParseInMultipart((Multipart) content);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Boolean> parseZip(InputStream raw) throws IOException, XMLStreamException {
+        ZipInputStream zis = new ZipInputStream(raw);
+        ZipEntry entry;
+        while ((entry = zis.getNextEntry()) != null) {
+            if (!entry.isDirectory()) {
+                Optional<Boolean> result = parseXml(limitedStream(zis, MAX_UNCOMPRESSED_BYTES));
+                if (result.isPresent()) {
+                    return result;
+                }
+            }
+            zis.closeEntry();
+        }
+        LOGGER.warn("No XML entry found in DMARC ZIP attachment");
+        return Optional.empty();
+    }
+
+    private static Optional<Boolean> parseGzip(InputStream raw) throws IOException, XMLStreamException {
+        return parseXml(limitedStream(new GZIPInputStream(raw), MAX_UNCOMPRESSED_BYTES));
+    }
+
+    private static Optional<Boolean> parseXml(InputStream xmlStream) throws XMLStreamException {
+        XMLStreamReader reader = XML_INPUT_FACTORY.createXMLStreamReader(xmlStream);
+        try {
+            return scanForIssues(reader);
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static Optional<Boolean> scanForIssues(XMLStreamReader reader) throws XMLStreamException {
+        boolean inRecord = false;
+        boolean inPolicyEvaluated = false;
+        String currentElement = null;
+        String dkimResult = null;
+        String spfResult = null;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            switch (event) {
+                case XMLStreamConstants.DTD:
+                    throw new XMLStreamException("DTD declarations are not allowed in DMARC reports");
+                case XMLStreamConstants.START_ELEMENT: {
+                    String name = reader.getLocalName();
+                    if ("record".equals(name)) {
+                        inRecord = true;
+                        dkimResult = null;
+                        spfResult = null;
+                    } else if ("policy_evaluated".equals(name) && inRecord) {
+                        inPolicyEvaluated = true;
+                    } else if (inPolicyEvaluated) {
+                        currentElement = name;
+                    }
+                    break;
+                }
+                case XMLStreamConstants.CHARACTERS:
+                case XMLStreamConstants.CDATA: {
+                    if (inPolicyEvaluated && currentElement != null) {
+                        String text = reader.getText();
+                        if ("dkim".equals(currentElement)) {
+                            dkimResult = (dkimResult == null ? "" : dkimResult) + text;
+                        } else if ("spf".equals(currentElement)) {
+                            spfResult = (spfResult == null ? "" : spfResult) + text;
+                        }
+                    }
+                    break;
+                }
+                case XMLStreamConstants.END_ELEMENT: {
+                    String name = reader.getLocalName();
+                    if ("policy_evaluated".equals(name)) {
+                        inPolicyEvaluated = false;
+                        currentElement = null;
+                    } else if ("record".equals(name)) {
+                        inRecord = false;
+                        if (isFail(dkimResult) && isFail(spfResult)) {
+                            return Optional.of(true);
+                        }
+                        dkimResult = null;
+                        spfResult = null;
+                    } else if (inPolicyEvaluated && name.equals(currentElement)) {
+                        currentElement = null;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+        return Optional.of(false);
+    }
+
+    private static boolean isFail(String value) {
+        return value != null && "fail".equalsIgnoreCase(value.trim());
+    }
+
+    private static InputStream limitedStream(InputStream in, long maxBytes) {
+        return new FilterInputStream(in) {
+            private long bytesRead = 0;
+
+            @Override
+            public int read() throws IOException {
+                int b = super.read();
+                if (b != -1 && ++bytesRead > maxBytes) {
+                    throw new IOException("DMARC attachment exceeds maximum allowed size of " + maxBytes + " bytes");
+                }
+                return b;
+            }
+
+            @Override
+            public int read(byte[] buf, int off, int len) throws IOException {
+                int n = super.read(buf, off, len);
+                if (n > 0) {
+                    bytesRead += n;
+                    if (bytesRead > maxBytes) {
+                        throw new IOException("DMARC attachment exceeds maximum allowed size of " + maxBytes + " bytes");
+                    }
+                }
+                return n;
+            }
+        };
+    }
+}

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -78,18 +78,18 @@ class DmarcReportAnalyzer {
         }
     }
 
-    private static Optional<Boolean> findAndParseAttachment(MimeMessage msg)
+    private static Optional<Boolean> findAndParseAttachment(MimeMessage message)
             throws MessagingException, IOException, XMLStreamException {
-        if (!msg.isMimeType("multipart/*")) {
+        if (!message.isMimeType("multipart/*")) {
             return Optional.empty();
         }
-        return findAndParseInMultipart((Multipart) msg.getContent());
+        return findAndParseInMultipart((Multipart) message.getContent());
     }
 
-    private static Optional<Boolean> findAndParseInMultipart(Multipart mp)
+    private static Optional<Boolean> findAndParseInMultipart(Multipart multipart)
             throws MessagingException, IOException, XMLStreamException {
-        for (int i = 0; i < mp.getCount(); i++) {
-            BodyPart part = mp.getBodyPart(i);
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart part = multipart.getBodyPart(i);
             Optional<Boolean> result = tryParsePart(part);
             if (result.isPresent()) {
                 return result;
@@ -101,47 +101,59 @@ class DmarcReportAnalyzer {
     private static Optional<Boolean> tryParsePart(BodyPart part)
             throws MessagingException, IOException, XMLStreamException {
         String filename = Optional.ofNullable(part.getFileName()).orElse("").toLowerCase();
-        String ct = part.getContentType().split(";")[0].trim().toLowerCase();
+        String contentType = part.getContentType().split(";")[0].trim().toLowerCase();
 
-        if (ct.equals("application/zip") || ct.equals("application/x-zip") || filename.endsWith(".zip")) {
+        if (isZip(contentType, filename)) {
             return parseZip(part.getInputStream());
         }
-        if (ct.equals("application/gzip") || ct.equals("application/x-gzip") || filename.endsWith(".gz")) {
+        if (isGzip(contentType, filename)) {
             return parseGzip(part.getInputStream());
         }
-        if (ct.equals("application/xml") || ct.equals("text/xml") || filename.endsWith(".xml")) {
+        if (isXml(contentType, filename)) {
             return parseXml(limitedStream(part.getInputStream(), MAX_UNCOMPRESSED_BYTES));
         }
 
         Object content = part.getContent();
-        if (content instanceof Multipart) {
-            return findAndParseInMultipart((Multipart) content);
+        if (content instanceof Multipart nestedMultipart) {
+            return findAndParseInMultipart(nestedMultipart);
         }
         return Optional.empty();
     }
 
-    private static Optional<Boolean> parseZip(InputStream raw) throws IOException, XMLStreamException {
-        ZipInputStream zis = new ZipInputStream(raw);
+    private static boolean isZip(String contentType, String filename) {
+        return contentType.equals("application/zip") || contentType.equals("application/x-zip") || filename.endsWith(".zip");
+    }
+
+    private static boolean isGzip(String contentType, String filename) {
+        return contentType.equals("application/gzip") || contentType.equals("application/x-gzip") || filename.endsWith(".gz");
+    }
+
+    private static boolean isXml(String contentType, String filename) {
+        return contentType.equals("application/xml") || contentType.equals("text/xml") || filename.endsWith(".xml");
+    }
+
+    private static Optional<Boolean> parseZip(InputStream rawInputStream) throws IOException, XMLStreamException {
+        ZipInputStream zipInputStream = new ZipInputStream(rawInputStream);
         ZipEntry entry;
-        while ((entry = zis.getNextEntry()) != null) {
+        while ((entry = zipInputStream.getNextEntry()) != null) {
             if (!entry.isDirectory()) {
-                Optional<Boolean> result = parseXml(limitedStream(zis, MAX_UNCOMPRESSED_BYTES));
+                Optional<Boolean> result = parseXml(limitedStream(zipInputStream, MAX_UNCOMPRESSED_BYTES));
                 if (result.isPresent()) {
                     return result;
                 }
             }
-            zis.closeEntry();
+            zipInputStream.closeEntry();
         }
         LOGGER.warn("No XML entry found in DMARC ZIP attachment");
         return Optional.empty();
     }
 
-    private static Optional<Boolean> parseGzip(InputStream raw) throws IOException, XMLStreamException {
-        return parseXml(limitedStream(new GZIPInputStream(raw), MAX_UNCOMPRESSED_BYTES));
+    private static Optional<Boolean> parseGzip(InputStream rawInputStream) throws IOException, XMLStreamException {
+        return parseXml(limitedStream(new GZIPInputStream(rawInputStream), MAX_UNCOMPRESSED_BYTES));
     }
 
-    private static Optional<Boolean> parseXml(InputStream xmlStream) throws XMLStreamException {
-        XMLStreamReader reader = XML_INPUT_FACTORY.createXMLStreamReader(xmlStream);
+    private static Optional<Boolean> parseXml(InputStream xmlInputStream) throws XMLStreamException {
+        XMLStreamReader reader = XML_INPUT_FACTORY.createXMLStreamReader(xmlInputStream);
         try {
             return scanForIssues(reader);
         } finally {
@@ -152,21 +164,26 @@ class DmarcReportAnalyzer {
     private static Optional<Boolean> scanForIssues(XMLStreamReader reader) throws XMLStreamException {
         RecordState state = new RecordState();
         while (reader.hasNext()) {
-            int event = reader.next();
-            if (event == XMLStreamConstants.DTD) {
+            int eventType = reader.next();
+            if (eventType == XMLStreamConstants.DTD) {
                 throw new XMLStreamException("DTD declarations are not allowed in DMARC reports");
             }
-            if (event == XMLStreamConstants.START_ELEMENT) {
-                state.onStartElement(reader.getLocalName());
-            } else if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
-                state.onText(reader.getText());
-            } else if (event == XMLStreamConstants.END_ELEMENT) {
-                if (state.onEndElement(reader.getLocalName())) {
-                    return Optional.of(true);
-                }
+            if (dispatchXmlEvent(reader, state, eventType)) {
+                return Optional.of(true);
             }
         }
         return Optional.of(false);
+    }
+
+    private static boolean dispatchXmlEvent(XMLStreamReader reader, RecordState state, int eventType) throws XMLStreamException {
+        if (eventType == XMLStreamConstants.START_ELEMENT) {
+            state.onStartElement(reader.getLocalName());
+        } else if (eventType == XMLStreamConstants.CHARACTERS || eventType == XMLStreamConstants.CDATA) {
+            state.onText(reader.getText());
+        } else if (eventType == XMLStreamConstants.END_ELEMENT) {
+            return state.onEndElement(reader.getLocalName());
+        }
+        return false;
     }
 
     private static boolean isFail(String value) {

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/DmarcReportAnalyzer.java
@@ -264,6 +264,14 @@ class DmarcReportAnalyzer {
         return new FilterInputStream(in) {
             private long bytesRead = 0;
 
+            // Close-shield: the XML reader auto-closes its input on END_DOCUMENT, but the
+            // underlying stream (ZIP entry, GZIP or part stream) is owned and closed by the
+            // caller's try-with-resources. Closing it here would break ZipInputStream.closeEntry().
+            @Override
+            public void close() {
+                // no-op
+            }
+
             @Override
             public int read() throws IOException {
                 int b = super.read();

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/IsDmarcReportWithIssues.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/IsDmarcReportWithIssues.java
@@ -1,0 +1,58 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Collection;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Matches DMARC aggregate report emails that contain at least one authentication failure.
+ *
+ * <p>A failure is defined as a {@code <record>} element where both
+ * {@code policy_evaluated/dkim} and {@code policy_evaluated/spf} are {@code fail}.
+ * This is the unambiguous signal that a message from that source was unauthenticated
+ * (DMARC passes when either alignment check passes).</p>
+ *
+ * <p>Handles ZIP, GZIP and plain XML attachments. Protects against XXE and zip-bomb
+ * attacks. Returns no match if the email is not a recognizable DMARC report or if
+ * the attachment cannot be parsed.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre><code>
+ * &lt;mailet match="IsDmarcReportWithIssues" class="ToRepository"&gt;
+ *   &lt;repositoryPath&gt;var://storage/inbox-dmarc-issues&lt;/repositoryPath&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ */
+public class IsDmarcReportWithIssues extends GenericMatcher {
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        return DmarcReportAnalyzer.analyze(mail)
+            .filter(hasIssues -> hasIssues)
+            .map(ignored -> mail.getRecipients())
+            .orElse(ImmutableList.of());
+    }
+}

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssues.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssues.java
@@ -1,0 +1,57 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Collection;
+
+import jakarta.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Matches DMARC aggregate report emails where all records pass authentication checks.
+ *
+ * <p>A report has no issues when no {@code <record>} element has both
+ * {@code policy_evaluated/dkim} and {@code policy_evaluated/spf} set to {@code fail}.
+ * Reports with a mix of passing and failing records do NOT match this matcher.</p>
+ *
+ * <p>Returns no match if the email is not a recognizable DMARC report, or if
+ * the attachment cannot be parsed (fail-safe: unclassified reports stay in INBOX).</p>
+ *
+ * <p>Example usage (archive clean reports, leave problematic ones in INBOX):</p>
+ * <pre><code>
+ * &lt;mailet match="And=(RecipientIs=dmarc-reports@example.com, IsDmarcReportWithoutIssues)"
+ *         class="ToRepository"&gt;
+ *   &lt;repositoryPath&gt;var://storage/archive&lt;/repositoryPath&gt;
+ * &lt;/mailet&gt;
+ * </code></pre>
+ */
+public class IsDmarcReportWithoutIssues extends GenericMatcher {
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        return DmarcReportAnalyzer.analyze(mail)
+            .filter(hasIssues -> !hasIssues)
+            .map(ignored -> mail.getRecipients())
+            .orElse(ImmutableList.of());
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/DmarcReportMatcherTestBase.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/DmarcReportMatcherTestBase.java
@@ -1,0 +1,122 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import jakarta.activation.DataHandler;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.base.test.FakeMail;
+
+abstract class DmarcReportMatcherTestBase {
+    protected static final MailAddress RECIPIENT = newAddress("recipient@example.com");
+    protected static final String DMARC_SUBJECT =
+        "Report Domain: example.com Submitter: google.com Report-ID: 12345";
+
+    record Attachment(byte[] bytes, String contentType, String filename) {}
+
+    protected FakeMail mailWithZipAttachment(String subject, String xmlContent) throws Exception {
+        byte[] zipBytes = createZip("report.xml", xmlContent.getBytes(StandardCharsets.UTF_8));
+        return mailWithAttachment(subject, new Attachment(zipBytes, "application/zip",
+            "example.com!google.com!1749340800!1749427199.zip"));
+    }
+
+    protected FakeMail mailWithGzipAttachment(String subject, String xmlContent) throws Exception {
+        byte[] gzipBytes = createGzip(xmlContent.getBytes(StandardCharsets.UTF_8));
+        return mailWithAttachment(subject, new Attachment(gzipBytes, "application/gzip",
+            "example.com!google.com!1749340800!1749427199.xml.gz"));
+    }
+
+    protected FakeMail mailWithXmlAttachment(String subject, String xmlContent) throws Exception {
+        return mailWithAttachment(subject, new Attachment(
+            xmlContent.getBytes(StandardCharsets.UTF_8), "application/xml",
+            "example.com!google.com!1749340800!1749427199.xml"));
+    }
+
+    private FakeMail mailWithAttachment(String subject, Attachment attachment) throws Exception {
+        MimeMessage message = buildMultipartMessage(subject, attachment);
+        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
+    }
+
+    private static MimeMessage buildMultipartMessage(String subject, Attachment attachment) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage message = new MimeMessage(session);
+        message.setSubject(subject);
+
+        MimeMultipart multipart = new MimeMultipart("mixed");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("DMARC aggregate report");
+        multipart.addBodyPart(textPart);
+
+        MimeBodyPart attachPart = new MimeBodyPart();
+        attachPart.setDataHandler(new DataHandler(
+            new ByteArrayDataSource(attachment.bytes(), attachment.contentType())));
+        attachPart.setFileName(attachment.filename());
+        multipart.addBodyPart(attachPart);
+
+        message.setContent(multipart);
+        message.saveChanges();
+
+        // Write and re-read so parts are backed by DataSource, enabling getInputStream().
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        message.writeTo(baos);
+        return new MimeMessage(session, new ByteArrayInputStream(baos.toByteArray()));
+    }
+
+    private static byte[] createZip(String entryName, byte[] content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry(entryName);
+            zos.putNextEntry(entry);
+            zos.write(content);
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] createGzip(byte[] content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+            gzos.write(content);
+        }
+        return baos.toByteArray();
+    }
+
+    protected static MailAddress newAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithIssuesTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithIssuesTest.java
@@ -1,0 +1,291 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import jakarta.activation.DataHandler;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IsDmarcReportWithIssuesTest {
+    private static final MailAddress RECIPIENT = newAddress("recipient@example.com");
+    private static final String DMARC_SUBJECT = "Report Domain: example.com Submitter: google.com Report-ID: 12345";
+
+    private static final String REPORT_WITH_ISSUES = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>1</count>
+              <policy_evaluated>
+                <disposition>quarantine</disposition>
+                <dkim>fail</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_WITHOUT_ISSUES = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>5</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_MIXED_RECORDS = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>5</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+          <record>
+            <row>
+              <source_ip>198.51.100.1</source_ip>
+              <count>2</count>
+              <policy_evaluated>
+                <disposition>quarantine</disposition>
+                <dkim>fail</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_DISPOSITION_QUARANTINE_BUT_DKIM_PASS = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>3</count>
+              <policy_evaluated>
+                <disposition>quarantine</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private IsDmarcReportWithIssues matcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        matcher = new IsDmarcReportWithIssues();
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("IsDmarcReportWithIssues")
+            .build());
+    }
+
+    @Test
+    void shouldMatchWhenReportHasIssuesInZip() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_WITH_ISSUES));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenReportHasIssuesInGzip() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithGzipAttachment(DMARC_SUBJECT, REPORT_WITH_ISSUES));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenReportHasIssuesInPlainXml() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithXmlAttachment(DMARC_SUBJECT, REPORT_WITH_ISSUES));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenMixedRecordsContainAtLeastOneFailing() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_MIXED_RECORDS));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldNotMatchWhenReportHasNoIssues() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_WITHOUT_ISSUES));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenDispositionIsQuarantineButDkimPasses() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_DISPOSITION_QUARANTINE_BUT_DKIM_PASS));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenSubjectDoesNotMatchDmarcPattern() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment("Regular email subject", REPORT_WITH_ISSUES));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenMalformedXml() throws Exception {
+        String malformed = "<this is not valid xml";
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, malformed));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenXmlContainsDoctypeDeclaration() throws Exception {
+        String withDoctype = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE feedback [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+            <feedback>
+              <record>
+                <row>
+                  <policy_evaluated>
+                    <dkim>fail</dkim>
+                    <spf>fail</spf>
+                  </policy_evaluated>
+                </row>
+              </record>
+            </feedback>
+            """;
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, withDoctype));
+
+        assertThat(result).isEmpty();
+    }
+
+    private FakeMail mailWithZipAttachment(String subject, String xmlContent) throws Exception {
+        byte[] zipBytes = createZip("report.xml", xmlContent.getBytes(StandardCharsets.UTF_8));
+        MimeMessage message = buildMultipartMessage(subject, zipBytes, "application/zip",
+            "example.com!google.com!1749340800!1749427199.zip");
+        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
+    }
+
+    private FakeMail mailWithGzipAttachment(String subject, String xmlContent) throws Exception {
+        byte[] gzipBytes = createGzip(xmlContent.getBytes(StandardCharsets.UTF_8));
+        MimeMessage message = buildMultipartMessage(subject, gzipBytes, "application/gzip",
+            "example.com!google.com!1749340800!1749427199.xml.gz");
+        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
+    }
+
+    private FakeMail mailWithXmlAttachment(String subject, String xmlContent) throws Exception {
+        MimeMessage message = buildMultipartMessage(subject,
+            xmlContent.getBytes(StandardCharsets.UTF_8), "application/xml",
+            "example.com!google.com!1749340800!1749427199.xml");
+        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
+    }
+
+    private static MimeMessage buildMultipartMessage(String subject, byte[] attachmentBytes,
+            String attachmentContentType, String filename) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage message = new MimeMessage(session);
+        message.setSubject(subject);
+
+        MimeMultipart multipart = new MimeMultipart("mixed");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("DMARC aggregate report");
+        multipart.addBodyPart(textPart);
+
+        MimeBodyPart attachPart = new MimeBodyPart();
+        attachPart.setDataHandler(new DataHandler(new ByteArrayDataSource(attachmentBytes, attachmentContentType)));
+        attachPart.setFileName(filename);
+        multipart.addBodyPart(attachPart);
+
+        message.setContent(multipart);
+        message.saveChanges();
+
+        // Write and re-read to get a MimeMessage backed by a parsed byte stream.
+        // This ensures part.getInputStream() works via DataSource rather than DCH.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        message.writeTo(baos);
+        return new MimeMessage(session, new ByteArrayInputStream(baos.toByteArray()));
+    }
+
+    private static byte[] createZip(String entryName, byte[] content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry(entryName);
+            zos.putNextEntry(entry);
+            zos.write(content);
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] createGzip(byte[] content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+            gzos.write(content);
+        }
+        return baos.toByteArray();
+    }
+
+    private static MailAddress newAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithIssuesTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithIssuesTest.java
@@ -20,33 +20,14 @@ package com.linagora.tmail.mailet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Properties;
-import java.util.zip.GZIPOutputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
-import jakarta.activation.DataHandler;
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeBodyPart;
-import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
-import jakarta.mail.util.ByteArrayDataSource;
 
 import org.apache.james.core.MailAddress;
-import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMatcherConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class IsDmarcReportWithIssuesTest {
-    private static final MailAddress RECIPIENT = newAddress("recipient@example.com");
-    private static final String DMARC_SUBJECT = "Report Domain: example.com Submitter: google.com Report-ID: 12345";
-
+class IsDmarcReportWithIssuesTest extends DmarcReportMatcherTestBase {
     private static final String REPORT_WITH_ISSUES = """
         <?xml version="1.0" encoding="UTF-8"?>
         <feedback>
@@ -173,7 +154,8 @@ class IsDmarcReportWithIssuesTest {
 
     @Test
     void shouldNotMatchWhenDispositionIsQuarantineButDkimPasses() throws Exception {
-        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_DISPOSITION_QUARANTINE_BUT_DKIM_PASS));
+        Collection<MailAddress> result = matcher.match(
+            mailWithZipAttachment(DMARC_SUBJECT, REPORT_DISPOSITION_QUARANTINE_BUT_DKIM_PASS));
 
         assertThat(result).isEmpty();
     }
@@ -212,80 +194,5 @@ class IsDmarcReportWithIssuesTest {
         Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, withDoctype));
 
         assertThat(result).isEmpty();
-    }
-
-    private FakeMail mailWithZipAttachment(String subject, String xmlContent) throws Exception {
-        byte[] zipBytes = createZip("report.xml", xmlContent.getBytes(StandardCharsets.UTF_8));
-        MimeMessage message = buildMultipartMessage(subject, zipBytes, "application/zip",
-            "example.com!google.com!1749340800!1749427199.zip");
-        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
-    }
-
-    private FakeMail mailWithGzipAttachment(String subject, String xmlContent) throws Exception {
-        byte[] gzipBytes = createGzip(xmlContent.getBytes(StandardCharsets.UTF_8));
-        MimeMessage message = buildMultipartMessage(subject, gzipBytes, "application/gzip",
-            "example.com!google.com!1749340800!1749427199.xml.gz");
-        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
-    }
-
-    private FakeMail mailWithXmlAttachment(String subject, String xmlContent) throws Exception {
-        MimeMessage message = buildMultipartMessage(subject,
-            xmlContent.getBytes(StandardCharsets.UTF_8), "application/xml",
-            "example.com!google.com!1749340800!1749427199.xml");
-        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
-    }
-
-    private static MimeMessage buildMultipartMessage(String subject, byte[] attachmentBytes,
-            String attachmentContentType, String filename) throws Exception {
-        Session session = Session.getInstance(new Properties());
-        MimeMessage message = new MimeMessage(session);
-        message.setSubject(subject);
-
-        MimeMultipart multipart = new MimeMultipart("mixed");
-
-        MimeBodyPart textPart = new MimeBodyPart();
-        textPart.setText("DMARC aggregate report");
-        multipart.addBodyPart(textPart);
-
-        MimeBodyPart attachPart = new MimeBodyPart();
-        attachPart.setDataHandler(new DataHandler(new ByteArrayDataSource(attachmentBytes, attachmentContentType)));
-        attachPart.setFileName(filename);
-        multipart.addBodyPart(attachPart);
-
-        message.setContent(multipart);
-        message.saveChanges();
-
-        // Write and re-read to get a MimeMessage backed by a parsed byte stream.
-        // This ensures part.getInputStream() works via DataSource rather than DCH.
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        message.writeTo(baos);
-        return new MimeMessage(session, new ByteArrayInputStream(baos.toByteArray()));
-    }
-
-    private static byte[] createZip(String entryName, byte[] content) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            ZipEntry entry = new ZipEntry(entryName);
-            zos.putNextEntry(entry);
-            zos.write(content);
-            zos.closeEntry();
-        }
-        return baos.toByteArray();
-    }
-
-    private static byte[] createGzip(byte[] content) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
-            gzos.write(content);
-        }
-        return baos.toByteArray();
-    }
-
-    private static MailAddress newAddress(String address) {
-        try {
-            return new MailAddress(address);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssuesTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssuesTest.java
@@ -1,0 +1,243 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import jakarta.activation.DataHandler;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IsDmarcReportWithoutIssuesTest {
+    private static final MailAddress RECIPIENT = newAddress("recipient@example.com");
+    private static final String DMARC_SUBJECT = "Report Domain: example.com Submitter: google.com Report-ID: 12345";
+
+    private static final String REPORT_WITHOUT_ISSUES = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>5</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_ALL_RECORDS_PASS = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>5</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+          <record>
+            <row>
+              <source_ip>198.51.100.1</source_ip>
+              <count>3</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>fail</dkim>
+                <spf>pass</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_WITH_ISSUES = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>1</count>
+              <policy_evaluated>
+                <disposition>quarantine</disposition>
+                <dkim>fail</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private static final String REPORT_MIXED_RECORDS = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feedback>
+          <record>
+            <row>
+              <source_ip>192.0.2.1</source_ip>
+              <count>5</count>
+              <policy_evaluated>
+                <disposition>none</disposition>
+                <dkim>pass</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+          <record>
+            <row>
+              <source_ip>198.51.100.1</source_ip>
+              <count>2</count>
+              <policy_evaluated>
+                <disposition>quarantine</disposition>
+                <dkim>fail</dkim>
+                <spf>fail</spf>
+              </policy_evaluated>
+            </row>
+          </record>
+        </feedback>
+        """;
+
+    private IsDmarcReportWithoutIssues matcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        matcher = new IsDmarcReportWithoutIssues();
+        matcher.init(FakeMatcherConfig.builder()
+            .matcherName("IsDmarcReportWithoutIssues")
+            .build());
+    }
+
+    @Test
+    void shouldMatchWhenReportHasNoIssues() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_WITHOUT_ISSUES));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldMatchWhenAllRecordsPassWithAtLeastOneDkimOrSpf() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_ALL_RECORDS_PASS));
+
+        assertThat(result).containsOnly(RECIPIENT);
+    }
+
+    @Test
+    void shouldNotMatchWhenReportHasIssues() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_WITH_ISSUES));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenMixedRecordsContainAtLeastOneFailing() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, REPORT_MIXED_RECORDS));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenSubjectDoesNotMatchDmarcPattern() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment("Random subject", REPORT_WITHOUT_ISSUES));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenMalformedXml() throws Exception {
+        Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, "not xml"));
+
+        assertThat(result).isEmpty();
+    }
+
+    private FakeMail mailWithZipAttachment(String subject, String xmlContent) throws Exception {
+        byte[] zipBytes = createZip("report.xml", xmlContent.getBytes(StandardCharsets.UTF_8));
+        MimeMessage message = buildMultipartMessage(subject, zipBytes, "application/zip",
+            "example.com!google.com!1749340800!1749427199.zip");
+        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
+    }
+
+    private static MimeMessage buildMultipartMessage(String subject, byte[] attachmentBytes,
+            String attachmentContentType, String filename) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage message = new MimeMessage(session);
+        message.setSubject(subject);
+
+        MimeMultipart multipart = new MimeMultipart("mixed");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("DMARC aggregate report");
+        multipart.addBodyPart(textPart);
+
+        MimeBodyPart attachPart = new MimeBodyPart();
+        attachPart.setDataHandler(new DataHandler(new ByteArrayDataSource(attachmentBytes, attachmentContentType)));
+        attachPart.setFileName(filename);
+        multipart.addBodyPart(attachPart);
+
+        message.setContent(multipart);
+        message.saveChanges();
+
+        // Write and re-read so parts are backed by DataSource (not DataHandler+Object),
+        // enabling getInputStream() without requiring a DCH for the attachment MIME type.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        message.writeTo(baos);
+        return new MimeMessage(session, new ByteArrayInputStream(baos.toByteArray()));
+    }
+
+    private static byte[] createZip(String entryName, byte[] content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry(entryName);
+            zos.putNextEntry(entry);
+            zos.write(content);
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    private static MailAddress newAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssuesTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/IsDmarcReportWithoutIssuesTest.java
@@ -20,32 +20,14 @@ package com.linagora.tmail.mailet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Properties;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
-import jakarta.activation.DataHandler;
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeBodyPart;
-import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
-import jakarta.mail.util.ByteArrayDataSource;
 
 import org.apache.james.core.MailAddress;
-import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMatcherConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class IsDmarcReportWithoutIssuesTest {
-    private static final MailAddress RECIPIENT = newAddress("recipient@example.com");
-    private static final String DMARC_SUBJECT = "Report Domain: example.com Submitter: google.com Report-ID: 12345";
-
+class IsDmarcReportWithoutIssuesTest extends DmarcReportMatcherTestBase {
     private static final String REPORT_WITHOUT_ISSUES = """
         <?xml version="1.0" encoding="UTF-8"?>
         <feedback>
@@ -186,58 +168,5 @@ class IsDmarcReportWithoutIssuesTest {
         Collection<MailAddress> result = matcher.match(mailWithZipAttachment(DMARC_SUBJECT, "not xml"));
 
         assertThat(result).isEmpty();
-    }
-
-    private FakeMail mailWithZipAttachment(String subject, String xmlContent) throws Exception {
-        byte[] zipBytes = createZip("report.xml", xmlContent.getBytes(StandardCharsets.UTF_8));
-        MimeMessage message = buildMultipartMessage(subject, zipBytes, "application/zip",
-            "example.com!google.com!1749340800!1749427199.zip");
-        return FakeMail.builder().name("test").recipient(RECIPIENT).mimeMessage(message).build();
-    }
-
-    private static MimeMessage buildMultipartMessage(String subject, byte[] attachmentBytes,
-            String attachmentContentType, String filename) throws Exception {
-        Session session = Session.getInstance(new Properties());
-        MimeMessage message = new MimeMessage(session);
-        message.setSubject(subject);
-
-        MimeMultipart multipart = new MimeMultipart("mixed");
-
-        MimeBodyPart textPart = new MimeBodyPart();
-        textPart.setText("DMARC aggregate report");
-        multipart.addBodyPart(textPart);
-
-        MimeBodyPart attachPart = new MimeBodyPart();
-        attachPart.setDataHandler(new DataHandler(new ByteArrayDataSource(attachmentBytes, attachmentContentType)));
-        attachPart.setFileName(filename);
-        multipart.addBodyPart(attachPart);
-
-        message.setContent(multipart);
-        message.saveChanges();
-
-        // Write and re-read so parts are backed by DataSource (not DataHandler+Object),
-        // enabling getInputStream() without requiring a DCH for the attachment MIME type.
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        message.writeTo(baos);
-        return new MimeMessage(session, new ByteArrayInputStream(baos.toByteArray()));
-    }
-
-    private static byte[] createZip(String entryName, byte[] content) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            ZipEntry entry = new ZipEntry(entryName);
-            zos.putNextEntry(entry);
-            zos.write(content);
-            zos.closeEntry();
-        }
-        return baos.toByteArray();
-    }
-
-    private static MailAddress newAddress(String address) {
-        try {
-            return new MailAddress(address);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DMARC aggregate report routing to identify emails with authentication issues across ZIP, GZIP, and XML attachments.
  * Added matchers to separate “has issues” vs “no issues” outcomes for clearer downstream handling.
* **Bug Fixes**
  * Improved DMARC report detection by robustly analyzing nested message parts and safely parsing report XML.
  * Strengthened security by rejecting unsafe XML content (including `DOCTYPE`/DTD) and avoiding incorrect matches on malformed reports.
* **Tests**
  * Added unit tests for issue/no-issue logic, mixed records, subject mismatch, malformed XML, and XXE protection across supported attachment formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->