### PR TITLE
ISSUE-2464 OBM mailing list: handle externalContactEmail attribute

### DIFF
--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 import jakarta.mail.MessagingException;
@@ -88,7 +89,12 @@ import com.unboundid.ldap.sdk.SearchScope;
  * member: uid=ixxx,ou=users,dc=linagora.com,dc=lng
  * mailBox: pxxx@linagora.com
  * mailBox: ixxx@linagora.com
+ * externalContactEmail: contact@example.com
  * </code></pre>
+ *
+ *  <p>Group members are resolved from both the <code>mailBox</code> attribute (internal members) and the
+ *  <code>externalContactEmail</code> attribute (external contacts). Both are treated as members: they receive the mail
+ *  and are allowed to post on member restricted lists.</p>
  */
 public class OBMLDAPMailingList extends GenericMailet {
     record GroupResolutionResult(MailAddress listAddress, boolean isPublic, List<MailAddress> members) {
@@ -181,29 +187,35 @@ public class OBMLDAPMailingList extends GenericMailet {
         this.listAttributes = ImmutableSet.builder()
             .add(mailAttributeForGroups)
             .add("mailBox")
+            .add("externalContactEmail")
             .add("mailAccess")
             .build().toArray(String[]::new);
     }
 
-    private Optional<GroupResolutionResult> asGroupResolutionResult(SearchResultEntry entry) throws AddressException {
+    @VisibleForTesting
+    Optional<GroupResolutionResult> asGroupResolutionResult(SearchResultEntry entry) throws AddressException {
         if (entry == null) {
             return Optional.empty();
         }
         boolean isPublic = isPublic(entry);
-        if (entry.hasAttribute("mailBox")) {
-            return Optional.of(
-                new GroupResolutionResult(
-                    new MailAddress(entry.getAttributeValue(mailAttributeForGroups)),
-                    isPublic,
-                    Arrays.stream(entry.getAttribute("mailBox").getValues())
-                        .map(Throwing.function(MailAddress::new))
-                        .collect(ImmutableList.toImmutableList())));
-        }
+        List<MailAddress> members = Stream.concat(
+                memberAddresses(entry, "mailBox"),
+                memberAddresses(entry, "externalContactEmail"))
+            .distinct()
+            .collect(ImmutableList.toImmutableList());
         return Optional.of(
             new GroupResolutionResult(
                 new MailAddress(entry.getAttributeValue(mailAttributeForGroups)),
                 isPublic,
-                ImmutableList.of()));
+                members));
+    }
+
+    private static Stream<MailAddress> memberAddresses(SearchResultEntry entry, String attribute) {
+        if (!entry.hasAttribute(attribute)) {
+            return Stream.empty();
+        }
+        return Arrays.stream(entry.getAttribute(attribute).getValues())
+            .map(Throwing.function(MailAddress::new));
     }
 
     private static boolean isPublic(SearchResultEntry entry) {

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/OBMLDAPMailingListTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/OBMLDAPMailingListTest.java
@@ -1,0 +1,126 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.base.test.FakeMailContext;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.mailet.OBMLDAPMailingList.GroupResolutionResult;
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+
+class OBMLDAPMailingListTest {
+    private static final String LIST_DN = "cn=group-canut,ou=groups,dc=linagora.com,dc=lng";
+
+    private OBMLDAPMailingList testee;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testee = new OBMLDAPMailingList((LDAPConnectionPool) null);
+        testee.init(FakeMailetConfig.builder()
+            .mailetName("OBMLDAPMailingList")
+            .setProperty("baseDN", "ou=groups,dc=linagora.com,dc=lng")
+            .setProperty("rejectedSenderProcessor", "rejectedSender")
+            .mailetContext(FakeMailContext.defaultContext())
+            .build());
+    }
+
+    private static SearchResultEntry entry(Attribute... attributes) {
+        return new SearchResultEntry(LIST_DN, attributes);
+    }
+
+    @Test
+    void shouldResolveExternalContactEmailAsMember() throws Exception {
+        SearchResultEntry entry = entry(
+            new Attribute("mail", "group-canut@linagora.com"),
+            new Attribute("mailAccess", "PERMIT"),
+            new Attribute("externalContactEmail", "ben@cozycloud.cc"));
+
+        Optional<GroupResolutionResult> result = testee.asGroupResolutionResult(entry);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().members()).containsExactly(new MailAddress("ben@cozycloud.cc"));
+    }
+
+    @Test
+    void shouldCombineMailBoxAndExternalContactEmailMembers() throws Exception {
+        SearchResultEntry entry = entry(
+            new Attribute("mail", "group-canut@linagora.com"),
+            new Attribute("mailAccess", "PERMIT"),
+            new Attribute("mailBox", "alice@linagora.com", "bob@linagora.com"),
+            new Attribute("externalContactEmail", "ben@cozycloud.cc"));
+
+        Optional<GroupResolutionResult> result = testee.asGroupResolutionResult(entry);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().members()).containsExactlyInAnyOrder(
+            new MailAddress("alice@linagora.com"),
+            new MailAddress("bob@linagora.com"),
+            new MailAddress("ben@cozycloud.cc"));
+    }
+
+    @Test
+    void shouldSupportMultivaluedExternalContactEmail() throws Exception {
+        SearchResultEntry entry = entry(
+            new Attribute("mail", "group-canut@linagora.com"),
+            new Attribute("mailAccess", "PERMIT"),
+            new Attribute("externalContactEmail", "ben@cozycloud.cc", "alice@external.com"));
+
+        Optional<GroupResolutionResult> result = testee.asGroupResolutionResult(entry);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().members()).containsExactlyInAnyOrder(
+            new MailAddress("ben@cozycloud.cc"),
+            new MailAddress("alice@external.com"));
+    }
+
+    @Test
+    void shouldDeduplicateMembersSharedByBothAttributes() throws Exception {
+        SearchResultEntry entry = entry(
+            new Attribute("mail", "group-canut@linagora.com"),
+            new Attribute("mailAccess", "PERMIT"),
+            new Attribute("mailBox", "ben@cozycloud.cc"),
+            new Attribute("externalContactEmail", "ben@cozycloud.cc"));
+
+        Optional<GroupResolutionResult> result = testee.asGroupResolutionResult(entry);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().members()).containsExactly(new MailAddress("ben@cozycloud.cc"));
+    }
+
+    @Test
+    void shouldResolveEmptyMembersWhenNoMailBoxNorExternalContactEmail() throws Exception {
+        SearchResultEntry entry = entry(
+            new Attribute("mail", "group-canut@linagora.com"),
+            new Attribute("mailAccess", "PERMIT"));
+
+        Optional<GroupResolutionResult> result = testee.asGroupResolutionResult(entry);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().members()).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #2464

OBM groups can define external recipients through the `externalContactEmail` LDAP attribute (e.g. `externalContactEmail: ben@cozycloud.cc`). `OBMLDAPMailingList` previously only resolved members from the `mailBox` attribute, so those external contacts never received the mail.

## Changes

- Request the `externalContactEmail` attribute when searching groups.
- Resolve group members from both `mailBox` (internal members) and `externalContactEmail` (external contacts), de-duplicating addresses present in both.
- External contacts are treated as members: they receive the mail and are allowed to post on member restricted lists.
- Added unit tests covering external-only, combined, multivalued, de-duplicated and empty membership cases.

---
*Generated automatically*
