### PR TITLE
Fix IndexOutOfBoundsException in DownloadRoutes for multi-mailbox messages

### DIFF
--- a/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/DownloadAllContract.scala
+++ b/tmail-backend/integration-tests/jmap/jmap-integration-tests-common/src/main/scala/com/linagora/tmail/james/common/DownloadAllContract.scala
@@ -102,6 +102,60 @@ trait DownloadAllContract {
   }
 
   @Test
+  def downloadAllShouldSucceedWhenMessageBelongsToSeveralMailboxes(server: GuiceJamesServer): Unit = {
+    val inboxPath = MailboxPath.inbox(BOB)
+    val otherPath = MailboxPath.forUser(BOB, "other")
+    val inboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(inboxPath)
+    val otherId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(otherPath)
+    val messageId: MessageId = server.getProbe(classOf[MailboxProbeImpl])
+      .appendMessage(BOB.asString, inboxPath, AppendCommand.from(
+        ClassLoaderUtils.getSystemResourceAsSharedStream(EMAIL_FILE_NAME)))
+      .getMessageId
+
+    val request = s"""{
+                     |  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+                     |  "methodCalls": [[
+                     |    "Email/set",
+                     |    {
+                     |      "accountId": "$accountId",
+                     |      "update": {
+                     |        "${messageId.serialize()}": {
+                     |          "mailboxIds": {
+                     |            "${inboxId.serialize()}": true,
+                     |            "${otherId.serialize()}": true
+                     |          }
+                     |        }
+                     |      }
+                     |    },
+                     |    "c1"]]
+                     |}""".stripMargin
+
+    `given`()
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+    .when()
+      .post()
+    .`then`
+      .statusCode(SC_OK)
+      .body("methodResponses[0][1].updated", hasKey(messageId.serialize()))
+
+    val response = `given`
+      .basePath("")
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+    .when
+      .get(s"/downloadAll/$accountId/${messageId.serialize()}")
+    .`then`
+      .statusCode(SC_OK)
+      .contentType("application/zip")
+      .extract
+      .body
+      .asInputStream()
+
+    assertThat(ZipUtil.readZipData(response))
+      .containsExactlyInAnyOrderElementsOf(ZIP_ENTRIES)
+  }
+
+  @Test
   def downloadAllShouldNotIncludeInlineAttachments(server: GuiceJamesServer): Unit = {
     val path = MailboxPath.inbox(BOB)
     server.getProbe(classOf[MailboxProbeImpl]).createMailbox(path)

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
@@ -163,7 +163,7 @@ class DownloadAllRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticat
     SMono.fromCallable(() => messageIdFactory.fromString(id: String))
       .onErrorResume(e => SMono.error(MessageNotFoundException(id, e)))
       .flatMap(messageId => SFlux(messageIdManager.getMessagesReactive(ImmutableList.of(messageId), FetchGroup.FULL_CONTENT, mailboxSession))
-        .singleOrEmpty()
+        .next()
         .switchIfEmpty(SMono.error(MessageNotFoundException(id)))
         .flatMap(messageResult => handleMessageResult(request, response, messageResult, mailboxSession)))
   }


### PR DESCRIPTION
Closes #2476

## Problem

`GET /downloadAll/{accountId}/{emailId}` failed with a 500 and the following error when the target message belonged to several mailboxes:

```
java.lang.IndexOutOfBoundsException: Source emitted more than one item
	at reactor.core.publisher.MonoSingle$SingleSubscriber.onNext(MonoSingle.java:134)
```

`DownloadAllRoutes` called `singleOrEmpty()` on the result of `messageIdManager.getMessagesReactive(...)`, which emits **one `MessageResult` per mailbox** the message is stored in. A message present in more than one mailbox (e.g. added to several mailboxes via `Email/set`) therefore made `singleOrEmpty()` throw.

## Fix

Use `next()` instead of `singleOrEmpty()` to pick the first `MessageResult`. All results carry the same message content, so any of them is suitable for extracting the attachments. The `switchIfEmpty(...)` still handles the not-found case.

## Test

Added `downloadAllShouldSucceedWhenMessageBelongsToSeveralMailboxes` to `DownloadAllContract`, which places a message in two mailboxes and asserts the download succeeds. It fails (500) before the fix and passes after. The full `MemoryDownloadAllRouteTest` suite (15 tests) is green.

---
*Generated automatically*
