### PR TITLE
Add POST /users?action=reindex to reindex all users

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1124,6 +1124,44 @@ Valid status includes:
 - `FAILED`: Error encountered while executing this step. Check the logs.
 - `ABORTED`: Won't be executed because of previous step failures.
 
+=== Reindexing all users
+
+....
+curl -XPOST http://ip:port/users?action=reindex
+....
+
+Would schedule one reindexing task per user, allowing to rebuild the search index of every
+user's mailboxes.
+
+The following query parameters, similar to the ones of the James
+link:https://james.apache.org/server/manage-webadmin.html#ReIndexing_a_user_mail[per-user reindexing endpoint],
+allow tuning the reindexing behaviour and are applied to every scheduled task:
+
+- `messagesPerSecond`: optional strictly positive integer. Rate limit of the reindexing, expressed
+in messages per second.
+- `mode`: optional. Either `rebuildAll` (default, reindex all messages) or `fixOutdated` (only reindex
+messages that are missing or outdated in the search index).
+
+link:https://james.apache.org/server/manage-webadmin.html#Endpoints_returning_a_task[More details about endpoints returning
+a task].
+
+Response codes:
+
+* 201: Success. A JSON object mapping each username to the id of the reindexing task scheduled for
+that user is returned.
+* 400: Error in the request (invalid or missing `action`, or invalid reindexing options). Details can
+be found in the reported error.
+
+....
+{
+    "bob@domain.tld": "6d94ea36-a0a4-4b4f-8b1e-1234567890ab",
+    "alice@domain.tld": "4b4f8b1e-a0a4-6d94-ea36-0987654321ba"
+}
+....
+
+Each scheduled task is a regular `ReIndexerImpl$UserReIndexingTask` that can be followed, awaited or
+cancelled through the link:https://james.apache.org/server/manage-webadmin.html#Task_management[task management API].
+
 == Domain-scoped task management
 
 In multi-tenant deployments, a domain administrator may need to inspect or cancel tasks that belong to their domain without having access to the global `/tasks` API. The following endpoints expose domain-scoped task operations.

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -237,6 +237,7 @@ import com.linagora.tmail.webadmin.jmap.JmapSettingsReportRoutesModule;
 import com.linagora.tmail.webadmin.jmap.JmapSettingsRoutesModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
+import com.linagora.tmail.webadmin.mailbox.AllUsersReindexingRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
@@ -304,7 +305,8 @@ public class DistributedServer {
         new ContactIndexingModule(),
         new PopulateKeywordEmailQueryViewTaskModule(),
         new UserDataTieringRoutesModule(),
-        new UserDataTieringTaskModule());
+        new UserDataTieringTaskModule(),
+        new AllUsersReindexingRoutesModule());
 
     public static final Module JMAP = Modules.override(
         new TMailJMAPModule(),

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -215,6 +215,7 @@ import com.linagora.tmail.webadmin.jmap.JmapSettingsReportRoutesModule;
 import com.linagora.tmail.webadmin.jmap.JmapSettingsRoutesModule;
 import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
+import com.linagora.tmail.webadmin.mailbox.AllUsersReindexingRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
@@ -325,6 +326,7 @@ public class PostgresTmailServer {
         new JmapSettingsRoutesModule(),
         new UserIdentityModule(),
         new ContactIndexingModule(),
+        new AllUsersReindexingRoutesModule(),
         new WebAdminMailOverWebModule(),
         new WebAdminReIndexingTaskSerializationModule(),
         new WebAdminServerModule());

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
@@ -37,6 +37,7 @@ import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 import spark.Request;
 import spark.Response;
 import spark.Service;
@@ -75,6 +76,7 @@ public class AllUsersReindexingRoutes implements Routes {
         RunningOptions runningOptions = parseRunningOptions(request);
 
         Map<String, String> taskIds = Flux.from(usersRepository.listReactive())
+            .publishOn(Schedulers.boundedElastic())
             .collectMap(Username::asString,
                 username -> scheduleReindexingTask(username, runningOptions),
                 LinkedHashMap::new)

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
@@ -1,0 +1,123 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailbox;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.indexer.ReIndexer;
+import org.apache.james.mailbox.indexer.ReIndexer.RunningOptions;
+import org.apache.james.task.TaskManager;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.routes.ReindexingRunningOptionsParser;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import reactor.core.publisher.Flux;
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+public class AllUsersReindexingRoutes implements Routes {
+    private static final String BASE_PATH = "/users";
+    private static final String ACTION_PARAM = "action";
+    private static final String REINDEX_ACTION = "reindex";
+
+    private final UsersRepository usersRepository;
+    private final ReIndexer reIndexer;
+    private final TaskManager taskManager;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public AllUsersReindexingRoutes(UsersRepository usersRepository, ReIndexer reIndexer,
+                                    TaskManager taskManager, JsonTransformer jsonTransformer) {
+        this.usersRepository = usersRepository;
+        this.reIndexer = reIndexer;
+        this.taskManager = taskManager;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.post(BASE_PATH, this::reIndexAllUsers, jsonTransformer);
+    }
+
+    private Map<String, String> reIndexAllUsers(Request request, Response response) {
+        assertReindexAction(request);
+        RunningOptions runningOptions = parseRunningOptions(request);
+
+        Map<String, String> taskIds = Flux.from(usersRepository.listReactive())
+            .collectMap(Username::asString,
+                username -> scheduleReindexingTask(username, runningOptions),
+                LinkedHashMap::new)
+            .block();
+
+        response.status(HttpStatus.CREATED_201);
+        return taskIds;
+    }
+
+    private String scheduleReindexingTask(Username username, RunningOptions runningOptions) {
+        try {
+            return taskManager.submit(reIndexer.reIndex(username, runningOptions)).asString();
+        } catch (MailboxException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+                .type(ErrorType.SERVER_ERROR)
+                .message("Error while scheduling reindexing task for user " + username.asString())
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private void assertReindexAction(Request request) {
+        String action = request.queryParams(ACTION_PARAM);
+        if (!REINDEX_ACTION.equals(action)) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorType.INVALID_ARGUMENT)
+                .message("Invalid or missing 'action' query parameter. Only 'reindex' is supported.")
+                .haltError();
+        }
+    }
+
+    private RunningOptions parseRunningOptions(Request request) {
+        try {
+            return ReindexingRunningOptionsParser.parse(request);
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorType.INVALID_ARGUMENT)
+                .message(e.getMessage())
+                .cause(e)
+                .haltError();
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutes.java
@@ -19,7 +19,9 @@
 package com.linagora.tmail.webadmin.mailbox;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
@@ -35,6 +37,8 @@ import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -43,6 +47,18 @@ import spark.Response;
 import spark.Service;
 
 public class AllUsersReindexingRoutes implements Routes {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AllUsersReindexingRoutes.class);
+
+    private record ReindexingResult(String username, String taskId, boolean succeeded) {
+        static ReindexingResult success(String username, String taskId) {
+            return new ReindexingResult(username, taskId, true);
+        }
+
+        static ReindexingResult errored(String username) {
+            return new ReindexingResult(username, null, false);
+        }
+    }
+
     private static final String BASE_PATH = "/users";
     private static final String ACTION_PARAM = "action";
     private static final String REINDEX_ACTION = "reindex";
@@ -71,31 +87,36 @@ public class AllUsersReindexingRoutes implements Routes {
         service.post(BASE_PATH, this::reIndexAllUsers, jsonTransformer);
     }
 
-    private Map<String, String> reIndexAllUsers(Request request, Response response) {
+    private Map<String, Object> reIndexAllUsers(Request request, Response response) {
         assertReindexAction(request);
         RunningOptions runningOptions = parseRunningOptions(request);
 
-        Map<String, String> taskIds = Flux.from(usersRepository.listReactive())
+        List<ReindexingResult> results = Flux.from(usersRepository.listReactive())
             .publishOn(Schedulers.boundedElastic())
-            .collectMap(Username::asString,
-                username -> scheduleReindexingTask(username, runningOptions),
-                LinkedHashMap::new)
+            .map(username -> scheduleReindexingTask(username, runningOptions))
+            .collectList()
             .block();
 
+        Map<String, String> taskIds = results.stream()
+            .filter(ReindexingResult::succeeded)
+            .collect(Collectors.toMap(ReindexingResult::username, ReindexingResult::taskId,
+                (first, second) -> first, LinkedHashMap::new));
+        List<String> erroredUsers = results.stream()
+            .filter(result -> !result.succeeded())
+            .map(ReindexingResult::username)
+            .collect(Collectors.toList());
+
         response.status(HttpStatus.CREATED_201);
-        return taskIds;
+        return Map.of("taskIds", taskIds, "erroredUsers", erroredUsers);
     }
 
-    private String scheduleReindexingTask(Username username, RunningOptions runningOptions) {
+    private ReindexingResult scheduleReindexingTask(Username username, RunningOptions runningOptions) {
         try {
-            return taskManager.submit(reIndexer.reIndex(username, runningOptions)).asString();
+            String taskId = taskManager.submit(reIndexer.reIndex(username, runningOptions)).asString();
+            return ReindexingResult.success(username.asString(), taskId);
         } catch (MailboxException e) {
-            throw ErrorResponder.builder()
-                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
-                .type(ErrorType.SERVER_ERROR)
-                .message("Error while scheduling reindexing task for user " + username.asString())
-                .cause(e)
-                .haltError();
+            LOGGER.error("Error while scheduling reindexing task for user {}", username.asString(), e);
+            return ReindexingResult.errored(username.asString());
         }
     }
 

--- a/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesModule.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/main/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesModule.java
@@ -1,0 +1,32 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailbox;
+
+import org.apache.james.webadmin.Routes;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class AllUsersReindexingRoutesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Routes.class)
+            .addBinding().to(AllUsersReindexingRoutes.class);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesTest.java
@@ -1,0 +1,184 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailbox;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
+import org.apache.james.mailbox.indexer.ReIndexer;
+import org.apache.james.mailbox.indexer.ReIndexer.RunningOptions;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskType;
+import org.apache.james.user.memory.MemoryUsersRepository;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+class AllUsersReindexingRoutesTest {
+    private static final Domain DOMAIN = Domain.of("example.com");
+    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+    private static final Username ALICE = Username.fromLocalPartWithDomain("alice", DOMAIN);
+
+    private static final Task NOOP_TASK = new Task() {
+        @Override
+        public Result run() {
+            return Result.COMPLETED;
+        }
+
+        @Override
+        public TaskType type() {
+            return TaskType.of("test-reindex");
+        }
+    };
+
+    private WebAdminServer webAdminServer;
+    private MemoryTaskManager taskManager;
+    private MemoryUsersRepository usersRepository;
+    private ReIndexer reIndexer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
+        domainList.configure(DomainListConfiguration.DEFAULT);
+        domainList.addDomain(DOMAIN);
+        usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+        usersRepository.addUser(BOB, "anyPassword");
+        usersRepository.addUser(ALICE, "anyPassword");
+
+        reIndexer = mock(ReIndexer.class);
+        when(reIndexer.reIndex(any(Username.class), any(RunningOptions.class))).thenReturn(NOOP_TASK);
+
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new AllUsersReindexingRoutes(usersRepository, reIndexer, taskManager, new JsonTransformer()))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Test
+    void postShouldReturn201WithTaskIdPerUser() {
+        Map<String, String> taskIds = given()
+            .queryParam("action", "reindex")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getMap(".");
+
+        assertThat(taskIds).containsOnlyKeys(BOB.asString(), ALICE.asString());
+        assertThat(taskIds.values()).doesNotContainNull();
+    }
+
+    @Test
+    void postShouldScheduleOneReindexingTaskPerUser() throws Exception {
+        given()
+            .queryParam("action", "reindex")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.CREATED_201);
+
+        verify(reIndexer).reIndex(eq(BOB), any(RunningOptions.class));
+        verify(reIndexer).reIndex(eq(ALICE), any(RunningOptions.class));
+    }
+
+    @Test
+    void postShouldReturnEmptyMapWhenNoUser() throws Exception {
+        usersRepository.removeUser(BOB);
+        usersRepository.removeUser(ALICE);
+
+        Map<String, String> taskIds = given()
+            .queryParam("action", "reindex")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath()
+            .getMap(".");
+
+        assertThat(taskIds).isEmpty();
+    }
+
+    @Test
+    void postShouldReturn400WhenActionMissing() {
+        when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+
+        verifyNoInteractions(reIndexer);
+    }
+
+    @Test
+    void postShouldReturn400WhenActionUnknown() {
+        given()
+            .queryParam("action", "unknown")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+
+        verifyNoInteractions(reIndexer);
+    }
+
+    @Test
+    void postShouldReturn400WhenMessagesPerSecondIsInvalid() {
+        given()
+            .queryParam("action", "reindex")
+            .queryParam("messagesPerSecond", "abc")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailbox/src/test/java/com/linagora/tmail/webadmin/mailbox/AllUsersReindexingRoutesTest.java
@@ -35,6 +35,7 @@ import org.apache.james.core.Username;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.indexer.ReIndexer;
 import org.apache.james.mailbox.indexer.ReIndexer.RunningOptions;
 import org.apache.james.task.Hostname;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
 
 class AllUsersReindexingRoutesTest {
     private static final Domain DOMAIN = Domain.of("example.com");
@@ -104,18 +106,37 @@ class AllUsersReindexingRoutesTest {
 
     @Test
     void postShouldReturn201WithTaskIdPerUser() {
-        Map<String, String> taskIds = given()
+        JsonPath response = given()
             .queryParam("action", "reindex")
         .when()
             .post("/users")
         .then()
             .statusCode(HttpStatus.CREATED_201)
             .extract()
-            .jsonPath()
-            .getMap(".");
+            .jsonPath();
 
+        Map<String, String> taskIds = response.getMap("taskIds");
         assertThat(taskIds).containsOnlyKeys(BOB.asString(), ALICE.asString());
         assertThat(taskIds.values()).doesNotContainNull();
+        assertThat(response.getList("erroredUsers")).isEmpty();
+    }
+
+    @Test
+    void postShouldReportUsersForWhichSchedulingFailed() throws Exception {
+        when(reIndexer.reIndex(eq(BOB), any(RunningOptions.class)))
+            .thenThrow(new MailboxException("boom"));
+
+        JsonPath response = given()
+            .queryParam("action", "reindex")
+        .when()
+            .post("/users")
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .extract()
+            .jsonPath();
+
+        assertThat(response.<String, String>getMap("taskIds")).containsOnlyKeys(ALICE.asString());
+        assertThat(response.<String>getList("erroredUsers")).containsExactly(BOB.asString());
     }
 
     @Test
@@ -136,17 +157,17 @@ class AllUsersReindexingRoutesTest {
         usersRepository.removeUser(BOB);
         usersRepository.removeUser(ALICE);
 
-        Map<String, String> taskIds = given()
+        JsonPath response = given()
             .queryParam("action", "reindex")
         .when()
             .post("/users")
         .then()
             .statusCode(HttpStatus.CREATED_201)
             .extract()
-            .jsonPath()
-            .getMap(".");
+            .jsonPath();
 
-        assertThat(taskIds).isEmpty();
+        assertThat(response.<String, String>getMap("taskIds")).isEmpty();
+        assertThat(response.getList("erroredUsers")).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Closes #2479

## Why

Global reindexing (`POST /mailboxes`) is not reliable: it gets stuck midway and exceeds timeouts. The workaround so far has been to emit, via a script, a per-user reindexing order — cumbersome and hard to remember. This builds that strategy into the product.

## What

New endpoint:

```
POST /users?action=reindex&messagesPerSecond=...&mode=...
```

- Schedules **one reindexing task per user** (same task as the per-user reindexing `POST /users/{user}/mailboxes?task=reIndex`).
- The `messagesPerSecond` and `mode` query parameters are the exact ones from user reindexing, carried over to each task (parsed via James' `ReindexingRunningOptionsParser`).
- Not wrapped in a task: the N tasks are scheduled and the call returns **synchronously** a map of `username -> taskId`:

```json
{
  "bob@example.com": "6d2b4c2f-...",
  "alice@example.com": "1a3f9e0b-..."
}
```

- Returns `400 Bad Request` when `action` is missing/unknown or when `messagesPerSecond` is invalid.

Registered on the `distributed` and `postgres` apps (those exposing `ReIndexer`).

## Tests

Added `AllUsersReindexingRoutesTest` covering: one task id per user, one reindex scheduled per user, empty map when no user, and the `400` cases.

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new WebAdmin action to reindex all users in one request.
  * The endpoint returns a task ID for each user so progress can be tracked.

* **Bug Fixes**
  * Added validation for request parameters, with clear bad-request responses for missing or invalid input.
  * Improved error handling when reindexing a user fails during task scheduling.

* **Tests**
  * Added coverage for successful reindexing, empty user lists, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->