### PR TITLE
ISSUE-2454 Stabilize flaky PublicAssetSetMethodContract upload

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/PublicAssetSetMethodContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/PublicAssetSetMethodContract.scala
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.{BeforeEach, Tag, Test}
 import play.api.libs.json.{JsString, Json}
 import reactor.core.scala.publisher.SMono
 
+import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
 object PublicAssetSetMethodContract {
@@ -77,20 +78,33 @@ trait PublicAssetSetMethodContract {
 
   private def uploadAsset(content: Array[Byte] = "Your asset content here".getBytes,
                           contentType: String = "image/png"): UploadResponse = {
-    val uploadResponse: String = `given`()
-      .basePath("")
-      .contentType(contentType)
-      .body(content)
-    .when
-      .post(s"/upload/$ACCOUNT_ID")
-    .`then`
-      .extract
-      .body
-      .asString
+    // The upload occasionally fails server side with a transient InterruptedException while the
+    // blob store reads the request body, returning a problem object instead of the blobId.
+    // Retry a few times to keep this contract test stable.
+    @tailrec
+    def attempt(remaining: Int): UploadResponse = {
+      val uploadResponse: String = `given`()
+        .basePath("")
+        .contentType(contentType)
+        .body(content)
+      .when
+        .post(s"/upload/$ACCOUNT_ID")
+      .`then`
+        .extract
+        .body
+        .asString
 
-    UploadResponse(blobId = (Json.parse(uploadResponse) \ "blobId").as[String],
-      contentType = org.apache.james.mailbox.model.ContentType.of((Json.parse(uploadResponse) \ "type").as[String]).mimeType(),
-      size = (Json.parse(uploadResponse) \ "size").as[Long])
+      (Json.parse(uploadResponse) \ "blobId").asOpt[String] match {
+        case Some(blobId) =>
+          UploadResponse(blobId = blobId,
+            contentType = org.apache.james.mailbox.model.ContentType.of((Json.parse(uploadResponse) \ "type").as[String]).mimeType(),
+            size = (Json.parse(uploadResponse) \ "size").as[Long])
+        case None if remaining > 0 => attempt(remaining - 1)
+        case None => throw new IllegalStateException(s"Upload did not return a blobId: $uploadResponse")
+      }
+    }
+
+    attempt(remaining = 3)
   }
 
   @Test


### PR DESCRIPTION
Closes #2454

## Problem

`PublicAssetSetMethodContract` (e.g. `updateShouldReturnUpdatedWhenRemovePartialValidate`) is flaky. The shared `uploadAsset` helper POSTs to `/upload/{accountId}` and then directly parses `blobId` from the response.

Occasionally the upload fails server side with a transient `InterruptedException` while the memory blob store reads the request body:

```
o.a.j.j.r.UploadRoutes - Unexpected error upon upload /upload/...
java.lang.InterruptedException
	at reactor.core.publisher.BlockingIterable$SubscriberIterator.hasNext(...)
	at org.apache.james.util.ReactorUtils$StreamInputStream.read(...)
	at org.apache.james.blob.memory.MemoryBlobStoreDAO.lambda$save$0(...)
```

When that happens the upload returns a JMAP problem object (`type` / `status` / `detail`) instead of a body containing `blobId`, and the test crashes parsing it:

```
JsonValidationError('blobId' is undefined on object. Available keys are 'type', 'status', 'detail')
```

## Fix

Make the `uploadAsset` test helper resilient: when the response does not contain a `blobId`, retry the upload a bounded number of times instead of letting the transient server-side failure fail the whole test. If no attempt succeeds, a clear error including the response body is raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset upload reliability by retrying failed uploads when a temporary server response is incomplete.
  * Uploads now only succeed once the expected upload details are returned; otherwise, they fail clearly after several attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->