### PR TITLE
Fix UnsupportedOperationException when copying calendars with custom X- properties

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifier.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifier.scala
@@ -18,8 +18,6 @@
 
 package com.linagora.tmail.james.jmap.calendar
 
-import java.io.ByteArrayInputStream
-import java.nio.charset.StandardCharsets
 import java.time.temporal.Temporal
 import java.time.{Instant, ZoneId, ZonedDateTime}
 import java.util
@@ -28,12 +26,12 @@ import java.util.function.Consumer
 import com.google.common.base.Preconditions.{checkArgument => require}
 import com.google.common.collect.ImmutableList
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier._
-import com.linagora.tmail.james.jmap.model.{CalendarAttendeeMailTo, CalendarEndField, CalendarEventParsed, CalendarLocationField, CalendarOrganizerField, CalendarStartField, CalendarTimeZoneField, VEventTemporalUtil}
-import net.fortuna.ical4j.model.component.VEvent
+import com.linagora.tmail.james.jmap.model.{CalendarAttendeeMailTo, CalendarEndField, CalendarLocationField, CalendarOrganizerField, CalendarStartField, CalendarTimeZoneField, VEventTemporalUtil}
+import net.fortuna.ical4j.model.component.{CalendarComponent, VAlarm, VEvent}
 import net.fortuna.ical4j.model.parameter.PartStat
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod
 import net.fortuna.ical4j.model.property.{Attendee, DtEnd, DtStart, Location, RecurrenceId, Sequence, XProperty}
-import net.fortuna.ical4j.model.{Calendar, Component, Parameter, Period, Property, PropertyList, RelationshipPropertyModifiers}
+import net.fortuna.ical4j.model.{Calendar, Component, ComponentList, Parameter, Period, Property, PropertyList, RelationshipPropertyModifiers}
 import net.fortuna.ical4j.validate.ValidationResult
 import org.apache.james.core.Username
 
@@ -203,15 +201,31 @@ object CalendarEventModifier {
   val RECURRENCE_IGNORE_COPIED_PROPERTIES: Set[String] = Set(Property.RRULE, Property.RDATE, Property.CREATED)
 
   /**
-   * Deep copy a calendar by re-parsing its textual representation.
+   * Deep copy a calendar by structurally rebuilding it from copied components and properties.
    *
    * `Calendar.copy()` relies on `Property.copy()`, which fails with
    * `UnsupportedOperationException: Factory not supported for custom properties`
    * whenever the event carries custom `X-` properties (see ical4j `XProperty.newFactory`).
-   * Re-parsing avoids that limitation while producing an independent copy.
+   *
+   * We reproduce `Calendar.copy()` semantics but route every property through `copyProperty`,
+   * which reconstructs `X-` properties instead of calling their unsupported `copy()`. Copying
+   * property-by-property (rather than re-parsing the textual representation) is important:
+   * re-parsing would rebind date/time properties to the calendar's embedded `VTIMEZONE`
+   * definitions, whereas `copy()` keeps resolving their `TZID` against the IANA registry.
    */
-  def deepCopy(calendar: Calendar): Calendar =
-    CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(calendar.toString.getBytes(StandardCharsets.UTF_8)))
+  def deepCopy(calendar: Calendar): Calendar = {
+    val properties = new PropertyList(calendar.getPropertyList.getAll.asScala.map(copyProperty).asJava)
+    val components = new ComponentList(calendar.getComponents[CalendarComponent].asScala.map(copyComponent).asJava)
+    new Calendar(properties, components)
+  }
+
+  def copyComponent(component: CalendarComponent): CalendarComponent = component match {
+    case vEvent: VEvent =>
+      val properties = new PropertyList(vEvent.getPropertyList.getAll.asScala.map(copyProperty).asJava)
+      val alarms = new ComponentList(vEvent.getComponentList.getAll.asScala.map(_.copy().asInstanceOf[VAlarm]).asJava)
+      new VEvent(properties, alarms)
+    case other => other.copy().asInstanceOf[CalendarComponent]
+  }
 
   /**
    * Copy a property, handling custom `X-` properties whose `copy()` is unsupported by ical4j.

--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifier.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifier.scala
@@ -18,6 +18,8 @@
 
 package com.linagora.tmail.james.jmap.calendar
 
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 import java.time.temporal.Temporal
 import java.time.{Instant, ZoneId, ZonedDateTime}
 import java.util
@@ -26,11 +28,11 @@ import java.util.function.Consumer
 import com.google.common.base.Preconditions.{checkArgument => require}
 import com.google.common.collect.ImmutableList
 import com.linagora.tmail.james.jmap.calendar.CalendarEventModifier._
-import com.linagora.tmail.james.jmap.model.{CalendarAttendeeMailTo, CalendarEndField, CalendarLocationField, CalendarOrganizerField, CalendarStartField, CalendarTimeZoneField, VEventTemporalUtil}
+import com.linagora.tmail.james.jmap.model.{CalendarAttendeeMailTo, CalendarEndField, CalendarEventParsed, CalendarLocationField, CalendarOrganizerField, CalendarStartField, CalendarTimeZoneField, VEventTemporalUtil}
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.parameter.PartStat
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod
-import net.fortuna.ical4j.model.property.{Attendee, DtEnd, DtStart, Location, RecurrenceId, Sequence}
+import net.fortuna.ical4j.model.property.{Attendee, DtEnd, DtStart, Location, RecurrenceId, Sequence, XProperty}
 import net.fortuna.ical4j.model.{Calendar, Component, Parameter, Period, Property, PropertyList, RelationshipPropertyModifiers}
 import net.fortuna.ical4j.validate.ValidationResult
 import org.apache.james.core.Username
@@ -134,7 +136,7 @@ case class CalendarEventModifier(patches: Seq[CalendarEventUpdatePatch],
                                  validator: Consumer[Calendar] = (_: Calendar) => {}) {
 
   def apply(calendar: Calendar): Calendar = {
-    val newCalendar = calendar.copy()
+    val newCalendar = deepCopy(calendar)
     validator.accept(newCalendar)
 
     val vEVentNeedToUpdate: VEvent = recurrenceId.map(findVEventByRecurrenceId(newCalendar, _))
@@ -154,11 +156,11 @@ case class CalendarEventModifier(patches: Seq[CalendarEventUpdatePatch],
     calendar.getComponents[VEvent](Component.VEVENT).asScala
       .find(_.getRecurrenceId[Temporal] == recurrenceId)
       .getOrElse {
-        val baseVEvent = calendar.getFirstVEvent.copy()
+        val baseVEvent = calendar.getFirstVEvent
 
         val filteredProperties: util.List[Property] = baseVEvent.getPropertyList.getAll.asScala
           .filterNot(p => RECURRENCE_IGNORE_COPIED_PROPERTIES.contains(p.getName))
-          .map(_.copy())
+          .map(copyProperty)
           .asJava
 
         val preVEvent = new VEvent(new PropertyList(ImmutableList.builder()
@@ -199,6 +201,25 @@ case class CalendarEventModifier(patches: Seq[CalendarEventUpdatePatch],
 object CalendarEventModifier {
   val MODIFIED_SEQUENCE_DEFAULT: Sequence = new Sequence("1")
   val RECURRENCE_IGNORE_COPIED_PROPERTIES: Set[String] = Set(Property.RRULE, Property.RDATE, Property.CREATED)
+
+  /**
+   * Deep copy a calendar by re-parsing its textual representation.
+   *
+   * `Calendar.copy()` relies on `Property.copy()`, which fails with
+   * `UnsupportedOperationException: Factory not supported for custom properties`
+   * whenever the event carries custom `X-` properties (see ical4j `XProperty.newFactory`).
+   * Re-parsing avoids that limitation while producing an independent copy.
+   */
+  def deepCopy(calendar: Calendar): Calendar =
+    CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(calendar.toString.getBytes(StandardCharsets.UTF_8)))
+
+  /**
+   * Copy a property, handling custom `X-` properties whose `copy()` is unsupported by ical4j.
+   */
+  def copyProperty(property: Property): Property = property match {
+    case xProperty: XProperty => new XProperty(xProperty.getName, xProperty.getParameterList, xProperty.getValue)
+    case other => other.copy()
+  }
 
   def of(patch: CalendarEventUpdatePatch): CalendarEventModifier =
     CalendarEventModifier(Seq(patch), None)

--- a/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifierTest.scala
+++ b/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifierTest.scala
@@ -181,6 +181,44 @@ class CalendarEventModifierTest {
   }
 
   @Test
+  def deepCopyShouldNotRebindTimingToAnInconsistentEmbeddedVTimeZone(): Unit = {
+    // The embedded VTIMEZONE labels Europe/Paris with a WIB (+07:00) offset. Copying the calendar
+    // must keep resolving TZID=Europe/Paris against the IANA zone (as ical4j Calendar.copy() does),
+    // not rebind DTSTART to the inconsistent embedded definition, cf https://github.com/linagora/tmail-backend/pull/2472
+    val target: Calendar = CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(
+      s"""BEGIN:VCALENDAR
+         |VERSION:2.0
+         |PRODID:-//Sabre//Sabre VObject 4.5.7//EN
+         |CALSCALE:GREGORIAN
+         |BEGIN:VTIMEZONE
+         |TZID:Europe/Paris
+         |BEGIN:STANDARD
+         |TZOFFSETFROM:+0700
+         |TZOFFSETTO:+0700
+         |TZNAME:WIB
+         |DTSTART:19700101T000000
+         |END:STANDARD
+         |END:VTIMEZONE
+         |BEGIN:VEVENT
+         |UID:123456789@example.com
+         |DTSTART;TZID=Europe/Paris:20250401T150000
+         |DTEND;TZID=Europe/Paris:20250401T153000
+         |SUMMARY:Loop3
+         |ORGANIZER;CN=John1 Doe1:mailto:organizer@example.com
+         |ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=John2:mailto:att@example.com
+         |DTSTAMP:20250331T075231Z
+         |SEQUENCE:0
+         |END:VEVENT
+         |END:VCALENDAR
+         |""".stripMargin.getBytes("UTF-8")))
+
+    val newStart = ZonedDateTime.parse("20250320T160000", LOCAL_DATE_TIME_FORMATTER.withZone(ZoneId.of("Europe/Paris")))
+    val newCalendar = testee.of(CalendarEventTimingUpdatePatch(newStart, newStart.plusHours(2))).apply(target)
+
+    assertThat(newCalendar.toString).contains("DTSTART;TZID=Europe/Paris:20250320T160000")
+  }
+
+  @Test
   def shouldSucceedWhenEventContainsCustomXProperties(): Unit = {
     // ical4j `Calendar.copy()` throws `UnsupportedOperationException` on custom `X-` properties, cf https://github.com/linagora/tmail-backend/issues/2471
     val calendarWithXProperties: Calendar = CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(

--- a/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifierTest.scala
+++ b/tmail-backend/jmap/extensions-api/src/test/scala/com/linagora/tmail/james/jmap/calendar/CalendarEventModifierTest.scala
@@ -181,6 +181,44 @@ class CalendarEventModifierTest {
   }
 
   @Test
+  def shouldSucceedWhenEventContainsCustomXProperties(): Unit = {
+    // ical4j `Calendar.copy()` throws `UnsupportedOperationException` on custom `X-` properties, cf https://github.com/linagora/tmail-backend/issues/2471
+    val calendarWithXProperties: Calendar = CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(
+      s"""
+         |BEGIN:VCALENDAR
+         |VERSION:2.0
+         |PRODID:-//Example Corp//NONSGML Event//EN
+         |METHOD:REQUEST
+         |BEGIN:VEVENT
+         |UID:123456789@example.com
+         |DTSTAMP:20250318T120000Z
+         |DTSTART:$START_DATE_SAMPLE_VALUE
+         |DTEND:$END_DATE_SAMPLE_VALUE
+         |SUMMARY:Project Kickoff Meeting
+         |ORGANIZER:mailto:organizer@example.com
+         |ATTENDEE;CN=John Doe;RSVP=TRUE:mailto:johndoe@example.com
+         |X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.example.com/room
+         |X-MOZ-GENERATION:1
+         |SEQUENCE:2
+         |END:VEVENT
+         |END:VCALENDAR
+         |
+         |""".stripMargin.getBytes("UTF-8")))
+
+    val newCalendar = testee.of(CalendarEventTimingUpdatePatch(START_DATE_SAMPLE.minusHours(1), END_DATE_SAMPLE))
+      .apply(calendarWithXProperties)
+
+    val softly = new SoftAssertions()
+    softly.assertThat(CalendarEventParsed.from(newCalendar).head.start.get.value)
+      .isEqualTo(START_DATE_SAMPLE.minusHours(1))
+    softly.assertThat(newCalendar.toString)
+      .contains("X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.example.com/room")
+    softly.assertThat(newCalendar.toString)
+      .contains("X-MOZ-GENERATION:1")
+    softly.assertAll()
+  }
+
+  @Test
   def shouldAddDTENDWhenAbsent(): Unit = {
     val absentDTSTARTCalendar: Calendar = CalendarEventParsed.parseICal4jCalendar(new ByteArrayInputStream(
       s"""


### PR DESCRIPTION
Closes #2471

## Problem

`CalendarEventReplyResults` reported `java.lang.UnsupportedOperationException: Factory not supported for custom properties` when replying to an event invitation.

The root cause is in `CalendarEventModifier.apply`, which starts by calling `calendar.copy()`. ical4j implements `Calendar.copy()` on top of `Property.copy()`, and `XProperty.newFactory()` throws `UnsupportedOperationException` for any custom `X-` property. So as soon as an event carries an `X-` property (e.g. `X-OPENPAAS-VIDEOCONFERENCE`, `X-MOZ-*`), copying the calendar — and thus the whole reply/counter update — fails.

## Fix

- Deep-copy the calendar by re-parsing its textual representation (`deepCopy`), which produces an independent copy without relying on the unsupported per-property factory.
- Copy individual properties through a `copyProperty` helper that reconstructs `XProperty` instances instead of calling their unsupported `copy()` (used in the recurrence-override path of `findVEventByRecurrenceId`).

## Test

Added `shouldSucceedWhenEventContainsCustomXProperties` reproducing the crash: a calendar carrying `X-OPENPAAS-VIDEOCONFERENCE` and `X-MOZ-GENERATION`. It fails with the exception on `master` and passes with the fix, asserting the update is applied and the `X-` properties are preserved.

All 35 `CalendarEventModifierTest` tests pass.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar event updates now preserve custom event details and handle calendars with embedded time zone data more reliably.
  * Recurring event edits are applied more consistently, reducing the risk of incorrect date/time changes when updating a single occurrence.
  
* **Tests**
  * Added coverage for calendar copying behavior and preservation of custom properties during event updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->