### PR TITLE
Migration proxy - close user IMAP sessions on migration

### DIFF
--- a/tmail-backend/apps/migration-proxy/pom.xml
+++ b/tmail-backend/apps/migration-proxy/pom.xml
@@ -62,6 +62,18 @@
             <artifactId>event-bus-in-vm</artifactId>
         </dependency>
         <dependency>
+            <!-- Distributed (RabbitMQ) TMAIL_EVENT_BUS backing the disconnection plumbing across a
+                 cluster of migration proxies (HA) -->
+            <groupId>${james.groupId}</groupId>
+            <artifactId>event-bus-distributed</artifactId>
+        </dependency>
+        <dependency>
+            <!-- RabbitMQ backend (connection pool, configuration) installed by
+                 MigrationProxyRabbitMQEventBusModule via org.apache.james.modules.queue.rabbitmq.RabbitMQModule -->
+            <groupId>${james.groupId}</groupId>
+            <artifactId>queue-rabbitmq-guice</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-postgres</artifactId>
             <type>test-jar</type>

--- a/tmail-backend/apps/migration-proxy/pom.xml
+++ b/tmail-backend/apps/migration-proxy/pom.xml
@@ -47,8 +47,19 @@
             <artifactId>logback-json-classic</artifactId>
         </dependency>
         <dependency>
+            <!-- Disconnection plumbing (DisconnectionEventListener, EventBusDisconnectorNotifier, ...)
+                 reused to close proxied IMAP sessions across a cluster of migration proxies -->
+            <groupId>com.linagora.tmail</groupId>
+            <artifactId>tmail-data-extra-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-postgres</artifactId>
+        </dependency>
+        <dependency>
+            <!-- In-VM TMAIL_EVENT_BUS backing the disconnection plumbing on a single-node proxy -->
+            <groupId>${james.groupId}</groupId>
+            <artifactId>event-bus-in-vm</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -203,6 +214,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/migration-proxy/pom.xml
+++ b/tmail-backend/apps/migration-proxy/pom.xml
@@ -262,7 +262,11 @@
                     <!-- Each test class (notably the ones booting a full server / Docker backends) runs
                          in a fresh JVM to avoid resource accumulation across heavy integration tests. -->
                     <reuseForks>false</reuseForks>
-                    <argLine>-Xms512m -Xmx1024m</argLine>
+                    <!-- No forced -Xms: each heavy integration test runs in a fresh JVM (reuseForks=false),
+                         and pre-committing 512m at every fork start needlessly pressured the CI agent's
+                         memory, occasionally killing the forked VM before the test even ran ("Error
+                         occurred in starting fork"). -Xmx1024m still caps the heap. -->
+                    <argLine>-Xmx1024m</argLine>
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>

--- a/tmail-backend/apps/migration-proxy/pom.xml
+++ b/tmail-backend/apps/migration-proxy/pom.xml
@@ -80,6 +80,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- DockerRabbitMQ / RabbitMQFixture used to boot the proxy against a real RabbitMQ and
+                 assert the distributed (HA) disconnection wiring actually starts -->
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-rabbitmq</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-guice-common</artifactId>
             <type>test-jar</type>

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -18,6 +18,8 @@
 
 package com.linagora.tmail.migration;
 
+import java.io.FileNotFoundException;
+
 import org.apache.james.ExtraProperties;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerMain;
@@ -54,6 +56,7 @@ import com.linagora.tmail.migration.modules.MigratedUsersModule;
 import com.linagora.tmail.migration.modules.MigrationProxyDisconnectorModule;
 import com.linagora.tmail.migration.modules.MigrationProxyImapModule;
 import com.linagora.tmail.migration.modules.MigrationProxyMemoryEventBusModule;
+import com.linagora.tmail.migration.modules.MigrationProxyRabbitMQEventBusModule;
 
 /**
  * Migration proxy server: a mailbox-less Twake Mail MTA assembled from our own Guice module set.
@@ -111,7 +114,7 @@ public class MigrationProxyServer {
             UsersRepositoryModuleChooser.Implementation.parse(new FileConfigurationProvider(fileSystem, configuration));
 
         return GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), chooseEventBusModule())
+            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), chooseEventBusModule(fileSystem))
             .combineWith(new UsersRepositoryModuleChooser(new PostgresUsersRepositoryModule())
                 .chooseModules(usersRepositoryImplementation));
     }
@@ -126,10 +129,24 @@ public class MigrationProxyServer {
     /**
      * Selects the event bus backing the disconnection plumbing, mirroring the module chooser the other
      * Twake Mail apps expose. The in-VM event bus is enough for a single migration proxy; a clustered
-     * deployment plugs in a distributed (RabbitMQ) event bus so a disconnection request reaches the node
-     * actually holding the user connection.
+     * deployment (several proxies behind a load balancer for HA) drops a {@code rabbitmq.properties} in
+     * the conf directory to plug in the distributed (RabbitMQ) event bus so a disconnection request
+     * reaches the node actually holding the user connection.
      */
-    private static Module chooseEventBusModule() {
+    private static Module chooseEventBusModule(FileSystem fileSystem) {
+        if (hasRabbitMQConfiguration(fileSystem)) {
+            LOGGER.info("Found rabbitmq.properties: backing the disconnection event bus with RabbitMQ (clustered migration proxy)");
+            return new MigrationProxyRabbitMQEventBusModule();
+        }
+        LOGGER.info("No rabbitmq.properties: backing the disconnection event bus with the in-VM event bus (single migration proxy)");
         return new MigrationProxyMemoryEventBusModule();
+    }
+
+    private static boolean hasRabbitMQConfiguration(FileSystem fileSystem) {
+        try {
+            return fileSystem.getFile(FileSystem.FILE_PROTOCOL_AND_CONF + "rabbitmq.properties").exists();
+        } catch (FileNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -159,7 +159,8 @@ public class MigrationProxyServer {
             UsersRepositoryModuleChooser.Implementation.parse(new FileConfigurationProvider(fileSystem, configuration));
 
         return GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), eventBusModuleChoice.module())
+            .combineWith(Modules.override(PROTOCOLS, DATA, chooseSslModule(), eventBusModuleChoice.module())
+                .with(MIGRATION_PROXY))
             .combineWith(new UsersRepositoryModuleChooser(new PostgresUsersRepositoryModule())
                 .chooseModules(usersRepositoryImplementation));
     }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -95,8 +95,8 @@ public class MigrationProxyServer {
                 LOGGER.info("No rabbitmq.properties: backing the disconnection event bus with the in-VM event bus (single migration proxy)");
                 return IN_MEMORY;
             } catch (ConfigurationException e) {
-                LOGGER.warn("Error reading rabbitmq.properties, defaulting to the in-VM event bus (single migration proxy)", e);
-                return IN_MEMORY;
+                throw new RuntimeException("rabbitmq.properties is present but could not be read: fix the configuration "
+                    + "rather than silently degrading to the single-node in-VM event bus in a clustered deployment", e);
             }
         }
 

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -51,7 +51,9 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import com.linagora.tmail.migration.modules.MigratedUsersModule;
+import com.linagora.tmail.migration.modules.MigrationProxyDisconnectorModule;
 import com.linagora.tmail.migration.modules.MigrationProxyImapModule;
+import com.linagora.tmail.migration.modules.MigrationProxyMemoryEventBusModule;
 
 /**
  * Migration proxy server: a mailbox-less Twake Mail MTA assembled from our own Guice module set.
@@ -86,7 +88,8 @@ public class MigrationProxyServer {
 
     private static final Module MIGRATION_PROXY = Modules.combine(
         new MigrationProxyImapModule(),
-        new MigratedUsersModule());
+        new MigratedUsersModule(),
+        new MigrationProxyDisconnectorModule());
 
     public static void main(String[] args) throws Exception {
         ExtraProperties.initialize();
@@ -108,7 +111,7 @@ public class MigrationProxyServer {
             UsersRepositoryModuleChooser.Implementation.parse(new FileConfigurationProvider(fileSystem, configuration));
 
         return GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule())
+            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), chooseEventBusModule())
             .combineWith(new UsersRepositoryModuleChooser(new PostgresUsersRepositoryModule())
                 .chooseModules(usersRepositoryImplementation));
     }
@@ -118,5 +121,15 @@ public class MigrationProxyServer {
             return new TCNativeEncryptionModule();
         }
         return new LegacyEncryptionModule();
+    }
+
+    /**
+     * Selects the event bus backing the disconnection plumbing, mirroring the module chooser the other
+     * Twake Mail apps expose. The in-VM event bus is enough for a single migration proxy; a clustered
+     * deployment plugs in a distributed (RabbitMQ) event bus so a disconnection request reaches the node
+     * actually holding the user connection.
+     */
+    private static Module chooseEventBusModule() {
+        return new MigrationProxyMemoryEventBusModule();
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -20,6 +20,7 @@ package com.linagora.tmail.migration;
 
 import java.io.FileNotFoundException;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.ExtraProperties;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerMain;
@@ -47,6 +48,7 @@ import org.apache.james.modules.server.WebAdminServerModule;
 import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.server.core.configuration.FileConfigurationProvider;
 import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +70,43 @@ import com.linagora.tmail.migration.modules.MigrationProxyRabbitMQEventBusModule
  */
 public class MigrationProxyServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MigrationProxyServer.class);
+
+    /**
+     * Backing implementation of the {@code TMAIL_EVENT_BUS} that carries the disconnection plumbing,
+     * mirroring the module chooser the other Twake Mail apps expose. The in-VM event bus is enough for a
+     * single migration proxy; a clustered deployment (several proxies behind a load balancer for HA) plugs
+     * in the distributed (RabbitMQ) event bus so a disconnection request reaches the node actually holding
+     * the user connection.
+     *
+     * <p>The choice is resolved from the configuration (which by default looks the {@code rabbitmq.properties}
+     * up on the file system) rather than from the file system directly, so tests can inject RabbitMQ mode
+     * without dropping a file in the conf directory (see {@link #createServer(Configuration, EventBusModuleChoice)}).
+     */
+    public enum EventBusModuleChoice {
+        IN_MEMORY,
+        RABBITMQ;
+
+        public static EventBusModuleChoice parse(PropertiesProvider propertiesProvider) {
+            try {
+                propertiesProvider.getConfiguration("rabbitmq");
+                LOGGER.info("Found rabbitmq.properties: backing the disconnection event bus with RabbitMQ (clustered migration proxy)");
+                return RABBITMQ;
+            } catch (FileNotFoundException e) {
+                LOGGER.info("No rabbitmq.properties: backing the disconnection event bus with the in-VM event bus (single migration proxy)");
+                return IN_MEMORY;
+            } catch (ConfigurationException e) {
+                LOGGER.warn("Error reading rabbitmq.properties, defaulting to the in-VM event bus (single migration proxy)", e);
+                return IN_MEMORY;
+            }
+        }
+
+        Module module() {
+            return switch (this) {
+                case IN_MEMORY -> new MigrationProxyMemoryEventBusModule();
+                case RABBITMQ -> new MigrationProxyRabbitMQEventBusModule();
+            };
+        }
+    }
 
     private static final Module PROTOCOLS = Modules.combine(
         new ProtocolHandlerModule(),
@@ -110,11 +149,17 @@ public class MigrationProxyServer {
 
     public static GuiceJamesServer createServer(Configuration configuration) {
         FileSystem fileSystem = new FileSystemImpl(configuration.directories());
+        return createServer(configuration,
+            EventBusModuleChoice.parse(new PropertiesProvider(fileSystem, configuration.configurationPath())));
+    }
+
+    public static GuiceJamesServer createServer(Configuration configuration, EventBusModuleChoice eventBusModuleChoice) {
+        FileSystem fileSystem = new FileSystemImpl(configuration.directories());
         UsersRepositoryModuleChooser.Implementation usersRepositoryImplementation =
             UsersRepositoryModuleChooser.Implementation.parse(new FileConfigurationProvider(fileSystem, configuration));
 
         return GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), chooseEventBusModule(fileSystem))
+            .combineWith(PROTOCOLS, DATA, MIGRATION_PROXY, chooseSslModule(), eventBusModuleChoice.module())
             .combineWith(new UsersRepositoryModuleChooser(new PostgresUsersRepositoryModule())
                 .chooseModules(usersRepositoryImplementation));
     }
@@ -124,29 +169,5 @@ public class MigrationProxyServer {
             return new TCNativeEncryptionModule();
         }
         return new LegacyEncryptionModule();
-    }
-
-    /**
-     * Selects the event bus backing the disconnection plumbing, mirroring the module chooser the other
-     * Twake Mail apps expose. The in-VM event bus is enough for a single migration proxy; a clustered
-     * deployment (several proxies behind a load balancer for HA) drops a {@code rabbitmq.properties} in
-     * the conf directory to plug in the distributed (RabbitMQ) event bus so a disconnection request
-     * reaches the node actually holding the user connection.
-     */
-    private static Module chooseEventBusModule(FileSystem fileSystem) {
-        if (hasRabbitMQConfiguration(fileSystem)) {
-            LOGGER.info("Found rabbitmq.properties: backing the disconnection event bus with RabbitMQ (clustered migration proxy)");
-            return new MigrationProxyRabbitMQEventBusModule();
-        }
-        LOGGER.info("No rabbitmq.properties: backing the disconnection event bus with the in-VM event bus (single migration proxy)");
-        return new MigrationProxyMemoryEventBusModule();
-    }
-
-    private static boolean hasRabbitMQConfiguration(FileSystem fileSystem) {
-        try {
-            return fileSystem.getFile(FileSystem.FILE_PROTOCOL_AND_CONF + "rabbitmq.properties").exists();
-        } catch (FileNotFoundException e) {
-            return false;
-        }
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
@@ -52,7 +52,13 @@ public class ProxyConnectionRegistry implements Disconnector {
     private final ConcurrentMap<Username, Set<Channel>> channelsByUser = new ConcurrentHashMap<>();
 
     public void register(Username username, Channel clientChannel) {
-        channelsByUser.computeIfAbsent(username, any -> ConcurrentHashMap.newKeySet()).add(clientChannel);
+        // compute() keeps the get-or-create and the add atomic per user so a concurrent closeConnections()
+        // cannot remove the entry in between and leave clientChannel tracked in an orphaned Set.
+        channelsByUser.compute(username, (key, channels) -> {
+            Set<Channel> tracked = channels != null ? channels : ConcurrentHashMap.newKeySet();
+            tracked.add(clientChannel);
+            return tracked;
+        });
         // Drop the channel from the registry once it closes so we do not accumulate dead connections.
         clientChannel.closeFuture().addListener(future -> deregister(username, clientChannel));
     }
@@ -65,12 +71,16 @@ public class ProxyConnectionRegistry implements Disconnector {
     }
 
     private void closeConnections(Username username) {
-        Set<Channel> channels = channelsByUser.remove(username);
-        if (channels != null && !channels.isEmpty()) {
-            LOGGER.info("Closing {} proxied connection(s) of {} to force reconnection after migration",
-                channels.size(), username.asString());
-            channels.forEach(Channel::close);
-        }
+        // Remove and close under the same atomic compute() as register() so we never miss a channel that
+        // is being registered concurrently (it would otherwise stay open and pinned to the old backend).
+        channelsByUser.compute(username, (key, channels) -> {
+            if (channels != null && !channels.isEmpty()) {
+                LOGGER.info("Closing {} proxied connection(s) of {} to force reconnection after migration",
+                    channels.size(), username.asString());
+                channels.forEach(Channel::close);
+            }
+            return null;
+        });
     }
 
     private void deregister(Username username, Channel clientChannel) {

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
@@ -21,9 +21,11 @@ package com.linagora.tmail.migration.core;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
 
 import jakarta.inject.Singleton;
 
+import org.apache.james.core.Disconnector;
 import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,13 +35,18 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.Channel;
 
 /**
- * Tracks the live proxied client connections per user. When a user is flipped to "migrated" their
- * in-flight IMAP sessions are still pinned to the old backend (the backend was resolved at LOGIN time);
- * closing them here forces the clients to reconnect and be routed to the new backend straight away
- * instead of lingering on the old one until they happen to disconnect on their own.
+ * Tracks the live proxied client connections per user and closes them on demand as the protocol-layer
+ * {@link Disconnector} of the IMAP proxy. When a user is flipped to "migrated" their in-flight IMAP
+ * sessions are still pinned to the old backend (the backend was resolved at LOGIN time); closing them
+ * forces the clients to reconnect and be routed to the new backend straight away instead of lingering
+ * on the old one until they happen to disconnect on their own.
+ *
+ * <p>The migration flow does not call this registry directly: it dispatches a disconnection request on
+ * the event bus (see {@code EventBusDisconnectorNotifier}) so that, in a cluster of migration proxies,
+ * the node actually holding the user's connection is the one that closes it.
  */
 @Singleton
-public class ProxyConnectionRegistry {
+public class ProxyConnectionRegistry implements Disconnector {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConnectionRegistry.class);
 
     private final ConcurrentMap<Username, Set<Channel>> channelsByUser = new ConcurrentHashMap<>();
@@ -50,7 +57,14 @@ public class ProxyConnectionRegistry {
         clientChannel.closeFuture().addListener(future -> deregister(username, clientChannel));
     }
 
-    public void closeConnections(Username username) {
+    @Override
+    public void disconnect(Predicate<Username> matcher) {
+        channelsByUser.keySet().stream()
+            .filter(matcher)
+            .forEach(this::closeConnections);
+    }
+
+    private void closeConnections(Username username) {
         Set<Channel> channels = channelsByUser.remove(username);
         if (channels != null && !channels.isEmpty()) {
             LOGGER.info("Closing {} proxied connection(s) of {} to force reconnection after migration",

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
@@ -28,6 +28,8 @@ import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import io.netty.channel.Channel;
 
 /**
@@ -62,5 +64,10 @@ public class ProxyConnectionRegistry {
             channels.remove(clientChannel);
             return channels.isEmpty() ? null : channels;
         });
+    }
+
+    @VisibleForTesting
+    int connectionCount(Username username) {
+        return channelsByUser.getOrDefault(username, Set.of()).size();
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/core/ProxyConnectionRegistry.java
@@ -1,0 +1,66 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration.core;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import jakarta.inject.Singleton;
+
+import org.apache.james.core.Username;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.Channel;
+
+/**
+ * Tracks the live proxied client connections per user. When a user is flipped to "migrated" their
+ * in-flight IMAP sessions are still pinned to the old backend (the backend was resolved at LOGIN time);
+ * closing them here forces the clients to reconnect and be routed to the new backend straight away
+ * instead of lingering on the old one until they happen to disconnect on their own.
+ */
+@Singleton
+public class ProxyConnectionRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConnectionRegistry.class);
+
+    private final ConcurrentMap<Username, Set<Channel>> channelsByUser = new ConcurrentHashMap<>();
+
+    public void register(Username username, Channel clientChannel) {
+        channelsByUser.computeIfAbsent(username, any -> ConcurrentHashMap.newKeySet()).add(clientChannel);
+        // Drop the channel from the registry once it closes so we do not accumulate dead connections.
+        clientChannel.closeFuture().addListener(future -> deregister(username, clientChannel));
+    }
+
+    public void closeConnections(Username username) {
+        Set<Channel> channels = channelsByUser.remove(username);
+        if (channels != null && !channels.isEmpty()) {
+            LOGGER.info("Closing {} proxied connection(s) of {} to force reconnection after migration",
+                channels.size(), username.asString());
+            channels.forEach(Channel::close);
+        }
+    }
+
+    private void deregister(Username username, Channel clientChannel) {
+        channelsByUser.computeIfPresent(username, (key, channels) -> {
+            channels.remove(clientChannel);
+            return channels.isEmpty() ? null : channels;
+        });
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/imap/ProxyImapProcessor.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/imap/ProxyImapProcessor.java
@@ -43,6 +43,7 @@ import com.linagora.tmail.migration.core.BackendRelay;
 import com.linagora.tmail.migration.core.BackendResolver;
 import com.linagora.tmail.migration.core.BackendSslContextFactory;
 import com.linagora.tmail.migration.core.MissingProxyInformationException;
+import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 import com.linagora.tmail.migration.core.ReflectiveChannelAccessor;
 
 import io.netty.buffer.Unpooled;
@@ -62,13 +63,16 @@ public class ProxyImapProcessor implements ImapProcessor {
     private final BackendResolver backendResolver;
     private final BackendRelay backendRelay;
     private final BackendSslContextFactory sslContextFactory;
+    private final ProxyConnectionRegistry connectionRegistry;
     private final Duration handshakeTimeout;
 
     public ProxyImapProcessor(BackendResolver backendResolver, BackendRelay backendRelay,
-                              BackendSslContextFactory sslContextFactory, Duration handshakeTimeout) {
+                              BackendSslContextFactory sslContextFactory,
+                              ProxyConnectionRegistry connectionRegistry, Duration handshakeTimeout) {
         this.backendResolver = backendResolver;
         this.backendRelay = backendRelay;
         this.sslContextFactory = sslContextFactory;
+        this.connectionRegistry = connectionRegistry;
         this.handshakeTimeout = handshakeTimeout;
     }
 
@@ -129,6 +133,9 @@ public class ProxyImapProcessor implements ImapProcessor {
         if (backendChannel.isPresent()) {
             writeLine(clientChannel, tag + " OK LOGIN completed, proxying to " + backend.name() + " backend.");
             backendRelay.takeOverClient(clientChannel, backendChannel.get(), backend);
+            // Track the live session so it can be force-closed if this user gets migrated, forcing a
+            // reconnection onto the (now) resolved backend rather than staying pinned to the old one.
+            connectionRegistry.register(login.getUserid(), clientChannel);
         } else {
             writeLine(clientChannel, tag + " NO LOGIN failed against backend.");
         }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyDisconnectorModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyDisconnectorModule.java
@@ -24,15 +24,10 @@ import jakarta.inject.Singleton;
 import org.apache.james.DisconnectorNotifier;
 import org.apache.james.core.Disconnector;
 import org.apache.james.events.EventBus;
-import org.apache.james.lifecycle.api.Startable;
-import org.apache.james.utils.InitializationOperation;
-import org.apache.james.utils.InitilizationOperationBuilder;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.multibindings.ProvidesIntoSet;
 import com.linagora.tmail.disconnector.DisconnectionEventListener;
-import com.linagora.tmail.disconnector.DisconnectorNotificationRegistration;
 import com.linagora.tmail.disconnector.EventBusDisconnectorNotifier;
 import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
@@ -49,7 +44,8 @@ import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
  *         holding the connection is the one that closes it, wherever the migration was triggered.</li>
  * </ul>
  *
- * <p>The event bus itself is contributed by a dedicated module chosen at assembly time (see
+ * <p>The event bus itself, along with the listener registration (which for a distributed bus must wait
+ * for the bus to be started), is contributed by a dedicated module chosen at assembly time (see
  * {@code MigrationProxyServer#chooseEventBusModule}), mirroring the other Twake Mail apps.
  */
 public class MigrationProxyDisconnectorModule extends AbstractModule {
@@ -62,20 +58,5 @@ public class MigrationProxyDisconnectorModule extends AbstractModule {
     @Singleton
     DisconnectorNotifier disconnectorNotifier(@Named("TMAIL_EVENT_BUS") EventBus tmailEventBus) {
         return new EventBusDisconnectorNotifier(tmailEventBus);
-    }
-
-    @ProvidesIntoSet
-    InitializationOperation registerDisconnectionListener(DisconnectorNotificationRegistration registration) {
-        return InitilizationOperationBuilder
-            .forClass(DisconnectionListenerLoader.class)
-            .init(registration::register);
-    }
-
-    /**
-     * Marker {@link Startable} anchoring the {@link InitializationOperation} that registers the
-     * disconnection listener on the event bus during server start-up.
-     */
-    public static class DisconnectionListenerLoader implements Startable {
-
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyDisconnectorModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyDisconnectorModule.java
@@ -1,0 +1,81 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration.modules;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.james.DisconnectorNotifier;
+import org.apache.james.core.Disconnector;
+import org.apache.james.events.EventBus;
+import org.apache.james.lifecycle.api.Startable;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.linagora.tmail.disconnector.DisconnectionEventListener;
+import com.linagora.tmail.disconnector.DisconnectorNotificationRegistration;
+import com.linagora.tmail.disconnector.EventBusDisconnectorNotifier;
+import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
+
+/**
+ * Reuses the standard Twake Mail disconnection plumbing for the IMAP proxy so that migrating a user
+ * disconnects its live sessions across a whole cluster of migration proxies:
+ *
+ * <ul>
+ *     <li>the {@link ProxyConnectionRegistry} is exposed as the protocol-layer {@link Disconnector}
+ *         that actually closes the tracked IMAP connections;</li>
+ *     <li>the webadmin migration flow publishes a disconnection request through the
+ *         {@link DisconnectorNotifier} onto the {@code TMAIL_EVENT_BUS};</li>
+ *     <li>every node registers a {@link DisconnectionEventListener} on that event bus so the node
+ *         holding the connection is the one that closes it, wherever the migration was triggered.</li>
+ * </ul>
+ *
+ * <p>The event bus itself is contributed by a dedicated module chosen at assembly time (see
+ * {@code MigrationProxyServer#chooseEventBusModule}), mirroring the other Twake Mail apps.
+ */
+public class MigrationProxyDisconnectorModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(Disconnector.class).to(ProxyConnectionRegistry.class);
+    }
+
+    @Provides
+    @Singleton
+    DisconnectorNotifier disconnectorNotifier(@Named("TMAIL_EVENT_BUS") EventBus tmailEventBus) {
+        return new EventBusDisconnectorNotifier(tmailEventBus);
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation registerDisconnectionListener(DisconnectorNotificationRegistration registration) {
+        return InitilizationOperationBuilder
+            .forClass(DisconnectionListenerLoader.class)
+            .init(registration::register);
+    }
+
+    /**
+     * Marker {@link Startable} anchoring the {@link InitializationOperation} that registers the
+     * disconnection listener on the event bus during server start-up.
+     */
+    public static class DisconnectionListenerLoader implements Startable {
+
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyImapModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyImapModule.java
@@ -40,6 +40,7 @@ import com.linagora.tmail.migration.core.BackendRelay;
 import com.linagora.tmail.migration.core.BackendResolver;
 import com.linagora.tmail.migration.core.BackendSslContextFactory;
 import com.linagora.tmail.migration.core.MigrationProxyConfiguration;
+import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 import com.linagora.tmail.migration.imap.ProxyImapProcessor;
 
 /**
@@ -60,9 +61,10 @@ public class MigrationProxyImapModule extends AbstractModule {
     @Singleton
     ProxyImapProcessor provideProxyImapProcessor(BackendResolver backendResolver, BackendRelay backendRelay,
                                                  BackendSslContextFactory sslContextFactory,
+                                                 ProxyConnectionRegistry connectionRegistry,
                                                  MigrationProxyConfiguration configuration) {
         return new ProxyImapProcessor(backendResolver, backendRelay, sslContextFactory,
-            configuration.handshakeTimeout());
+            connectionRegistry, configuration.handshakeTimeout());
     }
 
     @Provides

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyMemoryEventBusModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyMemoryEventBusModule.java
@@ -26,16 +26,22 @@ import org.apache.james.events.InVMEventBus;
 import org.apache.james.events.MemoryEventDeadLetters;
 import org.apache.james.events.RetryBackoffConfiguration;
 import org.apache.james.events.delivery.InVmEventDelivery;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.linagora.tmail.disconnector.DisconnectorNotificationRegistration;
 
 /**
  * In-VM implementation of the {@code TMAIL_EVENT_BUS} that carries the disconnection requests. This is
  * the single-node option of the event bus module chooser: disconnections triggered on a node only reach
  * that same node, which is enough when the migration proxy is deployed as a single instance. A clustered
- * deployment plugs a distributed (RabbitMQ) event bus here instead so the request reaches every node.
+ * deployment plugs the {@code MigrationProxyRabbitMQEventBusModule} here instead so the request reaches
+ * every node.
  */
 public class MigrationProxyMemoryEventBusModule extends AbstractModule {
     @Provides
@@ -45,5 +51,21 @@ public class MigrationProxyMemoryEventBusModule extends AbstractModule {
         return new InVMEventBus(new InVmEventDelivery(metricFactory),
             RetryBackoffConfiguration.DEFAULT,
             new MemoryEventDeadLetters());
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation registerDisconnectionListener(DisconnectorNotificationRegistration registration) {
+        // The in-VM bus needs no start-up, so we can register the disconnection listener straight away.
+        return InitilizationOperationBuilder
+            .forClass(DisconnectionListenerLoader.class)
+            .init(registration::register);
+    }
+
+    /**
+     * Marker {@link Startable} anchoring the {@link InitializationOperation} that registers the
+     * disconnection listener on the in-VM event bus during server start-up.
+     */
+    public static class DisconnectionListenerLoader implements Startable {
+
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyMemoryEventBusModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyMemoryEventBusModule.java
@@ -1,0 +1,49 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration.modules;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.james.events.EventBus;
+import org.apache.james.events.InVMEventBus;
+import org.apache.james.events.MemoryEventDeadLetters;
+import org.apache.james.events.RetryBackoffConfiguration;
+import org.apache.james.events.delivery.InVmEventDelivery;
+import org.apache.james.metrics.api.MetricFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+/**
+ * In-VM implementation of the {@code TMAIL_EVENT_BUS} that carries the disconnection requests. This is
+ * the single-node option of the event bus module chooser: disconnections triggered on a node only reach
+ * that same node, which is enough when the migration proxy is deployed as a single instance. A clustered
+ * deployment plugs a distributed (RabbitMQ) event bus here instead so the request reaches every node.
+ */
+public class MigrationProxyMemoryEventBusModule extends AbstractModule {
+    @Provides
+    @Singleton
+    @Named("TMAIL_EVENT_BUS")
+    EventBus provideTmailEventBus(MetricFactory metricFactory) {
+        return new InVMEventBus(new InVmEventDelivery(metricFactory),
+            RetryBackoffConfiguration.DEFAULT,
+            new MemoryEventDeadLetters());
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyRabbitMQEventBusModule.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/modules/MigrationProxyRabbitMQEventBusModule.java
@@ -1,0 +1,98 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration.modules;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
+import org.apache.james.events.DefaultNamingStrategy;
+import org.apache.james.events.EventBus;
+import org.apache.james.events.EventBusId;
+import org.apache.james.events.EventBusName;
+import org.apache.james.events.EventDeadLetters;
+import org.apache.james.events.MemoryEventDeadLetters;
+import org.apache.james.events.NamingStrategy;
+import org.apache.james.events.RabbitMQEventBus;
+import org.apache.james.events.RetryBackoffConfiguration;
+import org.apache.james.events.RoutingKeyConverter;
+import org.apache.james.modules.queue.rabbitmq.RabbitMQModule;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.linagora.tmail.disconnector.DisconnectionRequestedEventSerializer;
+import com.linagora.tmail.disconnector.DisconnectorNotificationRegistration;
+import com.linagora.tmail.disconnector.DisconnectorRegistrationKey;
+
+/**
+ * Distributed (RabbitMQ) implementation of the {@code TMAIL_EVENT_BUS} that carries the disconnection
+ * requests. This is the clustered option of the event bus module chooser: a disconnection request
+ * published on any node is fanned out over RabbitMQ so the node actually holding the user's proxied IMAP
+ * connection is the one that closes it, wherever the migration was triggered. This is what makes running
+ * several migration proxies behind a load balancer (HA) actually force-reconnect migrated users.
+ *
+ * <p>Only the disconnection plumbing rides this bus, so we keep the wiring minimal: the RabbitMQ backend
+ * (connection pool, configuration) comes from {@link RabbitMQModule}, and the bus is fed with the single
+ * {@link DisconnectionRequestedEventSerializer} / {@link DisconnectorRegistrationKey} pair rather than the
+ * full mailbox event stack the other Twake Mail apps carry.
+ */
+public class MigrationProxyRabbitMQEventBusModule extends AbstractModule {
+    private static final NamingStrategy NAMING_STRATEGY = new DefaultNamingStrategy(new EventBusName("migrationProxyDisconnect"));
+
+    @Override
+    protected void configure() {
+        install(new RabbitMQModule());
+        bind(EventDeadLetters.class).to(MemoryEventDeadLetters.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named("TMAIL_EVENT_BUS")
+    RabbitMQEventBus provideTmailEventBus(RabbitMQEventBus.Factory eventBusFactory, RabbitMQConfiguration rabbitMQConfiguration) {
+        return eventBusFactory.create(EventBusId.random(),
+            NAMING_STRATEGY,
+            new RoutingKeyConverter(ImmutableSet.of(new DisconnectorRegistrationKey.Factory())),
+            new DisconnectionRequestedEventSerializer(),
+            new RabbitMQEventBus.Configurations(rabbitMQConfiguration, RetryBackoffConfiguration.DEFAULT, EventBus.Configuration.DEFAULT));
+    }
+
+    @Provides
+    @Singleton
+    @Named("TMAIL_EVENT_BUS")
+    EventBus provideTmailEventBus(@Named("TMAIL_EVENT_BUS") RabbitMQEventBus eventBus) {
+        return eventBus;
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation startEventBus(@Named("TMAIL_EVENT_BUS") RabbitMQEventBus eventBus,
+                                          DisconnectorNotificationRegistration registration) {
+        return InitilizationOperationBuilder
+            .forClass(RabbitMQEventBus.class)
+            .init(() -> {
+                // Start the bus (declares the RabbitMQ exchange/queues) before registering the listener:
+                // registration.register() subscribes the DisconnectionEventListener on the running bus.
+                eventBus.start();
+                registration.register();
+            });
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
@@ -18,8 +18,12 @@
 
 package com.linagora.tmail.migration.webadmin;
 
+import java.util.Set;
+
 import jakarta.inject.Inject;
 
+import org.apache.james.DisconnectorNotifier;
+import org.apache.james.DisconnectorNotifier.MultipleUserRequest;
 import org.apache.james.core.Username;
 import org.apache.james.webadmin.Constants;
 import org.apache.james.webadmin.Routes;
@@ -28,7 +32,6 @@ import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
-import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
 import spark.Request;
 import spark.Response;
@@ -51,14 +54,14 @@ public class MigratedUsersRoutes implements Routes {
     private static final String USER_PATH = BASE_PATH + Constants.SEPARATOR + USERNAME_PARAM;
 
     private final MigratedUsersRepository migratedUsersRepository;
-    private final ProxyConnectionRegistry connectionRegistry;
+    private final DisconnectorNotifier disconnectorNotifier;
     private final JsonTransformer jsonTransformer;
 
     @Inject
     public MigratedUsersRoutes(MigratedUsersRepository migratedUsersRepository,
-                               ProxyConnectionRegistry connectionRegistry, JsonTransformer jsonTransformer) {
+                               DisconnectorNotifier disconnectorNotifier, JsonTransformer jsonTransformer) {
         this.migratedUsersRepository = migratedUsersRepository;
-        this.connectionRegistry = connectionRegistry;
+        this.disconnectorNotifier = disconnectorNotifier;
         this.jsonTransformer = jsonTransformer;
     }
 
@@ -87,8 +90,10 @@ public class MigratedUsersRoutes implements Routes {
             Username username = extractUsername(request);
             migratedUsersRepository.addMigratedUser(username).block();
             // Force the user's live proxied sessions to reconnect so they land on the new backend
-            // straight away rather than staying pinned to the old one until they disconnect.
-            connectionRegistry.closeConnections(username);
+            // straight away rather than staying pinned to the old one until they disconnect. The
+            // request goes through the event bus so that, in a cluster of migration proxies, the node
+            // actually holding the connection closes it, wherever the migration was triggered.
+            disconnectorNotifier.disconnect(MultipleUserRequest.of(Set.of(username)));
             return noContent(response);
         };
     }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
@@ -30,6 +30,8 @@ import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
 
@@ -49,6 +51,7 @@ import spark.Service;
  * </ul>
  */
 public class MigratedUsersRoutes implements Routes {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigratedUsersRoutes.class);
     private static final String USERNAME_PARAM = ":username";
     private static final String BASE_PATH = Constants.SEPARATOR + "migratedUsers";
     private static final String USER_PATH = BASE_PATH + Constants.SEPARATOR + USERNAME_PARAM;
@@ -93,7 +96,14 @@ public class MigratedUsersRoutes implements Routes {
             // straight away rather than staying pinned to the old one until they disconnect. The
             // request goes through the event bus so that, in a cluster of migration proxies, the node
             // actually holding the connection closes it, wherever the migration was triggered.
-            disconnectorNotifier.disconnect(MultipleUserRequest.of(Set.of(username)));
+            // Best-effort: the user is already flagged migrated, so a disconnection publishing failure
+            // (e.g. a transient event-bus issue) must not fail the request - the stale sessions will
+            // simply reconnect on the new backend the next time they cycle.
+            try {
+                disconnectorNotifier.disconnect(MultipleUserRequest.of(Set.of(username)));
+            } catch (Exception e) {
+                LOGGER.warn("Failed to publish the disconnection request for migrated user {}", username.asString(), e);
+            }
             return noContent(response);
         };
     }

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutes.java
@@ -28,6 +28,7 @@ import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
+import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
 import spark.Request;
 import spark.Response;
@@ -50,11 +51,14 @@ public class MigratedUsersRoutes implements Routes {
     private static final String USER_PATH = BASE_PATH + Constants.SEPARATOR + USERNAME_PARAM;
 
     private final MigratedUsersRepository migratedUsersRepository;
+    private final ProxyConnectionRegistry connectionRegistry;
     private final JsonTransformer jsonTransformer;
 
     @Inject
-    public MigratedUsersRoutes(MigratedUsersRepository migratedUsersRepository, JsonTransformer jsonTransformer) {
+    public MigratedUsersRoutes(MigratedUsersRepository migratedUsersRepository,
+                               ProxyConnectionRegistry connectionRegistry, JsonTransformer jsonTransformer) {
         this.migratedUsersRepository = migratedUsersRepository;
+        this.connectionRegistry = connectionRegistry;
         this.jsonTransformer = jsonTransformer;
     }
 
@@ -80,7 +84,11 @@ public class MigratedUsersRoutes implements Routes {
 
     private Route addMigratedUser() {
         return (request, response) -> {
-            migratedUsersRepository.addMigratedUser(extractUsername(request)).block();
+            Username username = extractUsername(request);
+            migratedUsersRepository.addMigratedUser(username).block();
+            // Force the user's live proxied sessions to reconnect so they land on the new backend
+            // straight away rather than staying pinned to the old one until they disconnect.
+            connectionRegistry.closeConnections(username);
             return noContent(response);
         };
     }

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/MigrationDisconnectOnMigrationTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/MigrationDisconnectOnMigrationTest.java
@@ -1,0 +1,153 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.linagora.tmail.migration.imap.ImapBackendDialog;
+
+import io.restassured.RestAssured;
+
+/**
+ * Integration test on the (memory event bus) migration proxy asserting the disconnection plumbing:
+ * flagging a user as migrated over webadmin must cut its already established, proxied IMAP connection so
+ * the client reconnects and lands on the new backend rather than lingering on the old one.
+ *
+ * <p>The proxy is booted for real (webadmin + IMAP server + in-VM {@code TMAIL_EVENT_BUS} + connection
+ * registry) with a lightweight {@link StubBackendServer} standing in for the old backend, so the whole
+ * webadmin &rarr; event bus &rarr; registry &rarr; channel close path is exercised end to end.
+ */
+class MigrationDisconnectOnMigrationTest {
+    private static final String DOMAIN = "managed.tld";
+    private static final String USER = "bob@" + DOMAIN; // not migrated: the proxy relays it to the old backend
+    private static final String PASSWORD = "secret";
+    private static final int PROXY_IMAP_PORT = 10143; // conf/imapserver.xml binds the proxy IMAP server here
+
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.empty();
+
+    @TempDir
+    static File workingDirectory;
+
+    private StubBackendServer oldBackend;
+    private GuiceJamesServer proxy;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Old backend accepting the proxy's LOGIN so the proxied connection gets established (and tracked).
+        oldBackend = new StubBackendServer("* OK backend ready")
+            .reply(ImapBackendDialog.PROXY_TAG + " LOGIN", ImapBackendDialog.PROXY_TAG + " OK LOGIN completed");
+        int backendPort = oldBackend.start();
+        System.setProperty("migration.imap.old.host", "127.0.0.1");
+        System.setProperty("migration.imap.old.port", String.valueOf(backendPort));
+
+        Configuration configuration = Configuration.builder()
+            .workingDirectory(workingDirectory)
+            .configurationFromClasspath()
+            .build();
+        proxy = MigrationProxyServer.createServer(configuration).overrideWith(postgresExtension.getModule());
+        proxy.start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(
+            proxy.getProbe(WebAdminGuiceProbe.class).getWebAdminPort()).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (proxy != null) {
+            proxy.stop();
+        }
+        if (oldBackend != null) {
+            oldBackend.close();
+        }
+        System.clearProperty("migration.imap.old.host");
+        System.clearProperty("migration.imap.old.port");
+        RestAssured.reset();
+    }
+
+    @Test
+    void puttingAUserAsMigratedShouldCutItsEstablishedProxiedConnection() throws Exception {
+        try (Socket clientSocket = new Socket("127.0.0.1", PROXY_IMAP_PORT)) {
+            clientSocket.setSoTimeout(60_000);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+            OutputStream out = clientSocket.getOutputStream();
+
+            // GIVEN an established, authenticated and proxied IMAP connection
+            out.write(("a1 LOGIN " + USER + " " + PASSWORD + "\r\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            assertThat(readTaggedResponse(reader, "a1")).startsWith("a1 OK");
+
+            // WHEN the user is flagged as migrated
+            given()
+                .put("/migratedUsers/" + USER)
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+
+            // THEN the established connection is cut (the client stream reaches EOF / is reset)
+            clientSocket.setSoTimeout(500);
+            await().atMost(Duration.ofSeconds(30))
+                .until(() -> !stillOpen(reader));
+        }
+    }
+
+    private static String readTaggedResponse(BufferedReader reader, String tag) throws IOException {
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.startsWith(tag + " ")) {
+                return line;
+            }
+        }
+        throw new AssertionError("Backend closed the connection before answering the LOGIN");
+    }
+
+    private static boolean stillOpen(BufferedReader reader) {
+        try {
+            // null means the peer closed the connection (EOF); any read line means it is still open.
+            return reader.readLine() != null;
+        } catch (SocketTimeoutException e) {
+            return true; // idle but still open: keep polling
+        } catch (IOException e) {
+            return false; // connection reset: the proxy closed it
+        }
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/MigrationProxyRabbitMQWiringTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/MigrationProxyRabbitMQWiringTest.java
@@ -1,0 +1,104 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration;
+
+import static org.apache.james.backends.rabbitmq.RabbitMQFixture.DEFAULT_MANAGEMENT_CREDENTIAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.backends.postgres.PostgresExtension;
+import org.apache.james.backends.rabbitmq.DockerRabbitMQ;
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
+import org.apache.james.server.core.configuration.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.linagora.tmail.migration.MigrationProxyServer.EventBusModuleChoice;
+
+/**
+ * Boots the migration proxy against a real RabbitMQ with the distributed (HA) event bus injected, to
+ * prove that the clustered disconnection wiring ({@code MigrationProxyRabbitMQEventBusModule}) assembles
+ * and the server actually starts. The RabbitMQ mode is injected through
+ * {@link MigrationProxyServer#createServer(Configuration, EventBusModuleChoice)} rather than dropped as a
+ * {@code rabbitmq.properties} file, which is the point of resolving the choice from the configuration.
+ */
+class MigrationProxyRabbitMQWiringTest {
+    @RegisterExtension
+    static PostgresExtension postgresExtension = PostgresExtension.empty();
+
+    static DockerRabbitMQ rabbitMQ = DockerRabbitMQ.withoutCookie();
+
+    @TempDir
+    static File workingDirectory;
+
+    private GuiceJamesServer proxy;
+
+    @BeforeAll
+    static void setUpAll() {
+        rabbitMQ.start();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        rabbitMQ.stop();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (proxy != null) {
+            proxy.stop();
+        }
+    }
+
+    @Test
+    void serverShouldStartWithRabbitMQEventBus() throws Exception {
+        Configuration configuration = Configuration.builder()
+            .workingDirectory(workingDirectory)
+            .configurationFromClasspath()
+            .build();
+
+        proxy = MigrationProxyServer.createServer(configuration, EventBusModuleChoice.RABBITMQ)
+            .overrideWith(postgresExtension.getModule())
+            .overrideWith(new RabbitMQConfigurationModule());
+        proxy.start();
+
+        assertThat(proxy.isStarted()).isTrue();
+    }
+
+    private static class RabbitMQConfigurationModule extends AbstractModule {
+        @Provides
+        @Singleton
+        RabbitMQConfiguration provideRabbitMQConfiguration() throws Exception {
+            return RabbitMQConfiguration.builder()
+                .amqpUri(rabbitMQ.amqpUri())
+                .managementUri(rabbitMQ.managementUri())
+                .managementCredentials(DEFAULT_MANAGEMENT_CREDENTIAL)
+                .build();
+        }
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
@@ -38,43 +38,56 @@ class ProxyConnectionRegistryTest {
     }
 
     @Test
-    void closeConnectionsShouldCloseRegisteredChannels() {
+    void disconnectShouldCloseRegisteredChannels() {
         EmbeddedChannel channel = new EmbeddedChannel();
         testee.register(BOB, channel);
 
-        testee.closeConnections(BOB);
+        testee.disconnect(BOB::equals);
 
         assertThat(channel.isOpen()).isFalse();
     }
 
     @Test
-    void closeConnectionsShouldCloseEveryChannelOfTheUser() {
+    void disconnectShouldCloseEveryChannelOfTheUser() {
         EmbeddedChannel first = new EmbeddedChannel();
         EmbeddedChannel second = new EmbeddedChannel();
         testee.register(BOB, first);
         testee.register(BOB, second);
 
-        testee.closeConnections(BOB);
+        testee.disconnect(BOB::equals);
 
         assertThat(first.isOpen()).isFalse();
         assertThat(second.isOpen()).isFalse();
     }
 
     @Test
-    void closeConnectionsShouldNotCloseChannelsOfOtherUsers() {
+    void disconnectShouldCloseEveryMatchingUser() {
         EmbeddedChannel bobChannel = new EmbeddedChannel();
         EmbeddedChannel aliceChannel = new EmbeddedChannel();
         testee.register(BOB, bobChannel);
         testee.register(ALICE, aliceChannel);
 
-        testee.closeConnections(BOB);
+        testee.disconnect(username -> true);
+
+        assertThat(bobChannel.isOpen()).isFalse();
+        assertThat(aliceChannel.isOpen()).isFalse();
+    }
+
+    @Test
+    void disconnectShouldNotCloseChannelsOfNonMatchingUsers() {
+        EmbeddedChannel bobChannel = new EmbeddedChannel();
+        EmbeddedChannel aliceChannel = new EmbeddedChannel();
+        testee.register(BOB, bobChannel);
+        testee.register(ALICE, aliceChannel);
+
+        testee.disconnect(BOB::equals);
 
         assertThat(aliceChannel.isOpen()).isTrue();
     }
 
     @Test
-    void closeConnectionsShouldNotThrowWhenUserHasNoConnection() {
-        testee.closeConnections(BOB);
+    void disconnectShouldNotThrowWhenUserHasNoConnection() {
+        testee.disconnect(BOB::equals);
     }
 
     @Test

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
@@ -84,8 +84,7 @@ class ProxyConnectionRegistryTest {
 
         channel.close().syncUninterruptibly();
 
-        // A second close attempt through the registry must be a no-op: the channel is already gone.
-        testee.closeConnections(BOB);
-        assertThat(channel.isOpen()).isFalse();
+        // Once the channel closes it must be dropped from the registry rather than lingering as a dead entry.
+        assertThat(testee.connectionCount(BOB)).isEqualTo(0);
     }
 }

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/core/ProxyConnectionRegistryTest.java
@@ -1,0 +1,91 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.migration.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+class ProxyConnectionRegistryTest {
+    private static final Username BOB = Username.of("bob@domain.tld");
+    private static final Username ALICE = Username.of("alice@domain.tld");
+
+    private ProxyConnectionRegistry testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new ProxyConnectionRegistry();
+    }
+
+    @Test
+    void closeConnectionsShouldCloseRegisteredChannels() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        testee.register(BOB, channel);
+
+        testee.closeConnections(BOB);
+
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    void closeConnectionsShouldCloseEveryChannelOfTheUser() {
+        EmbeddedChannel first = new EmbeddedChannel();
+        EmbeddedChannel second = new EmbeddedChannel();
+        testee.register(BOB, first);
+        testee.register(BOB, second);
+
+        testee.closeConnections(BOB);
+
+        assertThat(first.isOpen()).isFalse();
+        assertThat(second.isOpen()).isFalse();
+    }
+
+    @Test
+    void closeConnectionsShouldNotCloseChannelsOfOtherUsers() {
+        EmbeddedChannel bobChannel = new EmbeddedChannel();
+        EmbeddedChannel aliceChannel = new EmbeddedChannel();
+        testee.register(BOB, bobChannel);
+        testee.register(ALICE, aliceChannel);
+
+        testee.closeConnections(BOB);
+
+        assertThat(aliceChannel.isOpen()).isTrue();
+    }
+
+    @Test
+    void closeConnectionsShouldNotThrowWhenUserHasNoConnection() {
+        testee.closeConnections(BOB);
+    }
+
+    @Test
+    void closedChannelShouldBeDeregistered() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        testee.register(BOB, channel);
+
+        channel.close().syncUninterruptibly();
+
+        // A second close attempt through the registry must be a no-op: the channel is already gone.
+        testee.closeConnections(BOB);
+        assertThat(channel.isOpen()).isFalse();
+    }
+}

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
@@ -36,6 +36,7 @@ import com.linagora.tmail.migration.core.MemoryMigratedUsersRepository;
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
 import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.restassured.RestAssured;
 
 class MigratedUsersRoutesTest {
@@ -44,12 +45,14 @@ class MigratedUsersRoutesTest {
 
     private WebAdminServer webAdminServer;
     private MigratedUsersRepository repository;
+    private ProxyConnectionRegistry connectionRegistry;
 
     @BeforeEach
     void setUp() {
         repository = new MemoryMigratedUsersRepository();
+        connectionRegistry = new ProxyConnectionRegistry();
         webAdminServer = WebAdminUtils.createWebAdminServer(
-                new MigratedUsersRoutes(repository, new ProxyConnectionRegistry(), new JsonTransformer()))
+                new MigratedUsersRoutes(repository, connectionRegistry, new JsonTransformer()))
             .start();
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
     }
@@ -76,6 +79,19 @@ class MigratedUsersRoutesTest {
             .statusCode(HttpStatus.NO_CONTENT_204);
 
         assertThat(repository.isMigrated(Username.of(BOB)).block()).isTrue();
+    }
+
+    @Test
+    void putShouldCloseProxiedConnectionsOfMigratedUser() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        connectionRegistry.register(Username.of(BOB), channel);
+
+        given()
+            .put("/migratedUsers/" + BOB)
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+
+        assertThat(channel.isOpen()).isFalse();
     }
 
     @Test

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
@@ -22,7 +22,13 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import java.util.Set;
+
+import org.apache.james.DisconnectorNotifier;
+import org.apache.james.DisconnectorNotifier.MultipleUserRequest;
 import org.apache.james.core.Username;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
@@ -34,9 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.migration.core.MemoryMigratedUsersRepository;
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
-import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.restassured.RestAssured;
 
 class MigratedUsersRoutesTest {
@@ -45,14 +49,14 @@ class MigratedUsersRoutesTest {
 
     private WebAdminServer webAdminServer;
     private MigratedUsersRepository repository;
-    private ProxyConnectionRegistry connectionRegistry;
+    private DisconnectorNotifier disconnectorNotifier;
 
     @BeforeEach
     void setUp() {
         repository = new MemoryMigratedUsersRepository();
-        connectionRegistry = new ProxyConnectionRegistry();
+        disconnectorNotifier = mock(DisconnectorNotifier.class);
         webAdminServer = WebAdminUtils.createWebAdminServer(
-                new MigratedUsersRoutes(repository, connectionRegistry, new JsonTransformer()))
+                new MigratedUsersRoutes(repository, disconnectorNotifier, new JsonTransformer()))
             .start();
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
     }
@@ -82,16 +86,13 @@ class MigratedUsersRoutesTest {
     }
 
     @Test
-    void putShouldCloseProxiedConnectionsOfMigratedUser() {
-        EmbeddedChannel channel = new EmbeddedChannel();
-        connectionRegistry.register(Username.of(BOB), channel);
-
+    void putShouldDisconnectMigratedUser() {
         given()
             .put("/migratedUsers/" + BOB)
         .then()
             .statusCode(HttpStatus.NO_CONTENT_204);
 
-        assertThat(channel.isOpen()).isFalse();
+        verify(disconnectorNotifier).disconnect(MultipleUserRequest.of(Set.of(Username.of(BOB))));
     }
 
     @Test

--- a/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
+++ b/tmail-backend/apps/migration-proxy/src/test/java/com/linagora/tmail/migration/webadmin/MigratedUsersRoutesTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.migration.core.MemoryMigratedUsersRepository;
 import com.linagora.tmail.migration.core.MigratedUsersRepository;
+import com.linagora.tmail.migration.core.ProxyConnectionRegistry;
 
 import io.restassured.RestAssured;
 
@@ -48,7 +49,7 @@ class MigratedUsersRoutesTest {
     void setUp() {
         repository = new MemoryMigratedUsersRepository();
         webAdminServer = WebAdminUtils.createWebAdminServer(
-                new MigratedUsersRoutes(repository, new JsonTransformer()))
+                new MigratedUsersRoutes(repository, new ProxyConnectionRegistry(), new JsonTransformer()))
             .start();
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
     }


### PR DESCRIPTION
Closes #2466

## What

On `PUT /migratedUsers/{username}` the migration proxy now actively closes the user's live proxied IMAP connections, forcing affected clients to reconnect. Because the backend is resolved once at LOGIN time, a session opened before migration stays pinned to the old backend until the client happens to disconnect; closing it makes the client reconnect and be routed to the new backend straight away.

## How

- **`ProxyConnectionRegistry`** (new): tracks the live client `Channel`s per `Username`. Channels deregister themselves on close so dead connections do not accumulate.
- **`ProxyImapProcessor`**: registers the client channel in the registry right after a successful LOGIN + relay hand-over.
- **`MigratedUsersRoutes`**: after marking a user migrated, calls `connectionRegistry.closeConnections(username)` to force reconnection.
- **`MigrationProxyImapModule`**: injects the (singleton) registry into the processor so the route and the processor share the same instance.

## Tests

- `ProxyConnectionRegistryTest`: covers closing a user's channels, isolation between users, no-op when the user has no connection, and deregistration on channel close.
- `MigratedUsersRoutesTest`: updated for the new constructor.

---
*Generated automatically*
2436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrating a user now automatically forces disconnection of their existing live proxy IMAP sessions when migration state is updated, prompting clients to reconnect.
  * Added server-side session tracking and a disconnection mechanism with configurable in-memory or RabbitMQ-backed delivery.
  * Added event-bus mode selection at server startup.
* **Bug Fixes**
  * Ensures disconnected/closed sessions are removed from tracking to prevent stale entries.
  * Makes disconnection requests best-effort during migration updates without failing the HTTP call.
* **Tests**
  * Added unit, route, and integration coverage, including RabbitMQ startup wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->