### PR TITLE
ISSUE-2456 Close TMail AMQP consumers upon shutdown

### DIFF
--- a/tmail-backend/jmap/extensions-rabbitmq/src/main/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactSubscriber.java
+++ b/tmail-backend/jmap/extensions-rabbitmq/src/main/java/com/linagora/tmail/james/jmap/RabbitMQEmailAddressContactSubscriber.java
@@ -28,6 +28,7 @@ import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -140,6 +141,7 @@ public class RabbitMQEmailAddressContactSubscriber implements Startable, Closeab
             });
     }
 
+    @PreDestroy
     @Override
     public void close() {
         Optional.ofNullable(messageConsume).ifPresent(Disposable::dispose);

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/settings/TWPSettingsConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/settings/TWPSettingsConsumer.java
@@ -25,6 +25,8 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
 
+import jakarta.annotation.PreDestroy;
+
 import org.apache.james.backends.rabbitmq.QueueArguments;
 import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
@@ -177,6 +179,7 @@ public class TWPSettingsConsumer implements Closeable, Startable {
         return settingsUpdater.updateSettings(message);
     }
 
+    @PreDestroy
     @Override
     public void close() {
         Optional.ofNullable(consumeSettingsDisposable).ifPresent(Disposable::dispose);

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSDomainSubscriptionConsumer.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Named;
 
 import org.apache.james.backends.rabbitmq.QueueArguments;
@@ -181,6 +182,7 @@ public class SaaSDomainSubscriptionConsumer implements Closeable, Startable {
             });
     }
 
+    @PreDestroy
     @Override
     public void close() {
         Optional.ofNullable(consumeSubscriptionDisposable).ifPresent(Disposable::dispose);

--- a/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
+++ b/tmail-backend/saas/saas-rabbitmq/src/main/java/com/linagora/tmail/saas/rabbitmq/subscription/SaaSSubscriptionConsumer.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Named;
 
 import org.apache.james.backends.rabbitmq.QueueArguments;
@@ -175,6 +176,7 @@ public class SaaSSubscriptionConsumer implements Closeable, Startable {
             });
     }
 
+    @PreDestroy
     @Override
     public void close() {
         Optional.ofNullable(consumeSubscriptionDisposable).ifPresent(Disposable::dispose);

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/OpenPaasContactsConsumerModule.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/OpenPaasContactsConsumerModule.java
@@ -44,6 +44,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.linagora.tmail.configuration.OpenPaasConfiguration;
+import com.linagora.tmail.contact.SabreContactsConsumer;
 import com.linagora.tmail.contact.SabreContactsOperator;
 
 public class OpenPaasContactsConsumerModule extends AbstractModule {
@@ -51,6 +52,7 @@ public class OpenPaasContactsConsumerModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(SabreContactsConsumer.class).in(Scopes.SINGLETON);
         bind(SabreContactsOperator.class).in(Scopes.SINGLETON);
     }
 

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/contact/SabreContactsConsumer.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -260,6 +261,7 @@ public class SabreContactsConsumer implements Closeable {
             .then();
     }
 
+    @PreDestroy
     @Override
     public void close() {
         Optional.ofNullable(consumeAddedContactsDisposable).ifPresent(Disposable::dispose);


### PR DESCRIPTION
Closes #2456

Several TMail AMQP consumers implement `Closeable` and dispose their RabbitMQ subscription in `close()`, but `close()` was **not** annotated `@PreDestroy`. James only invokes cleanup on `@PreDestroy`-annotated methods (tracked by the onami `PreDestroyModule` and disposed in `GuiceJamesServer.stop()`), so these `close()` methods were never called on shutdown.

Consequences (same root cause as twake-calendar-side-service#847):
- non-graceful shutdown on `docker stop`/restart, RabbitMQ subscriptions not disposed;
- in tests/CI, stale consumers keep consuming messages, causing flakiness.

### Fix

Annotate `close()` with `@PreDestroy` (mirrors the existing `RabbitMQAndRedisEventBus.stop()` precedent) on:

1. `TWPSettingsConsumer`
2. `SaaSSubscriptionConsumer`
3. `SaaSDomainSubscriptionConsumer`
4. `RabbitMQEmailAddressContactSubscriber`
5. `SabreContactsConsumer`

The `close()` bodies already do the right thing (`Optional.ofNullable(disposable).ifPresent(Disposable::dispose)`); disposing the subscription terminates the `Flux.using(...)` which auto-invokes `Receiver::close`, so no further changes were needed.

Consumers 1-4 are bound as Guice `@Singleton`. `SabreContactsConsumer` was a just-in-time binding injected into the singleton `SabreContactsOperator`; it is now explicitly bound `in(Scopes.SINGLETON)` in `OpenPaasContactsConsumerModule` so `@PreDestroy` reliably fires.

Checkstyle and compilation of the affected modules pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for several background services, helping them clean up more reliably when the app stops.
  * Reduced the risk of lingering message consumers or subscription processes after restart or container shutdown.
  * Strengthened initialization for a contact-related service so it is consistently available when the app runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->