### PR TITLE
ISSUE-2375 Webadmin tasks to provision templates from a reference account

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1785,3 +1785,70 @@ Return codes:
 
 Note: this endpoint is only available in LDAP-based deployments.
 
+== Templates provisioning
+
+Email templates are simply messages stored in a user's `Templates` mailbox. These endpoints allow
+administrators to provision the templates of a reference (admin-controlled) account into the
+`Templates` mailbox of other users, so that a curated set of templates can be shared.
+
+The reference templates live in the `Templates` mailbox (or any sub-folder, see `folderName`) of a
+designated source account given by the `from` query parameter. The admin edits these templates with
+the regular JMAP / Twake Mail UI: no dedicated template store is involved.
+
+The operations are asynchronous and return a task identifier that can be polled for completion
+via `GET /tasks/{taskId}/await`.
+
+Templates are deduplicated across runs using their RFC 5322 `Message-Id` header, so re-provisioning
+after editing the reference templates is safe.
+
+Common query parameters:
+
+- `from` (required): the source account whose templates folder is the reference.
+- `folderName` (optional, default: `Templates`): the mailbox name to copy from the source account
+  and into the target accounts. Lets an admin manage several categories of templates
+  (e.g. `Templates.Marketing`).
+- `overwriteExisting` (optional, default: `false`): when `true`, a target template sharing its
+  `Message-Id` with a reference template is replaced; otherwise it is left untouched (skipped).
+- `prune` (optional, default: `false`): when `true`, target templates whose `Message-Id` is no
+  longer present in the reference folder are deleted (full mirror); otherwise the operation is
+  copy-only.
+
+The target `Templates` folder is created when missing.
+
+=== Provisioning templates to all users of a domain
+
+....
+curl -XPOST 'http://ip:port/domains/domain.tld/templates?action=provision&from=templates@domain.tld'
+....
+
+Provisions the reference templates into the `Templates` mailbox of every user of the domain. The
+source account itself is skipped.
+
+In addition to the common query parameters above:
+
+- `usersPerSecond` (optional, default: 1): maximum number of users processed per second (throttling).
+
+Return codes:
+
+- `201` Task created — response body contains `{"taskId": "<id>"}`.
+  The task's `additionalInformation` exposes `processedUsers`, `appliedTemplates`, `skippedTemplates`,
+  `removedTemplates` and `failedUsers`.
+- `400` Unknown `action`, missing `from`, invalid domain or invalid `usersPerSecond`
+- `404` Domain does not exist, or the source folder does not exist
+
+=== Provisioning templates to a single user
+
+....
+curl -XPOST 'http://ip:port/users/bob@domain.tld/templates?action=provision&from=templates@domain.tld'
+....
+
+Provisions the reference templates into the `Templates` mailbox of a single target user.
+
+Return codes:
+
+- `201` Task created — response body contains `{"taskId": "<id>"}`.
+  The task's `additionalInformation` exposes `processedUsers`, `appliedTemplates`, `skippedTemplates`,
+  `removedTemplates` and `failedUsers`.
+- `400` Unknown `action`, missing `from`, or invalid username
+- `404` The source folder does not exist
+

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -239,6 +239,7 @@ import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
+import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
 import reactor.core.publisher.Mono;
 
@@ -295,6 +296,7 @@ public class DistributedServer {
         new EmailAddressContactRoutesModule(),
         new UserIdentityModule(),
         new MailboxesCleanupModule(),
+        new TemplatesProvisionModule(),
         new DomainTasksModule(),
         new MailboxResourcesLocationRoutesModule(),
         new InboxArchivalTaskModule(),

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -139,6 +139,7 @@ import com.linagora.tmail.webadmin.jmap.JmapSettingsRoutesModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
+import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
 public class MemoryServer {
     public static final Module IN_MEMORY_SERVER_MODULE = Modules.combine(
@@ -182,6 +183,7 @@ public class MemoryServer {
         new PublicAssetsMemoryModule(),
         new MessageVaultCapabilitiesModule(),
         new MailboxesCleanupModule(),
+        new TemplatesProvisionModule(),
         new DomainTasksModule(),
         new MailboxResourcesLocationRoutesModule(),
         new InboxArchivalTaskModule(),

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -217,6 +217,7 @@ import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
+import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
 import reactor.core.publisher.Mono;
 
@@ -304,6 +305,7 @@ public class PostgresTmailServer {
         new JmapTasksModule(),
         new MailboxRoutesModule(),
         new MailboxesCleanupModule(),
+        new TemplatesProvisionModule(),
         new DomainTasksModule(),
         new MailboxResourcesLocationRoutesModule(),
         new MailboxesBackupRoutesModule(),

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
@@ -74,8 +74,9 @@ public class DomainTemplatesProvisionRoutes implements Routes {
         String folderName = TemplatesProvisionRequest.parseFolderName(request);
         ProvisionOptions options = TemplatesProvisionRequest.parseOptions(request);
         int usersPerSecond = TemplatesProvisionRequest.parseUsersPerSecond(request);
-        assertSourceFolderExists(new TemplatingSource(sourceUser, folderName));
-        return new DomainTemplatesProvisionTask(provisionService, domain, sourceUser, folderName, options, usersPerSecond);
+        TemplatingSource source = new TemplatingSource(sourceUser, folderName);
+        assertSourceFolderExists(source);
+        return new DomainTemplatesProvisionTask(provisionService, domain, source, options, usersPerSecond);
     }
 
     private Domain extractDomain(Request request) {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
@@ -1,0 +1,121 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.task.TaskManager;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.tasks.TaskFromRequest;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import spark.Request;
+import spark.Service;
+
+public class DomainTemplatesProvisionRoutes implements Routes {
+    private static final String DOMAINS_BASE = SEPARATOR + "domains";
+    private static final String DOMAIN_PARAM = ":domain";
+    private static final String TEMPLATES_PATH = DOMAINS_BASE + SEPARATOR + DOMAIN_PARAM + SEPARATOR + "templates";
+
+    private final TaskManager taskManager;
+    private final DomainList domainList;
+    private final TemplatesProvisionService provisionService;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public DomainTemplatesProvisionRoutes(TaskManager taskManager, DomainList domainList,
+                                          TemplatesProvisionService provisionService, JsonTransformer jsonTransformer) {
+        this.taskManager = taskManager;
+        this.domainList = domainList;
+        this.provisionService = provisionService;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return DOMAINS_BASE;
+    }
+
+    @Override
+    public void define(Service service) {
+        TaskFromRequest taskFromRequest = this::createTask;
+        service.post(TEMPLATES_PATH, taskFromRequest.asRoute(taskManager), jsonTransformer);
+    }
+
+    private DomainTemplatesProvisionTask createTask(Request request) {
+        TemplatesProvisionRequest.assertProvisionAction(request);
+        Domain domain = extractDomain(request);
+        assertDomainExists(domain);
+        Username sourceUser = TemplatesProvisionRequest.parseSourceUser(request);
+        String folderName = TemplatesProvisionRequest.parseFolderName(request);
+        ProvisionOptions options = TemplatesProvisionRequest.parseOptions(request);
+        int usersPerSecond = TemplatesProvisionRequest.parseUsersPerSecond(request);
+        assertSourceFolderExists(sourceUser, folderName);
+        return new DomainTemplatesProvisionTask(provisionService, domain, sourceUser, folderName, options, usersPerSecond);
+    }
+
+    private Domain extractDomain(Request request) {
+        try {
+            return Domain.of(request.params(DOMAIN_PARAM));
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid domain: '%s'", request.params(DOMAIN_PARAM))
+                .haltError();
+        }
+    }
+
+    private void assertDomainExists(Domain domain) {
+        try {
+            if (!domainList.containsDomain(domain)) {
+                throw ErrorResponder.builder()
+                    .statusCode(HttpStatus.NOT_FOUND_404)
+                    .type(ErrorResponder.ErrorType.NOT_FOUND)
+                    .message("Domain '%s' does not exist", domain.asString())
+                    .haltError();
+            }
+        } catch (DomainListException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+                .type(ErrorResponder.ErrorType.SERVER_ERROR)
+                .message("Error while checking domain existence")
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private void assertSourceFolderExists(Username sourceUser, String folderName) {
+        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(sourceUser, folderName).block())) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Folder '%s' of source user '%s' does not exist", folderName, sourceUser.asString())
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutes.java
@@ -74,7 +74,7 @@ public class DomainTemplatesProvisionRoutes implements Routes {
         String folderName = TemplatesProvisionRequest.parseFolderName(request);
         ProvisionOptions options = TemplatesProvisionRequest.parseOptions(request);
         int usersPerSecond = TemplatesProvisionRequest.parseUsersPerSecond(request);
-        assertSourceFolderExists(sourceUser, folderName);
+        assertSourceFolderExists(new TemplatingSource(sourceUser, folderName));
         return new DomainTemplatesProvisionTask(provisionService, domain, sourceUser, folderName, options, usersPerSecond);
     }
 
@@ -109,12 +109,12 @@ public class DomainTemplatesProvisionRoutes implements Routes {
         }
     }
 
-    private void assertSourceFolderExists(Username sourceUser, String folderName) {
-        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(sourceUser, folderName).block())) {
+    private void assertSourceFolderExists(TemplatingSource source) {
+        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(source).block())) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.NOT_FOUND_404)
                 .type(ErrorResponder.ErrorType.NOT_FOUND)
-                .message("Folder '%s' of source user '%s' does not exist", folderName, sourceUser.asString())
+                .message("Folder '%s' of source user '%s' does not exist", source.folderName(), source.sourceUser().asString())
                 .haltError();
         }
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
@@ -49,8 +49,8 @@ public class DomainTemplatesProvisionTask implements Task {
             TemplatesProvisionContext.Snapshot snapshot = task.context.snapshot();
             return new AdditionalInformation(Clock.systemUTC().instant(),
                 task.domain.asString(),
-                task.sourceUser.asString(),
-                task.folderName,
+                task.source.sourceUser().asString(),
+                task.source.folderName(),
                 task.options.overwriteExisting(),
                 task.options.prune(),
                 task.usersPerSecond,
@@ -64,8 +64,7 @@ public class DomainTemplatesProvisionTask implements Task {
 
     private final TemplatesProvisionService service;
     private final Domain domain;
-    private final Username sourceUser;
-    private final String folderName;
+    private final TemplatingSource source;
     private final ProvisionOptions options;
     private final int usersPerSecond;
     private final TemplatesProvisionContext context;
@@ -74,8 +73,7 @@ public class DomainTemplatesProvisionTask implements Task {
                                         String folderName, ProvisionOptions options, int usersPerSecond) {
         this.service = service;
         this.domain = domain;
-        this.sourceUser = sourceUser;
-        this.folderName = folderName;
+        this.source = new TemplatingSource(sourceUser, folderName);
         this.options = options;
         this.usersPerSecond = usersPerSecond;
         this.context = new TemplatesProvisionContext();
@@ -83,7 +81,7 @@ public class DomainTemplatesProvisionTask implements Task {
 
     @Override
     public Result run() {
-        return service.provisionDomain(domain, sourceUser, folderName, options, usersPerSecond, context).block();
+        return service.provisionDomain(domain, source, options, usersPerSecond, context).block();
     }
 
     @Override
@@ -101,11 +99,11 @@ public class DomainTemplatesProvisionTask implements Task {
     }
 
     public Username getSourceUser() {
-        return sourceUser;
+        return source.sourceUser();
     }
 
     public String getFolderName() {
-        return folderName;
+        return source.folderName();
     }
 
     public ProvisionOptions getOptions() {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
@@ -69,11 +69,11 @@ public class DomainTemplatesProvisionTask implements Task {
     private final int usersPerSecond;
     private final TemplatesProvisionContext context;
 
-    public DomainTemplatesProvisionTask(TemplatesProvisionService service, Domain domain, Username sourceUser,
-                                        String folderName, ProvisionOptions options, int usersPerSecond) {
+    public DomainTemplatesProvisionTask(TemplatesProvisionService service, Domain domain, TemplatingSource source,
+                                        ProvisionOptions options, int usersPerSecond) {
         this.service = service;
         this.domain = domain;
-        this.source = new TemplatingSource(sourceUser, folderName);
+        this.source = source;
         this.options = options;
         this.usersPerSecond = usersPerSecond;
         this.context = new TemplatesProvisionContext();
@@ -81,7 +81,7 @@ public class DomainTemplatesProvisionTask implements Task {
 
     @Override
     public Result run() {
-        return service.provisionDomain(domain, source, options, usersPerSecond, context).block();
+        return service.provisionDomain(domain, source, new TemplatesProvisionService.ProvisionRun(options, context), usersPerSecond).block();
     }
 
     @Override

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTask.java
@@ -1,0 +1,118 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+
+import com.google.common.collect.ImmutableList;
+
+public class DomainTemplatesProvisionTask implements Task {
+    public static final TaskType TASK_TYPE = TaskType.of("DomainTemplatesProvisionTask");
+
+    public record AdditionalInformation(Instant timestamp,
+                                        String domain,
+                                        String sourceUser,
+                                        String folderName,
+                                        boolean overwriteExisting,
+                                        boolean prune,
+                                        int usersPerSecond,
+                                        long processedUsers,
+                                        long appliedTemplates,
+                                        long skippedTemplates,
+                                        long removedTemplates,
+                                        ImmutableList<String> failedUsers) implements TaskExecutionDetails.AdditionalInformation {
+        static AdditionalInformation from(DomainTemplatesProvisionTask task) {
+            TemplatesProvisionContext.Snapshot snapshot = task.context.snapshot();
+            return new AdditionalInformation(Clock.systemUTC().instant(),
+                task.domain.asString(),
+                task.sourceUser.asString(),
+                task.folderName,
+                task.options.overwriteExisting(),
+                task.options.prune(),
+                task.usersPerSecond,
+                snapshot.processedUsers(),
+                snapshot.appliedTemplates(),
+                snapshot.skippedTemplates(),
+                snapshot.removedTemplates(),
+                snapshot.failedUsers());
+        }
+    }
+
+    private final TemplatesProvisionService service;
+    private final Domain domain;
+    private final Username sourceUser;
+    private final String folderName;
+    private final ProvisionOptions options;
+    private final int usersPerSecond;
+    private final TemplatesProvisionContext context;
+
+    public DomainTemplatesProvisionTask(TemplatesProvisionService service, Domain domain, Username sourceUser,
+                                        String folderName, ProvisionOptions options, int usersPerSecond) {
+        this.service = service;
+        this.domain = domain;
+        this.sourceUser = sourceUser;
+        this.folderName = folderName;
+        this.options = options;
+        this.usersPerSecond = usersPerSecond;
+        this.context = new TemplatesProvisionContext();
+    }
+
+    @Override
+    public Result run() {
+        return service.provisionDomain(domain, sourceUser, folderName, options, usersPerSecond, context).block();
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(AdditionalInformation.from(this));
+    }
+
+    public Domain getDomain() {
+        return domain;
+    }
+
+    public Username getSourceUser() {
+        return sourceUser;
+    }
+
+    public String getFolderName() {
+        return folderName;
+    }
+
+    public ProvisionOptions getOptions() {
+        return options;
+    }
+
+    public int getUsersPerSecond() {
+        return usersPerSecond;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskAdditionalInformationDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskAdditionalInformationDTO.java
@@ -1,0 +1,92 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+public record DomainTemplatesProvisionTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                                  @JsonProperty("timestamp") Instant timestamp,
+                                                                  @JsonProperty("domain") String domain,
+                                                                  @JsonProperty("sourceUser") String sourceUser,
+                                                                  @JsonProperty("folderName") String folderName,
+                                                                  @JsonProperty("overwriteExisting") boolean overwriteExisting,
+                                                                  @JsonProperty("prune") boolean prune,
+                                                                  @JsonProperty("usersPerSecond") int usersPerSecond,
+                                                                  @JsonProperty("processedUsers") long processedUsers,
+                                                                  @JsonProperty("appliedTemplates") long appliedTemplates,
+                                                                  @JsonProperty("skippedTemplates") long skippedTemplates,
+                                                                  @JsonProperty("removedTemplates") long removedTemplates,
+                                                                  @JsonProperty("failedUsers") ImmutableList<String> failedUsers) implements AdditionalInformationDTO {
+    public static AdditionalInformationDTOModule<DomainTemplatesProvisionTask.AdditionalInformation, DomainTemplatesProvisionTaskAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(DomainTemplatesProvisionTask.AdditionalInformation.class)
+            .convertToDTO(DomainTemplatesProvisionTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(DomainTemplatesProvisionTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(DomainTemplatesProvisionTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(DomainTemplatesProvisionTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static DomainTemplatesProvisionTaskAdditionalInformationDTO fromDomainObject(DomainTemplatesProvisionTask.AdditionalInformation info, String type) {
+        return new DomainTemplatesProvisionTaskAdditionalInformationDTO(type,
+            info.timestamp(),
+            info.domain(),
+            info.sourceUser(),
+            info.folderName(),
+            info.overwriteExisting(),
+            info.prune(),
+            info.usersPerSecond(),
+            info.processedUsers(),
+            info.appliedTemplates(),
+            info.skippedTemplates(),
+            info.removedTemplates(),
+            info.failedUsers());
+    }
+
+    private DomainTemplatesProvisionTask.AdditionalInformation toDomainObject() {
+        return new DomainTemplatesProvisionTask.AdditionalInformation(timestamp,
+            domain,
+            sourceUser,
+            folderName,
+            overwriteExisting,
+            prune,
+            usersPerSecond,
+            processedUsers,
+            appliedTemplates,
+            skippedTemplates,
+            removedTemplates,
+            failedUsers);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskDTO.java
@@ -38,8 +38,7 @@ public record DomainTemplatesProvisionTaskDTO(@JsonProperty("type") String type,
             .convertToDTO(DomainTemplatesProvisionTaskDTO.class)
             .toDomainObjectConverter(dto -> new DomainTemplatesProvisionTask(service,
                 Domain.of(dto.domain()),
-                Username.of(dto.sourceUser()),
-                dto.folderName(),
+                new TemplatingSource(Username.of(dto.sourceUser()), dto.folderName()),
                 new ProvisionOptions(dto.overwriteExisting(), dto.prune()),
                 dto.usersPerSecond()))
             .toDTOConverter((task, type) -> new DomainTemplatesProvisionTaskDTO(type,

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskDTO.java
@@ -1,0 +1,60 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DomainTemplatesProvisionTaskDTO(@JsonProperty("type") String type,
+                                              @JsonProperty("domain") String domain,
+                                              @JsonProperty("sourceUser") String sourceUser,
+                                              @JsonProperty("folderName") String folderName,
+                                              @JsonProperty("overwriteExisting") boolean overwriteExisting,
+                                              @JsonProperty("prune") boolean prune,
+                                              @JsonProperty("usersPerSecond") int usersPerSecond) implements TaskDTO {
+    public static TaskDTOModule<DomainTemplatesProvisionTask, DomainTemplatesProvisionTaskDTO> module(TemplatesProvisionService service) {
+        return DTOModule.forDomainObject(DomainTemplatesProvisionTask.class)
+            .convertToDTO(DomainTemplatesProvisionTaskDTO.class)
+            .toDomainObjectConverter(dto -> new DomainTemplatesProvisionTask(service,
+                Domain.of(dto.domain()),
+                Username.of(dto.sourceUser()),
+                dto.folderName(),
+                new ProvisionOptions(dto.overwriteExisting(), dto.prune()),
+                dto.usersPerSecond()))
+            .toDTOConverter((task, type) -> new DomainTemplatesProvisionTaskDTO(type,
+                task.getDomain().asString(),
+                task.getSourceUser().asString(),
+                task.getFolderName(),
+                task.getOptions().overwriteExisting(),
+                task.getOptions().prune(),
+                task.getUsersPerSecond()))
+            .typeName(DomainTemplatesProvisionTask.TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/ProvisionOptions.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/ProvisionOptions.java
@@ -1,0 +1,31 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+/**
+ * Options driving how reference templates are applied to a target mailbox.
+ *
+ * @param overwriteExisting when {@code true}, a target template sharing its {@code Message-Id} with a reference
+ *                          template is replaced by the reference one. When {@code false} it is left untouched (skipped).
+ * @param prune             when {@code true}, target templates whose {@code Message-Id} is not part of the reference
+ *                          folder anymore are deleted (full mirror). When {@code false} the operation is copy-only.
+ */
+public record ProvisionOptions(boolean overwriteExisting, boolean prune) {
+    public static final ProvisionOptions DEFAULT = new ProvisionOptions(false, false);
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/SourceTemplatesFolderNotFoundException.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/SourceTemplatesFolderNotFoundException.java
@@ -1,0 +1,27 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import org.apache.james.core.Username;
+
+public class SourceTemplatesFolderNotFoundException extends RuntimeException {
+    public SourceTemplatesFolderNotFoundException(Username sourceUser, String folderName) {
+        super(String.format("Folder '%s' of source user '%s' does not exist", folderName, sourceUser.asString()));
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionContext.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionContext.java
@@ -1,0 +1,75 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.collect.ImmutableList;
+
+public class TemplatesProvisionContext {
+    public record Snapshot(long processedUsers,
+                           long appliedTemplates,
+                           long skippedTemplates,
+                           long removedTemplates,
+                           ImmutableList<String> failedUsers) {
+    }
+
+    private final AtomicLong processedUsers;
+    private final AtomicLong appliedTemplates;
+    private final AtomicLong skippedTemplates;
+    private final AtomicLong removedTemplates;
+    private final ConcurrentLinkedDeque<String> failedUsers;
+
+    public TemplatesProvisionContext() {
+        this.processedUsers = new AtomicLong();
+        this.appliedTemplates = new AtomicLong();
+        this.skippedTemplates = new AtomicLong();
+        this.removedTemplates = new AtomicLong();
+        this.failedUsers = new ConcurrentLinkedDeque<>();
+    }
+
+    public void incrementProcessedUsers() {
+        processedUsers.incrementAndGet();
+    }
+
+    public void incrementAppliedTemplates() {
+        appliedTemplates.incrementAndGet();
+    }
+
+    public void incrementSkippedTemplates() {
+        skippedTemplates.incrementAndGet();
+    }
+
+    public void incrementRemovedTemplates(long amount) {
+        removedTemplates.addAndGet(amount);
+    }
+
+    public void addToFailedUsers(String user) {
+        failedUsers.add(user);
+    }
+
+    public Snapshot snapshot() {
+        return new Snapshot(processedUsers.get(),
+            appliedTemplates.get(),
+            skippedTemplates.get(),
+            removedTemplates.get(),
+            ImmutableList.copyOf(failedUsers));
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionModule.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionModule.java
@@ -1,0 +1,74 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.dto.DTOModuleInjections;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.google.inject.name.Named;
+
+public class TemplatesProvisionModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder<Routes> routesMultibinder = Multibinder.newSetBinder(binder(), Routes.class);
+        routesMultibinder.addBinding().to(DomainTemplatesProvisionRoutes.class);
+        routesMultibinder.addBinding().to(UserTemplatesProvisionRoutes.class);
+    }
+
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> domainTemplatesProvisionTaskDTO(TemplatesProvisionService service) {
+        return DomainTemplatesProvisionTaskDTO.module(service);
+    }
+
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> userTemplatesProvisionTaskDTO(TemplatesProvisionService service) {
+        return UserTemplatesProvisionTaskDTO.module(service);
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> domainTemplatesProvisionAdditionalInformation() {
+        return DomainTemplatesProvisionTaskAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> webAdminDomainTemplatesProvisionAdditionalInformation() {
+        return DomainTemplatesProvisionTaskAdditionalInformationDTO.module();
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> userTemplatesProvisionAdditionalInformation() {
+        return UserTemplatesProvisionTaskAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> webAdminUserTemplatesProvisionAdditionalInformation() {
+        return UserTemplatesProvisionTaskAdditionalInformationDTO.module();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
@@ -37,10 +37,6 @@ public class TemplatesProvisionRequest {
     private static final String USERS_PER_SECOND_PARAM = "usersPerSecond";
     private static final int DEFAULT_USERS_PER_SECOND = 1;
 
-    private TemplatesProvisionRequest() {
-
-    }
-
     public static void assertProvisionAction(Request request) {
         String action = request.queryParams(ACTION_PARAM);
         if (!PROVISION_ACTION.equals(action)) {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
@@ -109,7 +109,21 @@ public class TemplatesProvisionRequest {
 
     private static boolean parseBoolean(Request request, String parameterName) {
         return Optional.ofNullable(request.queryParams(parameterName))
-            .map(Boolean::parseBoolean)
+            .map(value -> parseBooleanValue(parameterName, value))
             .orElse(false);
+    }
+
+    private static boolean parseBooleanValue(String parameterName, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw ErrorResponder.builder()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+            .message("Invalid '%s' value '%s'. Expected 'true' or 'false'.", parameterName, value)
+            .haltError();
     }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionRequest.java
@@ -1,0 +1,115 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.eclipse.jetty.http.HttpStatus;
+
+import spark.Request;
+
+public class TemplatesProvisionRequest {
+    private static final String ACTION_PARAM = "action";
+    private static final String PROVISION_ACTION = "provision";
+    private static final String FROM_PARAM = "from";
+    private static final String FOLDER_NAME_PARAM = "folderName";
+    private static final String OVERWRITE_EXISTING_PARAM = "overwriteExisting";
+    private static final String PRUNE_PARAM = "prune";
+    private static final String USERS_PER_SECOND_PARAM = "usersPerSecond";
+    private static final int DEFAULT_USERS_PER_SECOND = 1;
+
+    private TemplatesProvisionRequest() {
+
+    }
+
+    public static void assertProvisionAction(Request request) {
+        String action = request.queryParams(ACTION_PARAM);
+        if (!PROVISION_ACTION.equals(action)) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Unknown action: '%s'. Supported actions: '%s'", action, PROVISION_ACTION)
+                .haltError();
+        }
+    }
+
+    public static Username parseSourceUser(Request request) {
+        String from = request.queryParams(FROM_PARAM);
+        if (from == null || from.isBlank()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("'%s' query parameter is required: the source account whose templates folder is the reference", FROM_PARAM)
+                .haltError();
+        }
+        return parseUsername(from);
+    }
+
+    public static Username parseUsername(String rawUsername) {
+        try {
+            return Username.of(rawUsername);
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid username: '%s'", rawUsername)
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    public static String parseFolderName(Request request) {
+        return Optional.ofNullable(request.queryParams(FOLDER_NAME_PARAM))
+            .filter(folderName -> !folderName.isBlank())
+            .orElse(DefaultMailboxes.TEMPLATES);
+    }
+
+    public static ProvisionOptions parseOptions(Request request) {
+        return new ProvisionOptions(parseBoolean(request, OVERWRITE_EXISTING_PARAM), parseBoolean(request, PRUNE_PARAM));
+    }
+
+    public static int parseUsersPerSecond(Request request) {
+        String rawUsersPerSecond = request.queryParams(USERS_PER_SECOND_PARAM);
+        if (rawUsersPerSecond == null) {
+            return DEFAULT_USERS_PER_SECOND;
+        }
+        try {
+            int usersPerSecond = Integer.parseInt(rawUsersPerSecond);
+            if (usersPerSecond <= 0) {
+                throw new IllegalArgumentException("'usersPerSecond' needs to be strictly positive");
+            }
+            return usersPerSecond;
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid '%s' value '%s'. Expected a strictly positive integer.", USERS_PER_SECOND_PARAM, rawUsersPerSecond)
+                .haltError();
+        }
+    }
+
+    private static boolean parseBoolean(Request request, String parameterName) {
+        return Optional.ofNullable(request.queryParams(parameterName))
+            .map(Boolean::parseBoolean)
+            .orElse(false);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
@@ -78,15 +78,15 @@ public class TemplatesProvisionService {
         this.usersRepository = usersRepository;
     }
 
-    public Mono<Task.Result> provisionDomain(Domain domain, Username sourceUser, String folderName,
+    public Mono<Task.Result> provisionDomain(Domain domain, TemplatingSource source,
                                              ProvisionOptions options, int usersPerSecond, TemplatesProvisionContext context) {
-        return loadSourceTemplates(sourceUser, folderName)
+        return loadSourceTemplates(source)
             .flatMap(templates -> Flux.from(usersRepository.listUsersOfADomainReactive(domain))
-                .filter(user -> !user.equals(sourceUser))
+                .filter(user -> !user.equals(source.sourceUser()))
                 .transform(ReactorUtils.<Username, Task.Result>throttle()
                     .elements(usersPerSecond)
                     .per(Duration.ofSeconds(1))
-                    .forOperation(user -> provisionForSingleUser(templates, user, folderName, options, context)))
+                    .forOperation(user -> provisionForSingleUser(templates, user, source.folderName(), options, context)))
                 .reduce(Task.Result.COMPLETED, Task::combine)
                 .onErrorResume(e -> {
                     LOGGER.error("Error while provisioning templates for users of domain {}", domain.asString(), e);
@@ -94,35 +94,42 @@ public class TemplatesProvisionService {
                 }));
     }
 
-    public Mono<Task.Result> provisionUser(Username sourceUser, Username targetUser, String folderName,
+    public Mono<Task.Result> provisionUser(TemplatingSource source, Username targetUser,
                                            ProvisionOptions options, TemplatesProvisionContext context) {
-        return loadSourceTemplates(sourceUser, folderName)
-            .flatMap(templates -> provisionForSingleUser(templates, targetUser, folderName, options, context));
+        return loadSourceTemplates(source)
+            .flatMap(templates -> provisionForSingleUser(templates, targetUser, source.folderName(), options, context));
     }
 
-    public Mono<Boolean> sourceFolderExists(Username sourceUser, String folderName) {
-        MailboxSession session = mailboxManager.createSystemSession(sourceUser);
-        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(sourceUser, folderName), session))
+    public Mono<Boolean> sourceFolderExists(TemplatingSource source) {
+        MailboxSession session = mailboxManager.createSystemSession(source.sourceUser());
+        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(source.sourceUser(), source.folderName()), session))
             .map(any -> true)
             .onErrorResume(MailboxNotFoundException.class, e -> Mono.just(false));
     }
 
-    private Mono<ImmutableList<SourceTemplate>> loadSourceTemplates(Username sourceUser, String folderName) {
-        MailboxSession session = mailboxManager.createSystemSession(sourceUser);
-        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(sourceUser, folderName), session))
+    public Mono<Boolean> userExists(Username user) {
+        return Mono.from(usersRepository.containsReactive(user));
+    }
+
+    private Mono<ImmutableList<SourceTemplate>> loadSourceTemplates(TemplatingSource source) {
+        MailboxSession session = mailboxManager.createSystemSession(source.sourceUser());
+        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(source.sourceUser(), source.folderName()), session))
             .onErrorResume(MailboxNotFoundException.class,
-                e -> Mono.error(new SourceTemplatesFolderNotFoundException(sourceUser, folderName)))
+                e -> Mono.error(new SourceTemplatesFolderNotFoundException(source.sourceUser(), source.folderName())))
             .flatMapMany(messageManager -> Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.FULL_CONTENT, session)))
             .map(Throwing.function(this::toSourceTemplate))
             .collect(ImmutableList.toImmutableList());
     }
 
     private SourceTemplate toSourceTemplate(MessageResult messageResult) throws Exception {
-        byte[] content;
-        try (InputStream inputStream = messageResult.getFullContent().getInputStream()) {
-            content = ByteStreams.toByteArray(inputStream);
-        }
+        byte[] content = readFully(messageResult);
         return new SourceTemplate(parseMessageId(new ByteArrayInputStream(content)), content);
+    }
+
+    private byte[] readFully(MessageResult messageResult) throws Exception {
+        try (InputStream inputStream = messageResult.getFullContent().getInputStream()) {
+            return ByteStreams.toByteArray(inputStream);
+        }
     }
 
     private Mono<Task.Result> provisionForSingleUser(List<SourceTemplate> templates, Username targetUser, String folderName,
@@ -170,11 +177,13 @@ public class TemplatesProvisionService {
             return Mono.empty();
         }
         Mono<Void> deleteExisting = alreadyPresent
-            ? messageManager.deleteReactive(ImmutableList.copyOf(targetsByMessageId.get(messageId.get())), session).then()
+            ? messageManager.deleteReactive(ImmutableList.copyOf(targetsByMessageId.removeAll(messageId.get())), session).then()
             : Mono.empty();
         return deleteExisting
             .then(appendTemplate(template, messageManager, session))
-            .doOnSuccess(any -> context.incrementAppliedTemplates());
+            .doOnNext(uid -> messageId.ifPresent(id -> targetsByMessageId.put(id, uid)))
+            .doOnSuccess(any -> context.incrementAppliedTemplates())
+            .then();
     }
 
     private Mono<Void> pruneTemplates(List<SourceTemplate> templates, MessageManager messageManager, MailboxSession session,
@@ -199,10 +208,10 @@ public class TemplatesProvisionService {
             .then();
     }
 
-    private Mono<Void> appendTemplate(SourceTemplate template, MessageManager messageManager, MailboxSession session) {
+    private Mono<MessageUid> appendTemplate(SourceTemplate template, MessageManager messageManager, MailboxSession session) {
         return Mono.fromCallable(() -> AppendCommand.builder().build(parseMessage(template.content())))
             .flatMap(appendCommand -> Mono.from(messageManager.appendMessageReactive(appendCommand, session)))
-            .then();
+            .map(appendResult -> appendResult.getId().getUid());
     }
 
     private TargetTemplate toTargetTemplate(MessageResult messageResult) throws Exception {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
@@ -69,6 +69,13 @@ public class TemplatesProvisionService {
     private record TargetTemplate(Optional<String> messageId, MessageUid uid) {
     }
 
+    public record ProvisionRun(ProvisionOptions options, TemplatesProvisionContext context) {
+    }
+
+    private record TargetMailbox(MessageManager messageManager, MailboxSession session,
+                                 ListMultimap<String, MessageUid> targetsByMessageId) {
+    }
+
     private final MailboxManager mailboxManager;
     private final UsersRepository usersRepository;
 
@@ -79,14 +86,14 @@ public class TemplatesProvisionService {
     }
 
     public Mono<Task.Result> provisionDomain(Domain domain, TemplatingSource source,
-                                             ProvisionOptions options, int usersPerSecond, TemplatesProvisionContext context) {
+                                             ProvisionRun run, int usersPerSecond) {
         return loadSourceTemplates(source)
             .flatMap(templates -> Flux.from(usersRepository.listUsersOfADomainReactive(domain))
                 .filter(user -> !user.equals(source.sourceUser()))
                 .transform(ReactorUtils.<Username, Task.Result>throttle()
                     .elements(usersPerSecond)
                     .per(Duration.ofSeconds(1))
-                    .forOperation(user -> provisionForSingleUser(templates, user, source.folderName(), options, context)))
+                    .forOperation(user -> provisionForSingleUser(templates, user, source.folderName(), run)))
                 .reduce(Task.Result.COMPLETED, Task::combine)
                 .onErrorResume(e -> {
                     LOGGER.error("Error while provisioning templates for users of domain {}", domain.asString(), e);
@@ -94,10 +101,9 @@ public class TemplatesProvisionService {
                 }));
     }
 
-    public Mono<Task.Result> provisionUser(TemplatingSource source, Username targetUser,
-                                           ProvisionOptions options, TemplatesProvisionContext context) {
+    public Mono<Task.Result> provisionUser(TemplatingSource source, Username targetUser, ProvisionRun run) {
         return loadSourceTemplates(source)
-            .flatMap(templates -> provisionForSingleUser(templates, targetUser, source.folderName(), options, context));
+            .flatMap(templates -> provisionForSingleUser(templates, targetUser, source.folderName(), run));
     }
 
     public Mono<Boolean> sourceFolderExists(TemplatingSource source) {
@@ -133,78 +139,76 @@ public class TemplatesProvisionService {
     }
 
     private Mono<Task.Result> provisionForSingleUser(List<SourceTemplate> templates, Username targetUser, String folderName,
-                                                     ProvisionOptions options, TemplatesProvisionContext context) {
+                                                     ProvisionRun run) {
         MailboxSession session = mailboxManager.createSystemSession(targetUser);
         MailboxPath targetPath = MailboxPath.forUser(targetUser, folderName);
         return ensureMailbox(session, targetPath)
             .then(Mono.from(mailboxManager.getMailboxReactive(targetPath, session)))
-            .flatMap(messageManager -> applyTemplates(templates, messageManager, session, options, context))
+            .flatMap(messageManager -> applyTemplates(templates, messageManager, session, run))
             .then(Mono.fromCallable(() -> {
-                context.incrementProcessedUsers();
+                run.context().incrementProcessedUsers();
                 LOGGER.info("Templates folder '{}' provisioned for user {}", folderName, targetUser.asString());
                 return Task.Result.COMPLETED;
             }))
             .onErrorResume(e -> {
                 LOGGER.error("Error while provisioning templates folder '{}' for user {}", folderName, targetUser.asString(), e);
-                context.addToFailedUsers(targetUser.asString());
+                run.context().addToFailedUsers(targetUser.asString());
                 return Mono.just(Task.Result.PARTIAL);
             });
     }
 
     private Mono<Void> applyTemplates(List<SourceTemplate> templates, MessageManager messageManager, MailboxSession session,
-                                      ProvisionOptions options, TemplatesProvisionContext context) {
+                                      ProvisionRun run) {
         return Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.HEADERS, session))
             .map(Throwing.function(this::toTargetTemplate))
             .collectList()
             .flatMap(targets -> {
                 ListMultimap<String, MessageUid> targetsByMessageId = ArrayListMultimap.create();
                 targets.forEach(target -> target.messageId().ifPresent(id -> targetsByMessageId.put(id, target.uid())));
+                TargetMailbox targetMailbox = new TargetMailbox(messageManager, session, targetsByMessageId);
 
                 return Flux.fromIterable(templates)
-                    .concatMap(template -> applyTemplate(template, messageManager, session, options, context, targetsByMessageId))
-                    .then(Mono.defer(() -> pruneTemplates(templates, messageManager, session, options, context, targetsByMessageId)));
+                    .concatMap(template -> applyTemplate(template, targetMailbox, run))
+                    .then(Mono.defer(() -> pruneTemplates(templates, targetMailbox, run)));
             });
     }
 
-    private Mono<Void> applyTemplate(SourceTemplate template, MessageManager messageManager, MailboxSession session,
-                                     ProvisionOptions options, TemplatesProvisionContext context,
-                                     ListMultimap<String, MessageUid> targetsByMessageId) {
+    private Mono<Void> applyTemplate(SourceTemplate template, TargetMailbox targetMailbox, ProvisionRun run) {
+        ListMultimap<String, MessageUid> targetsByMessageId = targetMailbox.targetsByMessageId();
         Optional<String> messageId = template.messageId();
         boolean alreadyPresent = messageId.isPresent() && targetsByMessageId.containsKey(messageId.get());
 
-        if (alreadyPresent && !options.overwriteExisting()) {
-            context.incrementSkippedTemplates();
+        if (alreadyPresent && !run.options().overwriteExisting()) {
+            run.context().incrementSkippedTemplates();
             return Mono.empty();
         }
         Mono<Void> deleteExisting = alreadyPresent
-            ? messageManager.deleteReactive(ImmutableList.copyOf(targetsByMessageId.removeAll(messageId.get())), session).then()
+            ? targetMailbox.messageManager().deleteReactive(ImmutableList.copyOf(targetsByMessageId.removeAll(messageId.get())), targetMailbox.session()).then()
             : Mono.empty();
         return deleteExisting
-            .then(appendTemplate(template, messageManager, session))
+            .then(appendTemplate(template, targetMailbox.messageManager(), targetMailbox.session()))
             .doOnNext(uid -> messageId.ifPresent(id -> targetsByMessageId.put(id, uid)))
-            .doOnSuccess(any -> context.incrementAppliedTemplates())
+            .doOnSuccess(any -> run.context().incrementAppliedTemplates())
             .then();
     }
 
-    private Mono<Void> pruneTemplates(List<SourceTemplate> templates, MessageManager messageManager, MailboxSession session,
-                                      ProvisionOptions options, TemplatesProvisionContext context,
-                                      ListMultimap<String, MessageUid> targetsByMessageId) {
-        if (!options.prune()) {
+    private Mono<Void> pruneTemplates(List<SourceTemplate> templates, TargetMailbox targetMailbox, ProvisionRun run) {
+        if (!run.options().prune()) {
             return Mono.empty();
         }
         Set<String> sourceMessageIds = templates.stream()
             .map(SourceTemplate::messageId)
             .flatMap(Optional::stream)
             .collect(ImmutableSet.toImmutableSet());
-        ImmutableList<MessageUid> orphans = targetsByMessageId.entries().stream()
+        ImmutableList<MessageUid> orphans = targetMailbox.targetsByMessageId().entries().stream()
             .filter(entry -> !sourceMessageIds.contains(entry.getKey()))
             .map(java.util.Map.Entry::getValue)
             .collect(ImmutableList.toImmutableList());
         if (orphans.isEmpty()) {
             return Mono.empty();
         }
-        return messageManager.deleteReactive(orphans, session)
-            .doOnSuccess(any -> context.incrementRemovedTemplates(orphans.size()))
+        return targetMailbox.messageManager().deleteReactive(orphans, targetMailbox.session())
+            .doOnSuccess(any -> run.context().incrementRemovedTemplates(orphans.size()))
             .then();
     }
 

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionService.java
@@ -1,0 +1,239 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.MessageManager.AppendCommand;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.exception.MailboxExistsException;
+import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.FetchGroup;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.model.MessageResult;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.task.Task;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.util.ReactorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import com.google.common.io.ByteStreams;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class TemplatesProvisionService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TemplatesProvisionService.class);
+
+    private record SourceTemplate(Optional<String> messageId, byte[] content) {
+    }
+
+    private record TargetTemplate(Optional<String> messageId, MessageUid uid) {
+    }
+
+    private final MailboxManager mailboxManager;
+    private final UsersRepository usersRepository;
+
+    @Inject
+    public TemplatesProvisionService(MailboxManager mailboxManager, UsersRepository usersRepository) {
+        this.mailboxManager = mailboxManager;
+        this.usersRepository = usersRepository;
+    }
+
+    public Mono<Task.Result> provisionDomain(Domain domain, Username sourceUser, String folderName,
+                                             ProvisionOptions options, int usersPerSecond, TemplatesProvisionContext context) {
+        return loadSourceTemplates(sourceUser, folderName)
+            .flatMap(templates -> Flux.from(usersRepository.listUsersOfADomainReactive(domain))
+                .filter(user -> !user.equals(sourceUser))
+                .transform(ReactorUtils.<Username, Task.Result>throttle()
+                    .elements(usersPerSecond)
+                    .per(Duration.ofSeconds(1))
+                    .forOperation(user -> provisionForSingleUser(templates, user, folderName, options, context)))
+                .reduce(Task.Result.COMPLETED, Task::combine)
+                .onErrorResume(e -> {
+                    LOGGER.error("Error while provisioning templates for users of domain {}", domain.asString(), e);
+                    return Mono.just(Task.Result.PARTIAL);
+                }));
+    }
+
+    public Mono<Task.Result> provisionUser(Username sourceUser, Username targetUser, String folderName,
+                                           ProvisionOptions options, TemplatesProvisionContext context) {
+        return loadSourceTemplates(sourceUser, folderName)
+            .flatMap(templates -> provisionForSingleUser(templates, targetUser, folderName, options, context));
+    }
+
+    public Mono<Boolean> sourceFolderExists(Username sourceUser, String folderName) {
+        MailboxSession session = mailboxManager.createSystemSession(sourceUser);
+        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(sourceUser, folderName), session))
+            .map(any -> true)
+            .onErrorResume(MailboxNotFoundException.class, e -> Mono.just(false));
+    }
+
+    private Mono<ImmutableList<SourceTemplate>> loadSourceTemplates(Username sourceUser, String folderName) {
+        MailboxSession session = mailboxManager.createSystemSession(sourceUser);
+        return Mono.from(mailboxManager.getMailboxReactive(MailboxPath.forUser(sourceUser, folderName), session))
+            .onErrorResume(MailboxNotFoundException.class,
+                e -> Mono.error(new SourceTemplatesFolderNotFoundException(sourceUser, folderName)))
+            .flatMapMany(messageManager -> Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.FULL_CONTENT, session)))
+            .map(Throwing.function(this::toSourceTemplate))
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private SourceTemplate toSourceTemplate(MessageResult messageResult) throws Exception {
+        byte[] content;
+        try (InputStream inputStream = messageResult.getFullContent().getInputStream()) {
+            content = ByteStreams.toByteArray(inputStream);
+        }
+        return new SourceTemplate(parseMessageId(new ByteArrayInputStream(content)), content);
+    }
+
+    private Mono<Task.Result> provisionForSingleUser(List<SourceTemplate> templates, Username targetUser, String folderName,
+                                                     ProvisionOptions options, TemplatesProvisionContext context) {
+        MailboxSession session = mailboxManager.createSystemSession(targetUser);
+        MailboxPath targetPath = MailboxPath.forUser(targetUser, folderName);
+        return ensureMailbox(session, targetPath)
+            .then(Mono.from(mailboxManager.getMailboxReactive(targetPath, session)))
+            .flatMap(messageManager -> applyTemplates(templates, messageManager, session, options, context))
+            .then(Mono.fromCallable(() -> {
+                context.incrementProcessedUsers();
+                LOGGER.info("Templates folder '{}' provisioned for user {}", folderName, targetUser.asString());
+                return Task.Result.COMPLETED;
+            }))
+            .onErrorResume(e -> {
+                LOGGER.error("Error while provisioning templates folder '{}' for user {}", folderName, targetUser.asString(), e);
+                context.addToFailedUsers(targetUser.asString());
+                return Mono.just(Task.Result.PARTIAL);
+            });
+    }
+
+    private Mono<Void> applyTemplates(List<SourceTemplate> templates, MessageManager messageManager, MailboxSession session,
+                                      ProvisionOptions options, TemplatesProvisionContext context) {
+        return Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.HEADERS, session))
+            .map(Throwing.function(this::toTargetTemplate))
+            .collectList()
+            .flatMap(targets -> {
+                ListMultimap<String, MessageUid> targetsByMessageId = ArrayListMultimap.create();
+                targets.forEach(target -> target.messageId().ifPresent(id -> targetsByMessageId.put(id, target.uid())));
+
+                return Flux.fromIterable(templates)
+                    .concatMap(template -> applyTemplate(template, messageManager, session, options, context, targetsByMessageId))
+                    .then(Mono.defer(() -> pruneTemplates(templates, messageManager, session, options, context, targetsByMessageId)));
+            });
+    }
+
+    private Mono<Void> applyTemplate(SourceTemplate template, MessageManager messageManager, MailboxSession session,
+                                     ProvisionOptions options, TemplatesProvisionContext context,
+                                     ListMultimap<String, MessageUid> targetsByMessageId) {
+        Optional<String> messageId = template.messageId();
+        boolean alreadyPresent = messageId.isPresent() && targetsByMessageId.containsKey(messageId.get());
+
+        if (alreadyPresent && !options.overwriteExisting()) {
+            context.incrementSkippedTemplates();
+            return Mono.empty();
+        }
+        Mono<Void> deleteExisting = alreadyPresent
+            ? messageManager.deleteReactive(ImmutableList.copyOf(targetsByMessageId.get(messageId.get())), session).then()
+            : Mono.empty();
+        return deleteExisting
+            .then(appendTemplate(template, messageManager, session))
+            .doOnSuccess(any -> context.incrementAppliedTemplates());
+    }
+
+    private Mono<Void> pruneTemplates(List<SourceTemplate> templates, MessageManager messageManager, MailboxSession session,
+                                      ProvisionOptions options, TemplatesProvisionContext context,
+                                      ListMultimap<String, MessageUid> targetsByMessageId) {
+        if (!options.prune()) {
+            return Mono.empty();
+        }
+        Set<String> sourceMessageIds = templates.stream()
+            .map(SourceTemplate::messageId)
+            .flatMap(Optional::stream)
+            .collect(ImmutableSet.toImmutableSet());
+        ImmutableList<MessageUid> orphans = targetsByMessageId.entries().stream()
+            .filter(entry -> !sourceMessageIds.contains(entry.getKey()))
+            .map(java.util.Map.Entry::getValue)
+            .collect(ImmutableList.toImmutableList());
+        if (orphans.isEmpty()) {
+            return Mono.empty();
+        }
+        return messageManager.deleteReactive(orphans, session)
+            .doOnSuccess(any -> context.incrementRemovedTemplates(orphans.size()))
+            .then();
+    }
+
+    private Mono<Void> appendTemplate(SourceTemplate template, MessageManager messageManager, MailboxSession session) {
+        return Mono.fromCallable(() -> AppendCommand.builder().build(parseMessage(template.content())))
+            .flatMap(appendCommand -> Mono.from(messageManager.appendMessageReactive(appendCommand, session)))
+            .then();
+    }
+
+    private TargetTemplate toTargetTemplate(MessageResult messageResult) throws Exception {
+        try (InputStream inputStream = messageResult.getHeaders().getInputStream()) {
+            return new TargetTemplate(parseMessageId(inputStream), messageResult.getUid());
+        }
+    }
+
+    private Mono<Void> ensureMailbox(MailboxSession session, MailboxPath mailboxPath) {
+        return Mono.from(mailboxManager.createMailboxReactive(mailboxPath, MailboxManager.CreateOption.CREATE_SUBSCRIPTION, session))
+            .onErrorResume(MailboxExistsException.class, e -> Mono.empty())
+            .then();
+    }
+
+    private Optional<String> parseMessageId(InputStream inputStream) {
+        try {
+            return Optional.ofNullable(messageBuilder().parseMessage(inputStream).getMessageId());
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse the Message-Id of a template, it will not be deduplicated", e);
+            return Optional.empty();
+        }
+    }
+
+    private Message parseMessage(byte[] content) throws Exception {
+        return messageBuilder().parseMessage(new ByteArrayInputStream(content));
+    }
+
+    private DefaultMessageBuilder messageBuilder() {
+        DefaultMessageBuilder builder = new DefaultMessageBuilder();
+        builder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
+        builder.setDecodeMonitor(DecodeMonitor.SILENT);
+        return builder;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatingSource.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/TemplatingSource.java
@@ -1,0 +1,24 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import org.apache.james.core.Username;
+
+public record TemplatingSource(Username sourceUser, String folderName) {
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutes.java
@@ -64,19 +64,30 @@ public class UserTemplatesProvisionRoutes implements Routes {
     private UserTemplatesProvisionTask createTask(Request request) {
         TemplatesProvisionRequest.assertProvisionAction(request);
         Username targetUser = TemplatesProvisionRequest.parseUsername(request.params(USERNAME_PARAM));
+        assertTargetUserExists(targetUser);
         Username sourceUser = TemplatesProvisionRequest.parseSourceUser(request);
         String folderName = TemplatesProvisionRequest.parseFolderName(request);
         ProvisionOptions options = TemplatesProvisionRequest.parseOptions(request);
-        assertSourceFolderExists(sourceUser, folderName);
+        assertSourceFolderExists(new TemplatingSource(sourceUser, folderName));
         return new UserTemplatesProvisionTask(provisionService, sourceUser, targetUser, folderName, options);
     }
 
-    private void assertSourceFolderExists(Username sourceUser, String folderName) {
-        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(sourceUser, folderName).block())) {
+    private void assertTargetUserExists(Username targetUser) {
+        if (Boolean.FALSE.equals(provisionService.userExists(targetUser).block())) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.NOT_FOUND_404)
                 .type(ErrorResponder.ErrorType.NOT_FOUND)
-                .message("Folder '%s' of source user '%s' does not exist", folderName, sourceUser.asString())
+                .message("User '%s' does not exist", targetUser.asString())
+                .haltError();
+        }
+    }
+
+    private void assertSourceFolderExists(TemplatingSource source) {
+        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(source).block())) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Folder '%s' of source user '%s' does not exist", source.folderName(), source.sourceUser().asString())
                 .haltError();
         }
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutes.java
@@ -1,0 +1,83 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.task.TaskManager;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.tasks.TaskFromRequest;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import spark.Request;
+import spark.Service;
+
+public class UserTemplatesProvisionRoutes implements Routes {
+    private static final String USERS_BASE = SEPARATOR + "users";
+    private static final String USERNAME_PARAM = ":username";
+    private static final String TEMPLATES_PATH = USERS_BASE + SEPARATOR + USERNAME_PARAM + SEPARATOR + "templates";
+
+    private final TaskManager taskManager;
+    private final TemplatesProvisionService provisionService;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public UserTemplatesProvisionRoutes(TaskManager taskManager, TemplatesProvisionService provisionService,
+                                        JsonTransformer jsonTransformer) {
+        this.taskManager = taskManager;
+        this.provisionService = provisionService;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return USERS_BASE;
+    }
+
+    @Override
+    public void define(Service service) {
+        TaskFromRequest taskFromRequest = this::createTask;
+        service.post(TEMPLATES_PATH, taskFromRequest.asRoute(taskManager), jsonTransformer);
+    }
+
+    private UserTemplatesProvisionTask createTask(Request request) {
+        TemplatesProvisionRequest.assertProvisionAction(request);
+        Username targetUser = TemplatesProvisionRequest.parseUsername(request.params(USERNAME_PARAM));
+        Username sourceUser = TemplatesProvisionRequest.parseSourceUser(request);
+        String folderName = TemplatesProvisionRequest.parseFolderName(request);
+        ProvisionOptions options = TemplatesProvisionRequest.parseOptions(request);
+        assertSourceFolderExists(sourceUser, folderName);
+        return new UserTemplatesProvisionTask(provisionService, sourceUser, targetUser, folderName, options);
+    }
+
+    private void assertSourceFolderExists(Username sourceUser, String folderName) {
+        if (Boolean.FALSE.equals(provisionService.sourceFolderExists(sourceUser, folderName).block())) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Folder '%s' of source user '%s' does not exist", folderName, sourceUser.asString())
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
@@ -46,9 +46,9 @@ public class UserTemplatesProvisionTask implements Task {
         static AdditionalInformation from(UserTemplatesProvisionTask task) {
             TemplatesProvisionContext.Snapshot snapshot = task.context.snapshot();
             return new AdditionalInformation(Clock.systemUTC().instant(),
-                task.sourceUser.asString(),
+                task.source.sourceUser().asString(),
                 task.targetUser.asString(),
-                task.folderName,
+                task.source.folderName(),
                 task.options.overwriteExisting(),
                 task.options.prune(),
                 snapshot.processedUsers(),
@@ -60,25 +60,23 @@ public class UserTemplatesProvisionTask implements Task {
     }
 
     private final TemplatesProvisionService service;
-    private final Username sourceUser;
+    private final TemplatingSource source;
     private final Username targetUser;
-    private final String folderName;
     private final ProvisionOptions options;
     private final TemplatesProvisionContext context;
 
     public UserTemplatesProvisionTask(TemplatesProvisionService service, Username sourceUser, Username targetUser,
                                       String folderName, ProvisionOptions options) {
         this.service = service;
-        this.sourceUser = sourceUser;
+        this.source = new TemplatingSource(sourceUser, folderName);
         this.targetUser = targetUser;
-        this.folderName = folderName;
         this.options = options;
         this.context = new TemplatesProvisionContext();
     }
 
     @Override
     public Result run() {
-        return service.provisionUser(sourceUser, targetUser, folderName, options, context).block();
+        return service.provisionUser(source, targetUser, options, context).block();
     }
 
     @Override
@@ -92,7 +90,7 @@ public class UserTemplatesProvisionTask implements Task {
     }
 
     public Username getSourceUser() {
-        return sourceUser;
+        return source.sourceUser();
     }
 
     public Username getTargetUser() {
@@ -100,7 +98,7 @@ public class UserTemplatesProvisionTask implements Task {
     }
 
     public String getFolderName() {
-        return folderName;
+        return source.folderName();
     }
 
     public ProvisionOptions getOptions() {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
@@ -1,0 +1,109 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.james.core.Username;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+
+import com.google.common.collect.ImmutableList;
+
+public class UserTemplatesProvisionTask implements Task {
+    public static final TaskType TASK_TYPE = TaskType.of("UserTemplatesProvisionTask");
+
+    public record AdditionalInformation(Instant timestamp,
+                                        String sourceUser,
+                                        String targetUser,
+                                        String folderName,
+                                        boolean overwriteExisting,
+                                        boolean prune,
+                                        long processedUsers,
+                                        long appliedTemplates,
+                                        long skippedTemplates,
+                                        long removedTemplates,
+                                        ImmutableList<String> failedUsers) implements TaskExecutionDetails.AdditionalInformation {
+        static AdditionalInformation from(UserTemplatesProvisionTask task) {
+            TemplatesProvisionContext.Snapshot snapshot = task.context.snapshot();
+            return new AdditionalInformation(Clock.systemUTC().instant(),
+                task.sourceUser.asString(),
+                task.targetUser.asString(),
+                task.folderName,
+                task.options.overwriteExisting(),
+                task.options.prune(),
+                snapshot.processedUsers(),
+                snapshot.appliedTemplates(),
+                snapshot.skippedTemplates(),
+                snapshot.removedTemplates(),
+                snapshot.failedUsers());
+        }
+    }
+
+    private final TemplatesProvisionService service;
+    private final Username sourceUser;
+    private final Username targetUser;
+    private final String folderName;
+    private final ProvisionOptions options;
+    private final TemplatesProvisionContext context;
+
+    public UserTemplatesProvisionTask(TemplatesProvisionService service, Username sourceUser, Username targetUser,
+                                      String folderName, ProvisionOptions options) {
+        this.service = service;
+        this.sourceUser = sourceUser;
+        this.targetUser = targetUser;
+        this.folderName = folderName;
+        this.options = options;
+        this.context = new TemplatesProvisionContext();
+    }
+
+    @Override
+    public Result run() {
+        return service.provisionUser(sourceUser, targetUser, folderName, options, context).block();
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(AdditionalInformation.from(this));
+    }
+
+    public Username getSourceUser() {
+        return sourceUser;
+    }
+
+    public Username getTargetUser() {
+        return targetUser;
+    }
+
+    public String getFolderName() {
+        return folderName;
+    }
+
+    public ProvisionOptions getOptions() {
+        return options;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTask.java
@@ -76,7 +76,7 @@ public class UserTemplatesProvisionTask implements Task {
 
     @Override
     public Result run() {
-        return service.provisionUser(source, targetUser, options, context).block();
+        return service.provisionUser(source, targetUser, new TemplatesProvisionService.ProvisionRun(options, context)).block();
     }
 
     @Override

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskAdditionalInformationDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskAdditionalInformationDTO.java
@@ -1,0 +1,89 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+public record UserTemplatesProvisionTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                                @JsonProperty("timestamp") Instant timestamp,
+                                                                @JsonProperty("sourceUser") String sourceUser,
+                                                                @JsonProperty("targetUser") String targetUser,
+                                                                @JsonProperty("folderName") String folderName,
+                                                                @JsonProperty("overwriteExisting") boolean overwriteExisting,
+                                                                @JsonProperty("prune") boolean prune,
+                                                                @JsonProperty("processedUsers") long processedUsers,
+                                                                @JsonProperty("appliedTemplates") long appliedTemplates,
+                                                                @JsonProperty("skippedTemplates") long skippedTemplates,
+                                                                @JsonProperty("removedTemplates") long removedTemplates,
+                                                                @JsonProperty("failedUsers") ImmutableList<String> failedUsers) implements AdditionalInformationDTO {
+    public static AdditionalInformationDTOModule<UserTemplatesProvisionTask.AdditionalInformation, UserTemplatesProvisionTaskAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(UserTemplatesProvisionTask.AdditionalInformation.class)
+            .convertToDTO(UserTemplatesProvisionTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(UserTemplatesProvisionTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(UserTemplatesProvisionTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(UserTemplatesProvisionTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static UserTemplatesProvisionTaskAdditionalInformationDTO fromDomainObject(UserTemplatesProvisionTask.AdditionalInformation info, String type) {
+        return new UserTemplatesProvisionTaskAdditionalInformationDTO(type,
+            info.timestamp(),
+            info.sourceUser(),
+            info.targetUser(),
+            info.folderName(),
+            info.overwriteExisting(),
+            info.prune(),
+            info.processedUsers(),
+            info.appliedTemplates(),
+            info.skippedTemplates(),
+            info.removedTemplates(),
+            info.failedUsers());
+    }
+
+    private UserTemplatesProvisionTask.AdditionalInformation toDomainObject() {
+        return new UserTemplatesProvisionTask.AdditionalInformation(timestamp,
+            sourceUser,
+            targetUser,
+            folderName,
+            overwriteExisting,
+            prune,
+            processedUsers,
+            appliedTemplates,
+            skippedTemplates,
+            removedTemplates,
+            failedUsers);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskDTO.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskDTO.java
@@ -1,0 +1,56 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import org.apache.james.core.Username;
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserTemplatesProvisionTaskDTO(@JsonProperty("type") String type,
+                                            @JsonProperty("sourceUser") String sourceUser,
+                                            @JsonProperty("targetUser") String targetUser,
+                                            @JsonProperty("folderName") String folderName,
+                                            @JsonProperty("overwriteExisting") boolean overwriteExisting,
+                                            @JsonProperty("prune") boolean prune) implements TaskDTO {
+    public static TaskDTOModule<UserTemplatesProvisionTask, UserTemplatesProvisionTaskDTO> module(TemplatesProvisionService service) {
+        return DTOModule.forDomainObject(UserTemplatesProvisionTask.class)
+            .convertToDTO(UserTemplatesProvisionTaskDTO.class)
+            .toDomainObjectConverter(dto -> new UserTemplatesProvisionTask(service,
+                Username.of(dto.sourceUser()),
+                Username.of(dto.targetUser()),
+                dto.folderName(),
+                new ProvisionOptions(dto.overwriteExisting(), dto.prune())))
+            .toDTOConverter((task, type) -> new UserTemplatesProvisionTaskDTO(type,
+                task.getSourceUser().asString(),
+                task.getTargetUser().asString(),
+                task.getFolderName(),
+                task.getOptions().overwriteExisting(),
+                task.getOptions().prune()))
+            .typeName(UserTemplatesProvisionTask.TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutesTest.java
@@ -20,17 +20,28 @@ package com.linagora.tmail.webadmin.templates;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import org.apache.james.core.Domain;
-import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.json.DTOConverter;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
-import org.apache.james.task.Task;
+import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.routes.TasksRoutes;
@@ -42,23 +53,34 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.RestAssured;
-import reactor.core.publisher.Mono;
+import jakarta.mail.Flags;
 
 class DomainTemplatesProvisionRoutesTest {
+    private static final Domain DOMAIN = Domain.of("example.com");
+    private static final Username SOURCE_USER = Username.fromLocalPartWithDomain("templates", DOMAIN);
+    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+    private static final String TEMPLATES = DefaultMailboxes.TEMPLATES;
+
     private WebAdminServer webAdminServer;
     private MemoryTaskManager taskManager;
-    private TemplatesProvisionService provisionService;
+    private StoreMailboxManager mailboxManager;
+    private SessionProvider sessionProvider;
 
     @BeforeEach
     void setUp() throws Exception {
-        provisionService = mock(TemplatesProvisionService.class);
-        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(true));
-        when(provisionService.provisionDomain(any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(Mono.just(Task.Result.COMPLETED));
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        mailboxManager = resources.getMailboxManager();
+        sessionProvider = mailboxManager.getSessionProvider();
 
-        DomainList domainList = mock(DomainList.class);
-        when(domainList.containsDomain(Domain.of("example.com"))).thenReturn(true);
-        when(domainList.containsDomain(Domain.of("unknown.com"))).thenReturn(false);
+        MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
+        domainList.configure(DomainListConfiguration.DEFAULT);
+        domainList.addDomain(DOMAIN);
+        MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+        usersRepository.addUser(SOURCE_USER, "anyPassword");
+        usersRepository.addUser(BOB, "anyPassword");
+
+        TemplatesProvisionService provisionService = new TemplatesProvisionService(mailboxManager, usersRepository);
+        createTemplatesFolderWithMessage(SOURCE_USER);
 
         taskManager = new MemoryTaskManager(new Hostname("foo"));
 
@@ -111,7 +133,9 @@ class DomainTemplatesProvisionRoutesTest {
             .body("status", Matchers.is("completed"))
             .body("type", Matchers.is(DomainTemplatesProvisionTask.TASK_TYPE.asString()))
             .body("additionalInformation.domain", Matchers.is("example.com"))
-            .body("additionalInformation.sourceUser", Matchers.is("templates@example.com"));
+            .body("additionalInformation.sourceUser", Matchers.is("templates@example.com"))
+            .body("additionalInformation.processedUsers", Matchers.is(1))
+            .body("additionalInformation.appliedTemplates", Matchers.is(1));
     }
 
     @Test
@@ -148,11 +172,9 @@ class DomainTemplatesProvisionRoutesTest {
 
     @Test
     void postShouldReturn404WhenSourceFolderDoesNotExist() {
-        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(false));
-
         given()
             .queryParam("action", "provision")
-            .queryParam("from", "templates@example.com")
+            .queryParam("from", "nofolder@example.com")
         .when()
             .post("/domains/example.com/templates")
         .then()
@@ -169,5 +191,14 @@ class DomainTemplatesProvisionRoutesTest {
             .post("/domains/example.com/templates")
         .then()
             .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    private void createTemplatesFolderWithMessage(Username user) throws Exception {
+        MailboxSession session = sessionProvider.createSystemSession(user);
+        mailboxManager.createMailbox(MailboxPath.forUser(user, TEMPLATES), session);
+        MessageManager messageManager = mailboxManager.getMailbox(MailboxPath.forUser(user, TEMPLATES), session);
+        String eml = "Message-ID: <t1@example.com>\r\nSubject: A template\r\n\r\nFirst template";
+        messageManager.appendMessage(new ByteArrayInputStream(eml.getBytes(StandardCharsets.UTF_8)),
+            new Date(), session, false, new Flags());
     }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionRoutesTest.java
@@ -1,0 +1,173 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.core.Domain;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.json.DTOConverter;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.Task;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import reactor.core.publisher.Mono;
+
+class DomainTemplatesProvisionRoutesTest {
+    private WebAdminServer webAdminServer;
+    private MemoryTaskManager taskManager;
+    private TemplatesProvisionService provisionService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        provisionService = mock(TemplatesProvisionService.class);
+        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(true));
+        when(provisionService.provisionDomain(any(), any(), any(), any(), anyInt(), any()))
+            .thenReturn(Mono.just(Task.Result.COMPLETED));
+
+        DomainList domainList = mock(DomainList.class);
+        when(domainList.containsDomain(Domain.of("example.com"))).thenReturn(true);
+        when(domainList.containsDomain(Domain.of("unknown.com"))).thenReturn(false);
+
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new DomainTemplatesProvisionRoutes(taskManager, domainList, provisionService, new JsonTransformer()),
+                new TasksRoutes(taskManager, new JsonTransformer(),
+                    DTOConverter.of(DomainTemplatesProvisionTaskAdditionalInformationDTO.module())))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Test
+    void postShouldReturn201WithTaskId() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue());
+    }
+
+    @Test
+    void taskShouldCompleteSuccessfully() {
+        String taskId = given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getString("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", Matchers.is("completed"))
+            .body("type", Matchers.is(DomainTemplatesProvisionTask.TASK_TYPE.asString()))
+            .body("additionalInformation.domain", Matchers.is("example.com"))
+            .body("additionalInformation.sourceUser", Matchers.is("templates@example.com"));
+    }
+
+    @Test
+    void postShouldReturn400WhenActionIsUnknown() {
+        given()
+            .queryParam("action", "unknown")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void postShouldReturn400WhenFromIsMissing() {
+        given()
+            .queryParam("action", "provision")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void postShouldReturn404WhenDomainDoesNotExist() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@unknown.com")
+        .when()
+            .post("/domains/unknown.com/templates")
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND_404);
+    }
+
+    @Test
+    void postShouldReturn404WhenSourceFolderDoesNotExist() {
+        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(false));
+
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND_404);
+    }
+
+    @Test
+    void postShouldReturn400WhenUsersPerSecondIsInvalid() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+            .queryParam("usersPerSecond", "0")
+        .when()
+            .post("/domains/example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskSerializationTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskSerializationTest.java
@@ -37,8 +37,7 @@ class DomainTemplatesProvisionTaskSerializationTest {
         JsonSerializationVerifier.dtoModule(DomainTemplatesProvisionTaskDTO.module(service))
             .bean(new DomainTemplatesProvisionTask(service,
                 Domain.of("domain.tld"),
-                Username.of("templates@domain.tld"),
-                "Templates",
+                new TemplatingSource(Username.of("templates@domain.tld"), "Templates"),
                 new ProvisionOptions(true, false),
                 10))
             .json("""

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskSerializationTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/DomainTemplatesProvisionTaskSerializationTest.java
@@ -1,0 +1,91 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class DomainTemplatesProvisionTaskSerializationTest {
+    private final TemplatesProvisionService service = mock(TemplatesProvisionService.class);
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(DomainTemplatesProvisionTaskDTO.module(service))
+            .bean(new DomainTemplatesProvisionTask(service,
+                Domain.of("domain.tld"),
+                Username.of("templates@domain.tld"),
+                "Templates",
+                new ProvisionOptions(true, false),
+                10))
+            .json("""
+                {
+                  "type": "DomainTemplatesProvisionTask",
+                  "domain": "domain.tld",
+                  "sourceUser": "templates@domain.tld",
+                  "folderName": "Templates",
+                  "overwriteExisting": true,
+                  "prune": false,
+                  "usersPerSecond": 10
+                }""")
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(DomainTemplatesProvisionTaskAdditionalInformationDTO.module())
+            .bean(new DomainTemplatesProvisionTask.AdditionalInformation(
+                Instant.parse("2007-12-03T10:15:30.00Z"),
+                "domain.tld",
+                "templates@domain.tld",
+                "Templates",
+                true,
+                false,
+                10,
+                100L,
+                200L,
+                5L,
+                3L,
+                ImmutableList.of("bob@domain.tld")))
+            .json("""
+                {
+                  "type": "DomainTemplatesProvisionTask",
+                  "timestamp": "2007-12-03T10:15:30Z",
+                  "domain": "domain.tld",
+                  "sourceUser": "templates@domain.tld",
+                  "folderName": "Templates",
+                  "overwriteExisting": true,
+                  "prune": false,
+                  "usersPerSecond": 10,
+                  "processedUsers": 100,
+                  "appliedTemplates": 200,
+                  "skippedTemplates": 5,
+                  "removedTemplates": 3,
+                  "failedUsers": ["bob@domain.tld"]
+                }""")
+            .verify();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
@@ -1,0 +1,281 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.FetchGroup;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.StoreMailboxManager;
+import org.apache.james.task.Task;
+import org.apache.james.user.memory.MemoryUsersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+
+import jakarta.mail.Flags;
+import reactor.core.publisher.Flux;
+
+class TemplatesProvisionServiceTest {
+    private static final Domain DOMAIN = Domain.of("example.org");
+    private static final Username ALICE = Username.fromLocalPartWithDomain("alice", DOMAIN);
+    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+    private static final Username CEDRIC = Username.fromLocalPartWithDomain("cedric", DOMAIN);
+    private static final String TEMPLATES = DefaultMailboxes.TEMPLATES;
+
+    private TemplatesProvisionService service;
+    private StoreMailboxManager mailboxManager;
+    private SessionProvider sessionProvider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        mailboxManager = resources.getMailboxManager();
+        sessionProvider = mailboxManager.getSessionProvider();
+
+        DNSService dnsService = mock(DNSService.class);
+        MemoryDomainList domainList = new MemoryDomainList(dnsService);
+        domainList.configure(DomainListConfiguration.DEFAULT);
+        domainList.addDomain(DOMAIN);
+        MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+        usersRepository.addUser(ALICE, "anyPassword");
+        usersRepository.addUser(BOB, "anyPassword");
+        usersRepository.addUser(CEDRIC, "anyPassword");
+
+        service = new TemplatesProvisionService(mailboxManager, usersRepository);
+    }
+
+    @Test
+    void provisionDomainShouldCopyTemplatesToUsersWithoutTemplatesFolder() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "First template");
+        appendTemplate(ALICE, "<t2@example.org>", "Second template");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        Task.Result result = service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
+        assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
+    }
+
+    @Test
+    void provisionDomainShouldNotCopyTemplatesToSourceUser() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "First template");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+
+        assertThat(messageIds(ALICE)).containsExactly("<t1@example.org>");
+        assertThat(context.snapshot().processedUsers()).isEqualTo(2);
+    }
+
+    @Test
+    void provisionDomainShouldSkipTemplatesAlreadyPresentByMessageId() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "Source body");
+        appendTemplate(ALICE, "<t2@example.org>", "Second template");
+        createTemplatesFolder(CEDRIC);
+        appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+
+        assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
+        assertThat(bodies(CEDRIC)).anyMatch(body -> body.contains("Cedric existing body"));
+        assertThat(context.snapshot().skippedTemplates()).isEqualTo(1);
+    }
+
+    @Test
+    void provisionDomainShouldReplaceExistingTemplateWhenOverwriteExisting() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "Source body");
+        createTemplatesFolder(CEDRIC);
+        appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, new ProvisionOptions(true, false), 10, context).block();
+
+        assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
+        assertThat(bodies(CEDRIC)).allMatch(body -> body.contains("Source body"));
+    }
+
+    @Test
+    void provisionDomainShouldRemoveOrphanTemplatesWhenPrune() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "First template");
+        createTemplatesFolder(CEDRIC);
+        appendTemplate(CEDRIC, "<orphan@example.org>", "Old template removed from source");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, new ProvisionOptions(false, true), 10, context).block();
+
+        assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
+        assertThat(context.snapshot().removedTemplates()).isEqualTo(1);
+    }
+
+    @Test
+    void provisionDomainShouldKeepOrphanTemplatesWhenPruneDisabled() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "First template");
+        createTemplatesFolder(CEDRIC);
+        appendTemplate(CEDRIC, "<orphan@example.org>", "Old template");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+
+        assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<orphan@example.org>");
+    }
+
+    @Test
+    void provisionUserShouldCopyTemplatesToTargetUser() {
+        createTemplatesFolder(ALICE);
+        appendTemplate(ALICE, "<t1@example.org>", "First template");
+        appendTemplate(ALICE, "<t2@example.org>", "Second template");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        Task.Result result = service.provisionUser(ALICE, BOB, TEMPLATES, ProvisionOptions.DEFAULT, context).block();
+
+        assertThat(result).isEqualTo(Task.Result.COMPLETED);
+        assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
+        assertThat(context.snapshot().processedUsers()).isEqualTo(1);
+    }
+
+    @Test
+    void provisionShouldFailWhenSourceFolderDoesNotExist() {
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        assertThatThrownBy(() -> service.provisionUser(ALICE, BOB, TEMPLATES, ProvisionOptions.DEFAULT, context).block())
+            .isInstanceOf(SourceTemplatesFolderNotFoundException.class);
+    }
+
+    @Test
+    void provisionShouldSupportCustomFolderName() {
+        String folderName = "Templates.Marketing";
+        createFolder(ALICE, folderName);
+        appendTemplate(ALICE, folderName, "<t1@example.org>", "Marketing template");
+
+        TemplatesProvisionContext context = new TemplatesProvisionContext();
+        service.provisionUser(ALICE, BOB, folderName, ProvisionOptions.DEFAULT, context).block();
+
+        assertThat(messageIds(BOB, folderName)).containsExactly("<t1@example.org>");
+    }
+
+    @Test
+    void sourceFolderExistsShouldReturnFalseWhenMissing() {
+        assertThat(service.sourceFolderExists(ALICE, TEMPLATES).block()).isFalse();
+    }
+
+    @Test
+    void sourceFolderExistsShouldReturnTrueWhenPresent() {
+        createTemplatesFolder(ALICE);
+        assertThat(service.sourceFolderExists(ALICE, TEMPLATES).block()).isTrue();
+    }
+
+    private void createTemplatesFolder(Username user) {
+        createFolder(user, TEMPLATES);
+    }
+
+    private void createFolder(Username user, String folderName) {
+        try {
+            MailboxSession session = sessionProvider.createSystemSession(user);
+            mailboxManager.createMailbox(MailboxPath.forUser(user, folderName), session);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void appendTemplate(Username user, String messageId, String body) {
+        appendTemplate(user, TEMPLATES, messageId, body);
+    }
+
+    private void appendTemplate(Username user, String folderName, String messageId, String body) {
+        try {
+            MailboxSession session = sessionProvider.createSystemSession(user);
+            MessageManager messageManager = mailboxManager.getMailbox(MailboxPath.forUser(user, folderName), session);
+            String eml = "Message-ID: " + messageId + "\r\nSubject: A template\r\n\r\n" + body;
+            messageManager.appendMessage(new ByteArrayInputStream(eml.getBytes(StandardCharsets.UTF_8)),
+                new Date(), session, false, new Flags());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<String> messageIds(Username user) {
+        return messageIds(user, TEMPLATES);
+    }
+
+    private List<String> messageIds(Username user, String folderName) {
+        return readFullContents(user, folderName).stream()
+            .map(this::extractMessageId)
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private List<String> bodies(Username user) {
+        return readFullContents(user, TEMPLATES);
+    }
+
+    private List<String> readFullContents(Username user, String folderName) {
+        try {
+            MailboxSession session = sessionProvider.createSystemSession(user);
+            MessageManager messageManager = mailboxManager.getMailbox(MailboxPath.forUser(user, folderName), session);
+            return Flux.from(messageManager.getMessagesReactive(MessageRange.all(), FetchGroup.FULL_CONTENT, session))
+                .map(messageResult -> {
+                    try (InputStream inputStream = messageResult.getFullContent().getInputStream()) {
+                        return new String(ByteStreams.toByteArray(inputStream), StandardCharsets.UTF_8);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(ImmutableList.toImmutableList())
+                .block();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String extractMessageId(String eml) {
+        return eml.lines()
+            .filter(line -> line.toLowerCase().startsWith("message-id:"))
+            .map(line -> line.substring("message-id:".length()).trim())
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
@@ -89,7 +89,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t2@example.org>", "Second template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        Task.Result result = service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+        Task.Result result = service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
@@ -102,7 +102,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t1@example.org>", "First template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
 
         assertThat(messageIds(ALICE)).containsExactly("<t1@example.org>");
         assertThat(context.snapshot().processedUsers()).isEqualTo(2);
@@ -117,7 +117,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
 
         assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
         assertThat(bodies(CEDRIC)).anyMatch(body -> body.contains("Cedric existing body"));
@@ -132,7 +132,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, new ProvisionOptions(true, false), 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new ProvisionOptions(true, false), 10, context).block();
 
         assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
         assertThat(bodies(CEDRIC)).allMatch(body -> body.contains("Source body"));
@@ -146,7 +146,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<orphan@example.org>", "Old template removed from source");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, new ProvisionOptions(false, true), 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new ProvisionOptions(false, true), 10, context).block();
 
         assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
         assertThat(context.snapshot().removedTemplates()).isEqualTo(1);
@@ -160,7 +160,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<orphan@example.org>", "Old template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, ALICE, TEMPLATES, ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
 
         assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<orphan@example.org>");
     }
@@ -172,7 +172,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t2@example.org>", "Second template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        Task.Result result = service.provisionUser(ALICE, BOB, TEMPLATES, ProvisionOptions.DEFAULT, context).block();
+        Task.Result result = service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, ProvisionOptions.DEFAULT, context).block();
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
@@ -182,7 +182,7 @@ class TemplatesProvisionServiceTest {
     @Test
     void provisionShouldFailWhenSourceFolderDoesNotExist() {
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        assertThatThrownBy(() -> service.provisionUser(ALICE, BOB, TEMPLATES, ProvisionOptions.DEFAULT, context).block())
+        assertThatThrownBy(() -> service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, ProvisionOptions.DEFAULT, context).block())
             .isInstanceOf(SourceTemplatesFolderNotFoundException.class);
     }
 
@@ -193,20 +193,20 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, folderName, "<t1@example.org>", "Marketing template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionUser(ALICE, BOB, folderName, ProvisionOptions.DEFAULT, context).block();
+        service.provisionUser(new TemplatingSource(ALICE, folderName), BOB, ProvisionOptions.DEFAULT, context).block();
 
         assertThat(messageIds(BOB, folderName)).containsExactly("<t1@example.org>");
     }
 
     @Test
     void sourceFolderExistsShouldReturnFalseWhenMissing() {
-        assertThat(service.sourceFolderExists(ALICE, TEMPLATES).block()).isFalse();
+        assertThat(service.sourceFolderExists(new TemplatingSource(ALICE, TEMPLATES)).block()).isFalse();
     }
 
     @Test
     void sourceFolderExistsShouldReturnTrueWhenPresent() {
         createTemplatesFolder(ALICE);
-        assertThat(service.sourceFolderExists(ALICE, TEMPLATES).block()).isTrue();
+        assertThat(service.sourceFolderExists(new TemplatingSource(ALICE, TEMPLATES)).block()).isTrue();
     }
 
     private void createTemplatesFolder(Username user) {

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/TemplatesProvisionServiceTest.java
@@ -89,7 +89,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t2@example.org>", "Second template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        Task.Result result = service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
+        Task.Result result = service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context), 10).block();
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
@@ -102,7 +102,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t1@example.org>", "First template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context), 10).block();
 
         assertThat(messageIds(ALICE)).containsExactly("<t1@example.org>");
         assertThat(context.snapshot().processedUsers()).isEqualTo(2);
@@ -117,7 +117,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context), 10).block();
 
         assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
         assertThat(bodies(CEDRIC)).anyMatch(body -> body.contains("Cedric existing body"));
@@ -132,7 +132,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<t1@example.org>", "Cedric existing body");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new ProvisionOptions(true, false), 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(new ProvisionOptions(true, false), context), 10).block();
 
         assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
         assertThat(bodies(CEDRIC)).allMatch(body -> body.contains("Source body"));
@@ -146,7 +146,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<orphan@example.org>", "Old template removed from source");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new ProvisionOptions(false, true), 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(new ProvisionOptions(false, true), context), 10).block();
 
         assertThat(messageIds(CEDRIC)).containsExactly("<t1@example.org>");
         assertThat(context.snapshot().removedTemplates()).isEqualTo(1);
@@ -160,7 +160,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(CEDRIC, "<orphan@example.org>", "Old template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), ProvisionOptions.DEFAULT, 10, context).block();
+        service.provisionDomain(DOMAIN, new TemplatingSource(ALICE, TEMPLATES), new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context), 10).block();
 
         assertThat(messageIds(CEDRIC)).containsExactlyInAnyOrder("<t1@example.org>", "<orphan@example.org>");
     }
@@ -172,7 +172,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, "<t2@example.org>", "Second template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        Task.Result result = service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, ProvisionOptions.DEFAULT, context).block();
+        Task.Result result = service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context)).block();
 
         assertThat(result).isEqualTo(Task.Result.COMPLETED);
         assertThat(messageIds(BOB)).containsExactlyInAnyOrder("<t1@example.org>", "<t2@example.org>");
@@ -182,7 +182,7 @@ class TemplatesProvisionServiceTest {
     @Test
     void provisionShouldFailWhenSourceFolderDoesNotExist() {
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        assertThatThrownBy(() -> service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, ProvisionOptions.DEFAULT, context).block())
+        assertThatThrownBy(() -> service.provisionUser(new TemplatingSource(ALICE, TEMPLATES), BOB, new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context)).block())
             .isInstanceOf(SourceTemplatesFolderNotFoundException.class);
     }
 
@@ -193,7 +193,7 @@ class TemplatesProvisionServiceTest {
         appendTemplate(ALICE, folderName, "<t1@example.org>", "Marketing template");
 
         TemplatesProvisionContext context = new TemplatesProvisionContext();
-        service.provisionUser(new TemplatingSource(ALICE, folderName), BOB, ProvisionOptions.DEFAULT, context).block();
+        service.provisionUser(new TemplatingSource(ALICE, folderName), BOB, new TemplatesProvisionService.ProvisionRun(ProvisionOptions.DEFAULT, context)).block();
 
         assertThat(messageIds(BOB, folderName)).containsExactly("<t1@example.org>");
     }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
@@ -20,14 +20,28 @@ package com.linagora.tmail.webadmin.templates;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.json.DTOConverter;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.SessionProvider;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.task.Hostname;
 import org.apache.james.task.MemoryTaskManager;
-import org.apache.james.task.Task;
+import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.routes.TasksRoutes;
@@ -39,19 +53,36 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.RestAssured;
-import reactor.core.publisher.Mono;
+import jakarta.mail.Flags;
 
 class UserTemplatesProvisionRoutesTest {
+    private static final Domain DOMAIN = Domain.of("example.com");
+    private static final Username SOURCE_USER = Username.fromLocalPartWithDomain("templates", DOMAIN);
+    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+    private static final String TEMPLATES = DefaultMailboxes.TEMPLATES;
+    private static final String CUSTOM_FOLDER = "Templates.Marketing";
+
     private WebAdminServer webAdminServer;
     private MemoryTaskManager taskManager;
-    private TemplatesProvisionService provisionService;
+    private StoreMailboxManager mailboxManager;
+    private SessionProvider sessionProvider;
 
     @BeforeEach
-    void setUp() {
-        provisionService = mock(TemplatesProvisionService.class);
-        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(true));
-        when(provisionService.provisionUser(any(), any(), any(), any(), any()))
-            .thenReturn(Mono.just(Task.Result.COMPLETED));
+    void setUp() throws Exception {
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        mailboxManager = resources.getMailboxManager();
+        sessionProvider = mailboxManager.getSessionProvider();
+
+        MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
+        domainList.configure(DomainListConfiguration.DEFAULT);
+        domainList.addDomain(DOMAIN);
+        MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+        usersRepository.addUser(SOURCE_USER, "anyPassword");
+        usersRepository.addUser(BOB, "anyPassword");
+
+        TemplatesProvisionService provisionService = new TemplatesProvisionService(mailboxManager, usersRepository);
+        createFolderWithMessage(SOURCE_USER, TEMPLATES);
+        createFolderWithMessage(SOURCE_USER, CUSTOM_FOLDER);
 
         taskManager = new MemoryTaskManager(new Hostname("foo"));
 
@@ -106,7 +137,9 @@ class UserTemplatesProvisionRoutesTest {
             .body("type", Matchers.is(UserTemplatesProvisionTask.TASK_TYPE.asString()))
             .body("additionalInformation.sourceUser", Matchers.is("templates@example.com"))
             .body("additionalInformation.targetUser", Matchers.is("bob@example.com"))
-            .body("additionalInformation.folderName", Matchers.is("Templates.Marketing"));
+            .body("additionalInformation.folderName", Matchers.is("Templates.Marketing"))
+            .body("additionalInformation.processedUsers", Matchers.is(1))
+            .body("additionalInformation.appliedTemplates", Matchers.is(1));
     }
 
     @Test
@@ -132,14 +165,21 @@ class UserTemplatesProvisionRoutesTest {
 
     @Test
     void postShouldReturn404WhenSourceFolderDoesNotExist() {
-        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(false));
-
         given()
             .queryParam("action", "provision")
-            .queryParam("from", "templates@example.com")
+            .queryParam("from", "nofolder@example.com")
         .when()
             .post("/users/bob@example.com/templates")
         .then()
             .statusCode(HttpStatus.NOT_FOUND_404);
+    }
+
+    private void createFolderWithMessage(Username user, String folderName) throws Exception {
+        MailboxSession session = sessionProvider.createSystemSession(user);
+        mailboxManager.createMailbox(MailboxPath.forUser(user, folderName), session);
+        MessageManager messageManager = mailboxManager.getMailbox(MailboxPath.forUser(user, folderName), session);
+        String eml = "Message-ID: <t1@example.com>\r\nSubject: A template\r\n\r\nFirst template";
+        messageManager.appendMessage(new ByteArrayInputStream(eml.getBytes(StandardCharsets.UTF_8)),
+            new Date(), session, false, new Flags());
     }
 }

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
@@ -1,0 +1,145 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.json.DTOConverter;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.Task;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import reactor.core.publisher.Mono;
+
+class UserTemplatesProvisionRoutesTest {
+    private WebAdminServer webAdminServer;
+    private MemoryTaskManager taskManager;
+    private TemplatesProvisionService provisionService;
+
+    @BeforeEach
+    void setUp() {
+        provisionService = mock(TemplatesProvisionService.class);
+        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(true));
+        when(provisionService.provisionUser(any(), any(), any(), any(), any()))
+            .thenReturn(Mono.just(Task.Result.COMPLETED));
+
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new UserTemplatesProvisionRoutes(taskManager, provisionService, new JsonTransformer()),
+                new TasksRoutes(taskManager, new JsonTransformer(),
+                    DTOConverter.of(UserTemplatesProvisionTaskAdditionalInformationDTO.module())))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Test
+    void postShouldReturn201WithTaskId() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue());
+    }
+
+    @Test
+    void taskShouldCompleteSuccessfully() {
+        String taskId = given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+            .queryParam("folderName", "Templates.Marketing")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getString("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", Matchers.is("completed"))
+            .body("type", Matchers.is(UserTemplatesProvisionTask.TASK_TYPE.asString()))
+            .body("additionalInformation.sourceUser", Matchers.is("templates@example.com"))
+            .body("additionalInformation.targetUser", Matchers.is("bob@example.com"))
+            .body("additionalInformation.folderName", Matchers.is("Templates.Marketing"));
+    }
+
+    @Test
+    void postShouldReturn400WhenActionIsUnknown() {
+        given()
+            .queryParam("action", "unknown")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void postShouldReturn400WhenFromIsMissing() {
+        given()
+            .queryParam("action", "provision")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void postShouldReturn404WhenSourceFolderDoesNotExist() {
+        when(provisionService.sourceFolderExists(any(), any())).thenReturn(Mono.just(false));
+
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND_404);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionRoutesTest.java
@@ -164,6 +164,29 @@ class UserTemplatesProvisionRoutesTest {
     }
 
     @Test
+    void postShouldReturn400WhenOverwriteExistingIsInvalid() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+            .queryParam("overwriteExisting", "invalid")
+        .when()
+            .post("/users/bob@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void postShouldReturn404WhenTargetUserDoesNotExist() {
+        given()
+            .queryParam("action", "provision")
+            .queryParam("from", "templates@example.com")
+        .when()
+            .post("/users/unknown@example.com/templates")
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND_404);
+    }
+
+    @Test
     void postShouldReturn404WhenSourceFolderDoesNotExist() {
         given()
             .queryParam("action", "provision")

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskSerializationTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/templates/UserTemplatesProvisionTaskSerializationTest.java
@@ -1,0 +1,86 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.templates;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class UserTemplatesProvisionTaskSerializationTest {
+    private final TemplatesProvisionService service = mock(TemplatesProvisionService.class);
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(UserTemplatesProvisionTaskDTO.module(service))
+            .bean(new UserTemplatesProvisionTask(service,
+                Username.of("templates@domain.tld"),
+                Username.of("bob@domain.tld"),
+                "Templates",
+                new ProvisionOptions(false, true)))
+            .json("""
+                {
+                  "type": "UserTemplatesProvisionTask",
+                  "sourceUser": "templates@domain.tld",
+                  "targetUser": "bob@domain.tld",
+                  "folderName": "Templates",
+                  "overwriteExisting": false,
+                  "prune": true
+                }""")
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(UserTemplatesProvisionTaskAdditionalInformationDTO.module())
+            .bean(new UserTemplatesProvisionTask.AdditionalInformation(
+                Instant.parse("2007-12-03T10:15:30.00Z"),
+                "templates@domain.tld",
+                "bob@domain.tld",
+                "Templates",
+                false,
+                true,
+                1L,
+                4L,
+                1L,
+                2L,
+                ImmutableList.of()))
+            .json("""
+                {
+                  "type": "UserTemplatesProvisionTask",
+                  "timestamp": "2007-12-03T10:15:30Z",
+                  "sourceUser": "templates@domain.tld",
+                  "targetUser": "bob@domain.tld",
+                  "folderName": "Templates",
+                  "overwriteExisting": false,
+                  "prune": true,
+                  "processedUsers": 1,
+                  "appliedTemplates": 4,
+                  "skippedTemplates": 1,
+                  "removedTemplates": 2,
+                  "failedUsers": []
+                }""")
+            .verify();
+    }
+}


### PR DESCRIPTION
Closes #2375

## What

Adds webadmin tasks to provision email templates from a reference (admin-controlled) account into the `Templates` mailbox of other users, as discussed on the issue.

A template is simply a message stored in a user's `Templates` mailbox. The reference templates live in the `Templates` mailbox (or any sub-folder via `folderName`) of a designated source account given by `from`. The admin edits these with the regular JMAP / Twake Mail UI — no new template store.

Two endpoints (folded into `webadmin-mailbox`, mirroring the cleanup / data-tiering task patterns):

```
POST /domains/{domain}/templates?action=provision&from={sourceUser}
        &folderName=Templates         # optional, default "Templates"
        &overwriteExisting=true|false # optional, default false
        &prune=true|false             # optional, default false (full mirror when true)
        &usersPerSecond=10            # optional, default 1 (throttle)
=> 201 { "taskId": "..." }            # poll /tasks/{id}

POST /users/{username}/templates?action=provision&from={sourceUser}
        &folderName=...&overwriteExisting=...&prune=...
=> 201 { "taskId": "..." }
```

Per the issue decisions:
- **Source model (A)**: a designated source account whose `Templates` mailbox is the reference.
- **`folderName`**: lets an admin manage several categories of templates (e.g. `Templates.Marketing`).
- **User-scoped mirror** of the domain-scoped task.
- **Conflict policy**: skip vs `overwriteExisting`, identifying "the same template" by RFC 5322 `Message-Id` (so re-provisioning after edits is idempotent).
- **Copy vs full sync**: `prune` option deletes target templates whose `Message-Id` is no longer in the reference folder.
- No global super-admin variant (domain + user scope only).

The target `Templates` folder is auto-created when missing; the source account is skipped in the domain task.

## Tests

- `TemplatesProvisionServiceTest` — in-memory mailbox: copy, dedup by `Message-Id`, `overwriteExisting`, `prune`, custom `folderName`, source-folder-missing.
- `DomainTemplatesProvisionRoutesTest` / `UserTemplatesProvisionRoutesTest` — route behaviour & validation (201/400/404).
- `*TaskSerializationTest` — task + additionalInformation JSON round-trips.

Also documented under `docs/.../webadmin.adoc`.

`mvn` compile, tests and checkstyle pass for `webadmin-mailbox`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAdmin endpoints to provision email templates for either an entire domain or a single user.
  * Supports selecting a source folder, deduplicating by `Message-Id`, replacing existing templates, and optionally pruning templates removed from the source.
  * Runs asynchronously and exposes task status/progress (taskId plus processed/applied/skipped/removed counts and failures), with configurable throughput (`usersPerSecond`).

* **Bug Fixes**
  * Improved request validation and error handling for missing/invalid parameters, unknown domains/users, and missing source template folders.

* **Documentation**
  * Documented the new “Templates provisioning” workflow, query parameters, and example requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->