### PR TITLE
Fix NPE in FirebasePushListener when Firebase messaging error code is null

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/firebase/FirebasePushListener.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/firebase/FirebasePushListener.scala
@@ -111,7 +111,7 @@ class FirebasePushListener @Inject()(subscriptionRepository: FirebaseSubscriptio
             case _ =>
               pushFailure.increment()
               SMono.error(new RuntimeException(
-                s"Unexpected error during push message to Firebase Cloud Messaging for user ${stateChangeEvent.username.asString()} and subscription ${subscription.id.serialize} and code ${e.getMessagingErrorCode.name()}", e))
+                s"Unexpected error during push message to Firebase Cloud Messaging for user ${stateChangeEvent.username.asString()} and subscription ${subscription.id.serialize} and code ${Option(e.getMessagingErrorCode).map(_.name()).getOrElse("UNKNOWN")}", e))
           }
           case e =>
             pushFailure.increment()

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebasePushListenerTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/firebase/FirebasePushListenerTest.scala
@@ -32,7 +32,7 @@ import org.apache.james.jmap.core.UuidState
 import org.apache.james.metrics.tests.RecordingMetricFactory
 import org.apache.james.user.api.DelegationStore
 import org.apache.james.user.memory.MemoryDelegationStore
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentCaptor
@@ -195,6 +195,30 @@ class FirebasePushListenerTest {
     SMono(testee.reactiveEvent(StateChangeEvent(EventId.random(), bob,
       Map(EmailTypeName -> UuidState(UUID.randomUUID())))))
       .onErrorResume(_ => SMono.empty).block()
+
+    assertThat(SMono.fromPublisher(subscriptionRepository.get(bob, java.util.Set.of(subscriptionId))).block())
+      .isNotNull
+  }
+
+  @Test
+  def shouldNotRemoveSubscriptionAndShouldNotThrowNpeWhenMessagingErrorCodeIsNull(): Unit = {
+    val firebaseException = mock(classOf[FirebaseMessagingException])
+    when(firebaseException.getMessagingErrorCode).thenReturn(null)
+    when(pushClient.push(any())).thenReturn(Mono.error(firebaseException))
+
+    val subscriptionId = SMono(subscriptionRepository.save(bob, FirebaseSubscriptionCreationRequest(
+      deviceClientId = DeviceClientId("junit"),
+      token = FirebaseToken("token"),
+      types = Seq(EmailTypeName)))).block().id
+
+    assertThat(SMono.fromPublisher(subscriptionRepository.get(bob, java.util.Set.of(subscriptionId))).block())
+      .isNotNull
+
+    assertThatThrownBy(() => SMono(testee.reactiveEvent(StateChangeEvent(EventId.random(), bob,
+      Map(EmailTypeName -> UuidState(UUID.randomUUID()))))).block())
+      .isInstanceOf(classOf[RuntimeException])
+      .hasMessageContaining("Unexpected error during push message to Firebase Cloud Messaging")
+      .hasCause(firebaseException)
 
     assertThat(SMono.fromPublisher(subscriptionRepository.get(bob, java.util.Set.of(subscriptionId))).block())
       .isNotNull


### PR DESCRIPTION
Closes #2469

## Problem

`GroupConsumerRetry` logged a `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "com.google.firebase.messaging.MessagingErrorCode.name()" because the return value of "com.google.firebase.messaging.FirebaseMessagingException.getMessagingErrorCode()" is null
	at ...FirebasePushListener.$anonfun$sendNotification$4(FirebasePushListener.scala:114)
```

`FirebaseMessagingException.getMessagingErrorCode()` can return `null` (for instance when the underlying failure is a `Connection reset` rather than a proper FCM error code). In the fallback (`case _`) branch of the error handling, the error message was built with `e.getMessagingErrorCode.name()`, which throws an NPE on a null code, masking the real error and failing the event handling.

## Fix

Build the code segment of the error message defensively via `Option(e.getMessagingErrorCode).map(_.name()).getOrElse("UNKNOWN")`, so a null messaging error code no longer triggers an NPE and the original exception is properly propagated as the cause.

## Test

Added `shouldNotRemoveSubscriptionAndShouldNotThrowNpeWhenMessagingErrorCodeIsNull` which mocks a `FirebaseMessagingException` with a null messaging error code and asserts the resulting `RuntimeException` carries the original exception as its cause (instead of an NPE). All existing `FirebasePushListenerTest` tests still pass.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for push notification failures when an error code is unavailable, preventing a crash and showing `UNKNOWN` instead.
  * Kept affected push subscriptions intact in this edge case.

* **Tests**
  * Added coverage for notification failures with a missing error code to verify the error message and subscription handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->