### PR TITLE
[TMail] Webadmin mailing list routes (#2488)

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/ldap-mailing-list.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/ldap-mailing-list.adoc
@@ -7,6 +7,41 @@ See xref:tmail-backend/features/ldapMailingLists.adoc[explanations] on LDAP mail
 
 We integrated a working example onto the link:https://github.com/linagora/tmail-backend/tree/master/demo[Twake mail demo].
 
+=== Centralized configuration: mailingLists.properties
+
+Mailing list related components (the `LDAPMailingList` and `OBMLDAPMailingList` mailets, the
+`TMailWithMailingListValidRcptHandler` SMTP handler and the xref:tmail-backend/webadmin.adoc#_mailing_lists[`/mailingLists` webadmin routes])
+can share a centralized configuration defined in an optional `mailingLists.properties` file.
+
+.mailingLists.properties content
+|===
+| Property name | Explanation
+
+| baseDN
+| Optional. The base DN of the subtree holding the mailing list groups. EG: `ou=lists,dc=linagora,dc=com`.
+When set, mailing list components no longer require their own `baseDN` and fall back to this value. A `baseDN`
+explicitly configured on a component (mailet init parameter or SMTP handler configuration) takes precedence.
+
+| mailAttributeForGroups
+| Optional, defaults to `mail`. The LDAP attribute holding the mail address of a group. For easy testing this can be
+set to `description` but for production use a special LDAP schema needs to be crafted for using the `mail` attribute.
+
+| obm.compatibility
+| Optional, defaults to `false`. When `true`, mailing lists follow the OBM schema (`obmGroup` object class,
+members resolved from the `mailBox` and `externalContactEmail` attributes) rather than the default `groupOfNames` schema.
+|===
+
+Example:
+
+....
+baseDN=ou=lists,dc=linagora,dc=com
+mailAttributeForGroups=mail
+obm.compatibility=false
+....
+
+When no `mailingLists.properties` file is provided, components keep their previous behaviour (each requires its own
+`baseDN`) and the `/mailingLists` webadmin routes answer `409 Conflict`.
+
 === LDAPMailingList
 
 Mailing list resolution for Twake mail based on LDAP groups.</p>

--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1890,3 +1890,61 @@ Return codes:
 - `400` Unknown `action`, missing `from`, or invalid username
 - `404` The source folder does not exist
 
+== Mailing lists
+
+These routes expose a read only view of the LDAP mailing lists. They are only available for LDAP based deployments and
+require a centralized xref:tmail-backend/configure/ldap-mailing-list.adoc#_centralized_configuration_mailinglistsproperties[`mailingLists.properties`]
+file with a `baseDN` entry. When no such configuration is available, the routes answer `409 Conflict`.
+
+=== Listing mailing lists
+
+....
+curl -XGET 'http://ip:port/mailingLists'
+....
+
+Returns the mail addresses of all the mailing lists:
+
+....
+["sales@lists.linagora.com", "marketing@lists.linagora.com", ...]
+....
+
+A domain filtered version is available through the `domain` query parameter:
+
+....
+curl -XGET 'http://ip:port/mailingLists?domain=lists.linagora.com'
+....
+
+....
+["sales@lists.linagora.com", ...]
+....
+
+Return codes:
+
+- `200` The list of mailing lists is returned
+- `400` Invalid domain
+- `409` Mailing lists are not configured (no `mailingLists.properties` file or no `baseDN`)
+
+=== Getting a single mailing list
+
+....
+curl -XGET 'http://ip:port/mailingLists/sales@lists.linagora.com'
+....
+
+Returns the details of a mailing list, its members and its owners:
+
+....
+{
+  "mail": "sales@lists.linagora.com",
+  "businessCategory": "ownerRestrictedList",
+  "members": ["bob@linagora.com", ...],
+  "owners": ["alice@linagora.com", ...]
+}
+....
+
+Return codes:
+
+- `200` The mailing list details are returned
+- `400` Invalid mail address
+- `404` The mailing list does not exist
+- `409` Mailing lists are not configured (no `mailingLists.properties` file or no `baseDN`)
+

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -167,6 +167,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-mailing-list</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>welcome-listener</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -291,7 +291,6 @@ public class DistributedServer {
         new LabelRoutesModule(),
         new JmapSettingsReportRoutesModule(),
         new JmapSettingsRoutesModule(),
-        new MailingListConfigurationModule(),
         new SieveRoutesModule(),
         new WebAdminServerModule(),
         new WebAdminReIndexingTaskSerializationModule(),
@@ -453,7 +452,7 @@ public class DistributedServer {
             .combineWith(new UsersRepositoryModuleChooser(
                 DatabaseCombinedUserRequireModule.of(CassandraUsersDAO.class),
                 new CassandraUsersRepositoryModule(),
-                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule())).chooseModule(configuration.usersRepositoryImplementation()))
+                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListConfigurationModule(), new MailingListRoutesModule())).chooseModule(configuration.usersRepositoryImplementation()))
             .combineWith(chooseFirebase(configuration.firebaseModuleChooserConfiguration()))
             .combineWith(chooseLinagoraServicesDiscovery(configuration.linagoraServicesDiscoveryModuleChooserConfiguration()))
             .combineWith(chooseRedisRateLimiterModule(configuration))

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -239,6 +239,8 @@ import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.AllUsersReindexingRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListConfigurationModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
@@ -289,6 +291,7 @@ public class DistributedServer {
         new LabelRoutesModule(),
         new JmapSettingsReportRoutesModule(),
         new JmapSettingsRoutesModule(),
+        new MailingListConfigurationModule(),
         new SieveRoutesModule(),
         new WebAdminServerModule(),
         new WebAdminReIndexingTaskSerializationModule(),
@@ -450,7 +453,7 @@ public class DistributedServer {
             .combineWith(new UsersRepositoryModuleChooser(
                 DatabaseCombinedUserRequireModule.of(CassandraUsersDAO.class),
                 new CassandraUsersRepositoryModule(),
-                List.of(new DomainSignatureTemplateRoutesModule())).chooseModule(configuration.usersRepositoryImplementation()))
+                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule())).chooseModule(configuration.usersRepositoryImplementation()))
             .combineWith(chooseFirebase(configuration.firebaseModuleChooserConfiguration()))
             .combineWith(chooseLinagoraServicesDiscovery(configuration.linagoraServicesDiscoveryModuleChooserConfiguration()))
             .combineWith(chooseRedisRateLimiterModule(configuration))

--- a/tmail-backend/apps/memory/pom.xml
+++ b/tmail-backend/apps/memory/pom.xml
@@ -107,6 +107,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-mailing-list</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>webadmin-jmap</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -138,6 +138,8 @@ import com.linagora.tmail.webadmin.jmap.JmapSettingsReportRoutesModule;
 import com.linagora.tmail.webadmin.jmap.JmapSettingsRoutesModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListConfigurationModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
@@ -205,6 +207,7 @@ public class MemoryServer {
           new LabelRoutesModule(),
           new JmapSettingsReportRoutesModule(),
           new JmapSettingsRoutesModule(),
+          new MailingListConfigurationModule(),
           new DKIMMailetModule())
         .with(new TeamMailboxModule(),
             new TMailScanningQuotaSearcherModule(),
@@ -282,7 +285,7 @@ public class MemoryServer {
 
     private static List<Module> chooseDomainSignatureModule(UsersRepositoryModuleChooser.Implementation implementation) {
         if (implementation == UsersRepositoryModuleChooser.Implementation.LDAP) {
-            return List.of(new DomainSignatureTemplateRoutesModule());
+            return List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule());
         }
         return List.of();
     }

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -207,7 +207,6 @@ public class MemoryServer {
           new LabelRoutesModule(),
           new JmapSettingsReportRoutesModule(),
           new JmapSettingsRoutesModule(),
-          new MailingListConfigurationModule(),
           new DKIMMailetModule())
         .with(new TeamMailboxModule(),
             new TMailScanningQuotaSearcherModule(),
@@ -285,7 +284,7 @@ public class MemoryServer {
 
     private static List<Module> chooseDomainSignatureModule(UsersRepositoryModuleChooser.Implementation implementation) {
         if (implementation == UsersRepositoryModuleChooser.Implementation.LDAP) {
-            return List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule());
+            return List.of(new DomainSignatureTemplateRoutesModule(), new MailingListConfigurationModule(), new MailingListRoutesModule());
         }
         return List.of();
     }

--- a/tmail-backend/apps/postgres/pom.xml
+++ b/tmail-backend/apps/postgres/pom.xml
@@ -261,6 +261,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>webadmin-mailing-list</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tmail-webadmin-team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -217,6 +217,8 @@ import com.linagora.tmail.webadmin.jmap.PopulateKeywordEmailQueryViewTaskModule;
 import com.linagora.tmail.webadmin.label.LabelRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.AllUsersReindexingRoutesModule;
 import com.linagora.tmail.webadmin.mailbox.MailboxResourcesLocationRoutesModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListConfigurationModule;
+import com.linagora.tmail.webadmin.mailinglist.MailingListRoutesModule;
 import com.linagora.tmail.webadmin.quota.UserQuotaReporterRoutesModule;
 import com.linagora.tmail.webadmin.templates.TemplatesProvisionModule;
 
@@ -324,6 +326,7 @@ public class PostgresTmailServer {
         new LabelRoutesModule(),
         new JmapSettingsReportRoutesModule(),
         new JmapSettingsRoutesModule(),
+        new MailingListConfigurationModule(),
         new UserIdentityModule(),
         new ContactIndexingModule(),
         new AllUsersReindexingRoutesModule(),
@@ -498,7 +501,7 @@ public class PostgresTmailServer {
             new UsersRepositoryModuleChooser(
                 DatabaseCombinedUserRequireModule.of(PostgresUsersDAO.class),
                 new TMailPostgresUsersRepositoryModule(),
-                List.of(new DomainSignatureTemplateRoutesModule()))
+                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule()))
                 .chooseModule(configuration.usersRepositoryImplementation()));
     }
 

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -326,7 +326,6 @@ public class PostgresTmailServer {
         new LabelRoutesModule(),
         new JmapSettingsReportRoutesModule(),
         new JmapSettingsRoutesModule(),
-        new MailingListConfigurationModule(),
         new UserIdentityModule(),
         new ContactIndexingModule(),
         new AllUsersReindexingRoutesModule(),
@@ -501,7 +500,7 @@ public class PostgresTmailServer {
             new UsersRepositoryModuleChooser(
                 DatabaseCombinedUserRequireModule.of(PostgresUsersDAO.class),
                 new TMailPostgresUsersRepositoryModule(),
-                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListRoutesModule()))
+                List.of(new DomainSignatureTemplateRoutesModule(), new MailingListConfigurationModule(), new MailingListRoutesModule()))
                 .chooseModule(configuration.usersRepositoryImplementation()));
     }
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
@@ -201,6 +201,7 @@ public class LDAPMailingList extends GenericMailet {
 
     private final LDAPConnectionPool ldapConnectionPool;
     private final LdapRepositoryConfiguration configuration;
+    private final MailingListConfiguration mailingListConfiguration;
     private Filter objectClassFilter;
     private String[] listAttributes;
     private LoadingCache<String, List<MailAddress>> userMailCache;
@@ -211,14 +212,21 @@ public class LDAPMailingList extends GenericMailet {
     private Optional<Filter> extraFilter = Optional.empty();
 
     @Inject
-    public LDAPMailingList(LDAPConnectionPool ldapConnectionPool, LdapRepositoryConfiguration configuration) {
+    public LDAPMailingList(LDAPConnectionPool ldapConnectionPool, LdapRepositoryConfiguration configuration,
+                           MailingListConfiguration mailingListConfiguration) {
         this.configuration = configuration;
         this.ldapConnectionPool = ldapConnectionPool;
+        this.mailingListConfiguration = mailingListConfiguration;
     }
 
     @VisibleForTesting
     public LDAPMailingList(LdapRepositoryConfiguration configuration) throws LDAPException {
-        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool(), configuration);
+        this(configuration, MailingListConfiguration.EMPTY);
+    }
+
+    @VisibleForTesting
+    public LDAPMailingList(LdapRepositoryConfiguration configuration, MailingListConfiguration mailingListConfiguration) throws LDAPException {
+        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool(), configuration, mailingListConfiguration);
     }
 
     @Override
@@ -234,10 +242,12 @@ public class LDAPMailingList extends GenericMailet {
 
     @Override
     public void init() throws MessagingException {
-        baseDN = getInitParameter("baseDN");
+        baseDN = mailingListConfiguration.resolveBaseDN(Optional.ofNullable(getInitParameter("baseDN")))
+            .orElse(null);
         extraFilter = Optional.ofNullable(getInitParameter("extraFilter"))
             .map(Throwing.function(Filter::create));
-        mailAttributeForGroups = getInitParameter("mailAttributeForGroups", "mail");
+        mailAttributeForGroups = Optional.ofNullable(getInitParameter("mailAttributeForGroups"))
+            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
         String groupObjectClass = getInitParameter("groupObjectClass", "groupofnames");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
         rejectedSenderProcessor = getInitParameter("rejectedSenderProcessor");

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
@@ -246,8 +246,8 @@ public class LDAPMailingList extends GenericMailet {
             .orElse(null);
         extraFilter = Optional.ofNullable(getInitParameter("extraFilter"))
             .map(Throwing.function(Filter::create));
-        mailAttributeForGroups = Optional.ofNullable(getInitParameter("mailAttributeForGroups"))
-            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
+        mailAttributeForGroups = mailingListConfiguration.resolveMailAttributeForGroups(
+            Optional.ofNullable(getInitParameter("mailAttributeForGroups")));
         String groupObjectClass = getInitParameter("groupObjectClass", "groupofnames");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
         rejectedSenderProcessor = getInitParameter("rejectedSenderProcessor");

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/MailingListConfiguration.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/MailingListConfiguration.java
@@ -1,0 +1,73 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+
+/**
+ * <p>Centralized configuration for mailing list related components (the {@code LDAPMailingList} and
+ * {@code OBMLDAPMailingList} mailets, the {@code TMailWithMailingListValidRcptHandler} SMTP handler and the
+ * {@code /mailingLists} webadmin routes).</p>
+ *
+ * <p>This configuration is loaded from a {@code mailingLists.properties} file:</p>
+ *
+ * <pre><code>
+ * # Base DN of the subtree holding the mailing list groups. Optional: when set, mailing list components no
+ * # longer require a per-component baseDN and fall back to this value.
+ * baseDN=ou=lists,dc=linagora,dc=com
+ *
+ * # LDAP attribute holding the mail address of a group. Optional, defaults to "mail".
+ * mailAttributeForGroups=mail
+ *
+ * # Whether mailing lists follow the OBM schema (obmGroup / mailBox / externalContactEmail) rather than the
+ * # default groupOfNames schema. Optional, defaults to false.
+ * obm.compatibility=false
+ * </code></pre>
+ */
+public record MailingListConfiguration(Optional<String> baseDN,
+                                       String mailAttributeForGroups,
+                                       boolean obmCompatibility) {
+    public static final String DEFAULT_MAIL_ATTRIBUTE_FOR_GROUPS = "mail";
+
+    /**
+     * An empty configuration: no baseDN override, default mail attribute, no OBM compatibility. Used as a fallback
+     * when no {@code mailingLists.properties} file is provided.
+     */
+    public static final MailingListConfiguration EMPTY =
+        new MailingListConfiguration(Optional.empty(), DEFAULT_MAIL_ATTRIBUTE_FOR_GROUPS, false);
+
+    public static MailingListConfiguration from(Configuration configuration) {
+        return new MailingListConfiguration(
+            Optional.ofNullable(configuration.getString("baseDN", null))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty()),
+            configuration.getString("mailAttributeForGroups", DEFAULT_MAIL_ATTRIBUTE_FOR_GROUPS),
+            configuration.getBoolean("obm.compatibility", false));
+    }
+
+    /**
+     * Resolves the effective baseDN: the per-component value when provided, otherwise the centralized value from
+     * {@code mailingLists.properties}.
+     */
+    public Optional<String> resolveBaseDN(Optional<String> componentBaseDN) {
+        return componentBaseDN.or(this::baseDN);
+    }
+}

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/MailingListConfiguration.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/MailingListConfiguration.java
@@ -70,4 +70,12 @@ public record MailingListConfiguration(Optional<String> baseDN,
     public Optional<String> resolveBaseDN(Optional<String> componentBaseDN) {
         return componentBaseDN.or(this::baseDN);
     }
+
+    /**
+     * Resolves the effective mail attribute for groups: the per-component value when provided, otherwise the
+     * centralized value from {@code mailingLists.properties}.
+     */
+    public String resolveMailAttributeForGroups(Optional<String> componentValue) {
+        return componentValue.orElseGet(this::mailAttributeForGroups);
+    }
 }

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -144,6 +144,7 @@ public class OBMLDAPMailingList extends GenericMailet {
     }
 
     private final LDAPConnectionPool ldapConnectionPool;
+    private final MailingListConfiguration mailingListConfiguration;
     private Filter objectClassFilter;
     private String[] listAttributes;
     private String baseDN;
@@ -152,13 +153,19 @@ public class OBMLDAPMailingList extends GenericMailet {
     private Optional<Filter> extraFilter = Optional.empty();
 
     @Inject
-    public OBMLDAPMailingList(LDAPConnectionPool ldapConnectionPool) {
+    public OBMLDAPMailingList(LDAPConnectionPool ldapConnectionPool, MailingListConfiguration mailingListConfiguration) {
         this.ldapConnectionPool = ldapConnectionPool;
+        this.mailingListConfiguration = mailingListConfiguration;
     }
 
     @VisibleForTesting
     public OBMLDAPMailingList(LdapRepositoryConfiguration configuration) throws LDAPException {
-        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool());
+        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool(), MailingListConfiguration.EMPTY);
+    }
+
+    @VisibleForTesting
+    public OBMLDAPMailingList(LdapRepositoryConfiguration configuration, MailingListConfiguration mailingListConfiguration) throws LDAPException {
+        this(new LDAPConnectionFactory(configuration).getLdapConnectionPool(), mailingListConfiguration);
     }
 
     @Override
@@ -176,10 +183,12 @@ public class OBMLDAPMailingList extends GenericMailet {
 
     @Override
     public void init() throws MessagingException {
-        baseDN = getInitParameter("baseDN");
+        baseDN = mailingListConfiguration.resolveBaseDN(Optional.ofNullable(getInitParameter("baseDN")))
+            .orElse(null);
         extraFilter = Optional.ofNullable(getInitParameter("extraFilter"))
             .map(Throwing.function(Filter::create));
-        mailAttributeForGroups = getInitParameter("mailAttributeForGroups", "mail");
+        mailAttributeForGroups = Optional.ofNullable(getInitParameter("mailAttributeForGroups"))
+            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
         String groupObjectClass = getInitParameter("groupObjectClass", "obmGroup");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
         rejectedSenderProcessor = getInitParameter("rejectedSenderProcessor");

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -187,8 +187,8 @@ public class OBMLDAPMailingList extends GenericMailet {
             .orElse(null);
         extraFilter = Optional.ofNullable(getInitParameter("extraFilter"))
             .map(Throwing.function(Filter::create));
-        mailAttributeForGroups = Optional.ofNullable(getInitParameter("mailAttributeForGroups"))
-            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
+        mailAttributeForGroups = mailingListConfiguration.resolveMailAttributeForGroups(
+            Optional.ofNullable(getInitParameter("mailAttributeForGroups")));
         String groupObjectClass = getInitParameter("groupObjectClass", "obmGroup");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
         rejectedSenderProcessor = getInitParameter("rejectedSenderProcessor");

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
@@ -96,6 +96,41 @@ class LDAPMailingListTest {
     }
 
     @Test
+    void shouldFallbackToMailingListConfigurationWhenBaseDNAndAttributeNotSetAsInitParameters() throws Exception {
+        LDAPMailingList testee = new LDAPMailingList(
+            LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)),
+            new MailingListConfiguration(Optional.of("ou=lists,dc=james,dc=org"), "description", false));
+        FakeMailContext mailetContext = FakeMailContext.defaultContext();
+        FakeMailetConfig config = FakeMailetConfig.builder()
+            .mailetName("LDAPMailingList")
+            .setProperty("rejectedSenderProcessor", "rejectedSender")
+            .setProperty("mailingListPredicate", "lists-prefix")
+            .mailetContext(mailetContext)
+            .build();
+        testee.init(config);
+
+        FakeMail mail = FakeMail.builder()
+            .name("test-mail")
+            .state(FakeMail.DEFAULT)
+            .sender("bob@james.org")
+            .recipient("mygroup@lists.james.org")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setSubject("test")
+                .setText(MESSAGE_CONTENT)
+                .build())
+            .build();
+        testee.service(mail);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(mailetContext.getSentMails()).hasSize(1);
+            softly.assertThat(mailetContext.getSentMails().get(0).getRecipients())
+                .containsOnly(new MailAddress("james-user@james.org"),
+                    new MailAddress("james-user2@james.org"));
+            softly.assertThat(mail.getRecipients()).isEmpty();
+        }));
+    }
+
+    @Test
     void shouldSupportOpenList() throws Exception {
         LDAPMailingList testee = new LDAPMailingList(LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)));
         FakeMailContext mailetContext = FakeMailContext.defaultContext();

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/MailingListConfigurationTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/MailingListConfigurationTest.java
@@ -1,0 +1,88 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+class MailingListConfigurationTest {
+    @Test
+    void shouldReadBaseDnMailAttributeAndObmFlag() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("baseDN", "ou=lists,dc=linagora,dc=com");
+        configuration.addProperty("mailAttributeForGroups", "description");
+        configuration.addProperty("obm.compatibility", "true");
+
+        MailingListConfiguration result = MailingListConfiguration.from(configuration);
+
+        assertThat(result).isEqualTo(new MailingListConfiguration(
+            Optional.of("ou=lists,dc=linagora,dc=com"), "description", true));
+    }
+
+    @Test
+    void mailAttributeForGroupsShouldDefaultToMail() {
+        MailingListConfiguration result = MailingListConfiguration.from(new PropertiesConfiguration());
+
+        assertThat(result.mailAttributeForGroups()).isEqualTo("mail");
+    }
+
+    @Test
+    void baseDnShouldBeEmptyWhenMissing() {
+        MailingListConfiguration result = MailingListConfiguration.from(new PropertiesConfiguration());
+
+        assertThat(result.baseDN()).isEmpty();
+    }
+
+    @Test
+    void baseDnShouldBeEmptyWhenBlank() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("baseDN", "  ");
+
+        assertThat(MailingListConfiguration.from(configuration).baseDN()).isEmpty();
+    }
+
+    @Test
+    void obmCompatibilityShouldDefaultToFalse() {
+        MailingListConfiguration result = MailingListConfiguration.from(new PropertiesConfiguration());
+
+        assertThat(result.obmCompatibility()).isFalse();
+    }
+
+    @Test
+    void resolveBaseDnShouldPreferComponentValue() {
+        MailingListConfiguration configuration = new MailingListConfiguration(
+            Optional.of("ou=centralized,dc=james,dc=org"), "mail", false);
+
+        assertThat(configuration.resolveBaseDN(Optional.of("ou=component,dc=james,dc=org")))
+            .contains("ou=component,dc=james,dc=org");
+    }
+
+    @Test
+    void resolveBaseDnShouldFallbackToCentralizedValue() {
+        MailingListConfiguration configuration = new MailingListConfiguration(
+            Optional.of("ou=centralized,dc=james,dc=org"), "mail", false);
+
+        assertThat(configuration.resolveBaseDN(Optional.empty()))
+            .contains("ou=centralized,dc=james,dc=org");
+    }
+}

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/OBMLDAPMailingListTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/OBMLDAPMailingListTest.java
@@ -40,7 +40,7 @@ class OBMLDAPMailingListTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        testee = new OBMLDAPMailingList((LDAPConnectionPool) null);
+        testee = new OBMLDAPMailingList((LDAPConnectionPool) null, MailingListConfiguration.EMPTY);
         testee.init(FakeMailetConfig.builder()
             .mailetName("OBMLDAPMailingList")
             .setProperty("baseDN", "ou=groups,dc=linagora.com,dc=lng")

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -99,6 +99,7 @@
         <module>webadmin/webadmin-jmap</module>
         <module>webadmin/webadmin-team-mailboxes</module>
         <module>webadmin/webadmin-rate-limit</module>
+        <module>webadmin/webadmin-mailing-list</module>
         <module>webadmin/webadmin-domain-signature-templates</module>
         <module>webadmin/webadmin-tmail-tasks</module>
         <module>healthcheck</module>
@@ -338,6 +339,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>webadmin-rate-limit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>webadmin-mailing-list</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tmail-backend/smtp-extensions/pom.xml
+++ b/tmail-backend/smtp-extensions/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>tmail-mailets</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>team-mailboxes</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
@@ -144,8 +144,8 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
         super.init(config);
         baseDN = mailingListConfiguration.resolveBaseDN(Optional.ofNullable(config.getString("baseDN", null)))
             .orElse(null);
-        mailAttributeForGroups = Optional.ofNullable(config.getString("mailAttributeForGroups", null))
-            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
+        mailAttributeForGroups = mailingListConfiguration.resolveMailAttributeForGroups(
+            Optional.ofNullable(config.getString("mailAttributeForGroups", null)));
         String groupObjectClass = config.getString("groupObjectClass", "groupofnames");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
     }

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
@@ -36,6 +36,7 @@ import org.apache.james.user.ldap.LDAPConnectionFactory;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.linagora.tmail.mailet.MailingListConfiguration;
 import com.linagora.tmail.team.TeamMailbox;
 import com.linagora.tmail.team.TeamMailboxRepository;
 import com.unboundid.ldap.sdk.Filter;
@@ -52,6 +53,7 @@ import reactor.core.publisher.Mono;
 public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
     private final TeamMailboxRepository teamMailboxRepository;
     private final LDAPConnectionPool ldapConnectionPool;
+    private final MailingListConfiguration mailingListConfiguration;
     private Filter objectClassFilter;
     private String baseDN;
     private String mailAttributeForGroups;
@@ -61,10 +63,12 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
                                                 RecipientRewriteTable recipientRewriteTable,
                                                 DomainList domains,
                                                 TeamMailboxRepository teamMailboxRepository,
-                                                LDAPConnectionPool ldapConnectionPool) {
+                                                LDAPConnectionPool ldapConnectionPool,
+                                                MailingListConfiguration mailingListConfiguration) {
         super(users, recipientRewriteTable, domains);
         this.teamMailboxRepository = teamMailboxRepository;
         this.ldapConnectionPool = ldapConnectionPool;
+        this.mailingListConfiguration = mailingListConfiguration;
     }
 
     @VisibleForTesting
@@ -73,8 +77,19 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
                                                 DomainList domains,
                                                 TeamMailboxRepository teamMailboxRepository,
                                                 LdapRepositoryConfiguration configuration) {
+        this(users, recipientRewriteTable, domains, teamMailboxRepository, configuration, MailingListConfiguration.EMPTY);
+    }
+
+    @VisibleForTesting
+    public TMailWithMailingListValidRcptHandler(UsersRepository users,
+                                                RecipientRewriteTable recipientRewriteTable,
+                                                DomainList domains,
+                                                TeamMailboxRepository teamMailboxRepository,
+                                                LdapRepositoryConfiguration configuration,
+                                                MailingListConfiguration mailingListConfiguration) {
         super(users, recipientRewriteTable, domains);
         this.teamMailboxRepository = teamMailboxRepository;
+        this.mailingListConfiguration = mailingListConfiguration;
         try {
             this.ldapConnectionPool = new LDAPConnectionFactory(configuration).getLdapConnectionPool();
         } catch (LDAPException e) {
@@ -127,8 +142,10 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
     @Override
     public void init(Configuration config) throws ConfigurationException {
         super.init(config);
-        baseDN = config.getString("baseDN");
-        mailAttributeForGroups = config.getString("mailAttributeForGroups", "mail");
+        baseDN = mailingListConfiguration.resolveBaseDN(Optional.ofNullable(config.getString("baseDN", null)))
+            .orElse(null);
+        mailAttributeForGroups = Optional.ofNullable(config.getString("mailAttributeForGroups", null))
+            .orElseGet(mailingListConfiguration::mailAttributeForGroups);
         String groupObjectClass = config.getString("groupObjectClass", "groupofnames");
         objectClassFilter = Filter.createEqualityFilter("objectClass", groupObjectClass);
     }

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
@@ -50,9 +50,11 @@ import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.linagora.tmail.mailet.MailingListConfiguration;
 import com.linagora.tmail.team.TeamMailbox;
 import com.linagora.tmail.team.TeamMailboxCallbackNoop;
 import com.linagora.tmail.team.TeamMailboxMember;
@@ -144,6 +146,37 @@ class TMailWithMailingListValidRcptHandlerTest {
     void shouldNotHandeRemoteResources(String address) throws Exception {
         assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))
             .isFalse();
+    }
+
+    @Test
+    void shouldFallbackToMailingListConfigurationWhenBaseDNAndAttributeNotSetAsInitParameters() throws Exception {
+        InMemoryIntegrationResources integrationResources = InMemoryIntegrationResources.defaultResources();
+        SubscriptionManager subscriptionManager = new StoreSubscriptionManager(integrationResources.getMailboxManager().getMapperFactory(),
+                integrationResources.getMailboxManager().getMapperFactory(), integrationResources.getMailboxManager().getEventBus());
+
+        TeamMailboxRepositoryImpl teamMailboxRepository = new TeamMailboxRepositoryImpl(integrationResources.getMailboxManager(), subscriptionManager, integrationResources.getMailboxManager().getMapperFactory(),java.util.Set.of(new TeamMailboxCallbackNoop()));
+
+        MemoryDomainList domainList = new MemoryDomainList(mock(DNSService.class));
+        domainList.configure(DomainListConfiguration.DEFAULT);
+        domainList.addDomain(DOMAIN);
+
+        MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
+
+        MemoryRecipientRewriteTable rrt = new MemoryRecipientRewriteTable();
+        rrt.setUsersRepository(usersRepository);
+        rrt.setDomainList(domainList);
+        rrt.setConfiguration(RecipientRewriteTableConfiguration.DEFAULT_ENABLED);
+
+        TMailWithMailingListValidRcptHandler fallbackTestee = new TMailWithMailingListValidRcptHandler(usersRepository, rrt, domainList, teamMailboxRepository,
+            LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)),
+            new MailingListConfiguration(Optional.of("ou=lists,dc=james,dc=org"), "description", false));
+
+        Configuration configuration = new PropertiesConfiguration();
+        configuration.addProperty("groupObjectClass", "groupofnames");
+        fallbackTestee.init(configuration);
+
+        assertThat(fallbackTestee.isValidRecipient(mock(SMTPSession.class), new MailAddress("mygroup@lists.james.org")))
+            .isTrue();
     }
 
     static HierarchicalConfiguration<ImmutableNode> ldapRepositoryConfigurationWithVirtualHosting(LdapGenericContainer ldapContainer) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/pom.xml
+++ b/tmail-backend/webadmin/webadmin-mailing-list/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~  As a subpart of Twake Mail, this file is edited by Linagora.   ~
+  ~                                                                 ~
+  ~  https://twake-mail.com/                                        ~
+  ~  https://linagora.com                                           ~
+  ~                                                                 ~
+  ~  This file is subject to The Affero Gnu Public License          ~
+  ~  version 3.                                                     ~
+  ~                                                                 ~
+  ~  https://www.gnu.org/licenses/agpl-3.0.en.html                  ~
+  ~                                                                 ~
+  ~  This program is distributed in the hope that it will be        ~
+  ~  useful, but WITHOUT ANY WARRANTY; without even the implied     ~
+  ~  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR        ~
+  ~  PURPOSE. See the GNU Affero General Public License for         ~
+  ~  more details.                                                  ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tmail-backend</artifactId>
+        <groupId>com.linagora.tmail</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webadmin-mailing-list</artifactId>
+    <name>Twake Mail :: WebAdmin :: Mailing lists</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tmail-mailets</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-ldap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-ldap</artifactId>
+            <version>${james.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
@@ -19,14 +19,18 @@
 package com.linagora.tmail.webadmin.mailinglist;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
@@ -47,6 +51,7 @@ import com.unboundid.ldap.sdk.SearchScope;
  * supported, depending on the {@code obm.compatibility} flag of the {@link MailingListConfiguration}.</p>
  */
 public class LdapMailingListRepository implements MailingListRepository {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapMailingListRepository.class);
     private static final String OBM_GROUP_OBJECT_CLASS = "obmGroup";
     private static final String GROUP_OF_NAMES_OBJECT_CLASS = "groupofnames";
     private static final String BUSINESS_CATEGORY_ATTRIBUTE = "businessCategory";
@@ -134,17 +139,36 @@ public class LdapMailingListRepository implements MailingListRepository {
         if (!entry.hasAttribute(attribute)) {
             return ImmutableList.of();
         }
+        Set<String> visitedDns = new HashSet<>();
+        visitedDns.add(entry.getDN());
         return Arrays.stream(entry.getAttribute(attribute).getValues())
-            .flatMap(dn -> resolveMail(dn).stream())
+            .flatMap(dn -> resolveMail(dn, visitedDns))
+            .distinct()
             .collect(ImmutableList.toImmutableList());
     }
 
-    private Optional<MailAddress> resolveMail(String dn) {
+    /**
+     * Resolves a member/owner DN into mail addresses. When the DN points to another group (i.e. it holds a
+     * {@code member} attribute) it is expanded recursively, mirroring the production {@code LDAPMailingList} mailet.
+     * The {@code visitedDns} set guards against loops introduced by recursive group definitions.
+     */
+    private Stream<MailAddress> resolveMail(String dn, Set<String> visitedDns) {
+        if (!visitedDns.add(dn)) {
+            LOGGER.warn("Recursive LDAP group definition creates a loop for dn {}. Please review LDAP data", dn);
+            return Stream.empty();
+        }
         try {
-            SearchResultEntry entry = ldapConnectionPool.getEntry(dn, ldapConfiguration.getUserIdAttribute());
-            return Optional.ofNullable(entry)
-                .map(e -> e.getAttributeValue(ldapConfiguration.getUserIdAttribute()))
-                .map(Throwing.function(MailAddress::new));
+            SearchResultEntry entry = ldapConnectionPool.getEntry(dn, ldapConfiguration.getUserIdAttribute(), MEMBER_ATTRIBUTE);
+            if (entry == null) {
+                return Stream.empty();
+            }
+            if (entry.hasAttribute(MEMBER_ATTRIBUTE)) {
+                return Arrays.stream(entry.getAttribute(MEMBER_ATTRIBUTE).getValues())
+                    .flatMap(nestedDn -> resolveMail(nestedDn, visitedDns));
+            }
+            return Optional.ofNullable(entry.getAttributeValue(ldapConfiguration.getUserIdAttribute()))
+                .map(Throwing.function(MailAddress::new))
+                .stream();
         } catch (LDAPException e) {
             throw new RuntimeException(e);
         }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
@@ -1,0 +1,164 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import com.unboundid.ldap.sdk.SearchScope;
+
+/**
+ * <p>Read only view of the mailing lists stored in LDAP, backing the {@code /mailingLists} webadmin routes.</p>
+ *
+ * <p>Both the default groupOfNames schema (members resolved from the {@code member} / {@code owner} DN attributes) and
+ * the OBM schema (members resolved from the {@code mailBox} / {@code externalContactEmail} mail attributes) are
+ * supported, depending on the {@code obm.compatibility} flag of the {@link MailingListConfiguration}.</p>
+ */
+public class LdapMailingListRepository implements MailingListRepository {
+    private static final String OBM_GROUP_OBJECT_CLASS = "obmGroup";
+    private static final String GROUP_OF_NAMES_OBJECT_CLASS = "groupofnames";
+    private static final String BUSINESS_CATEGORY_ATTRIBUTE = "businessCategory";
+    private static final String MEMBER_ATTRIBUTE = "member";
+    private static final String OWNER_ATTRIBUTE = "owner";
+    private static final String MAIL_BOX_ATTRIBUTE = "mailBox";
+    private static final String EXTERNAL_CONTACT_EMAIL_ATTRIBUTE = "externalContactEmail";
+
+    private final LDAPConnectionPool ldapConnectionPool;
+    private final LdapRepositoryConfiguration ldapConfiguration;
+    private final String baseDN;
+    private final String mailAttributeForGroups;
+    private final boolean obmCompatibility;
+    private final Filter objectClassFilter;
+
+    public LdapMailingListRepository(LDAPConnectionPool ldapConnectionPool,
+                                     LdapRepositoryConfiguration ldapConfiguration,
+                                     MailingListConfiguration mailingListConfiguration) {
+        this.ldapConnectionPool = ldapConnectionPool;
+        this.ldapConfiguration = ldapConfiguration;
+        this.baseDN = mailingListConfiguration.baseDN()
+            .orElseThrow(MailingListsNotConfiguredException::new);
+        this.mailAttributeForGroups = mailingListConfiguration.mailAttributeForGroups();
+        this.obmCompatibility = mailingListConfiguration.obmCompatibility();
+        this.objectClassFilter = Filter.createEqualityFilter("objectClass",
+            obmCompatibility ? OBM_GROUP_OBJECT_CLASS : GROUP_OF_NAMES_OBJECT_CLASS);
+    }
+
+    @Override
+    public List<MailAddress> list() {
+        return search(objectClassFilter, mailAttributeForGroups).stream()
+            .map(entry -> entry.getAttributeValue(mailAttributeForGroups))
+            .filter(Objects::nonNull)
+            .map(Throwing.function(MailAddress::new))
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public List<MailAddress> list(Domain domain) {
+        return list().stream()
+            .filter(address -> address.getDomain().equals(domain))
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public Optional<MailingList> get(MailAddress address) {
+        Filter filter = Filter.createANDFilter(objectClassFilter,
+            Filter.createEqualityFilter(mailAttributeForGroups, address.asString()));
+        return search(filter,
+            mailAttributeForGroups, BUSINESS_CATEGORY_ATTRIBUTE, MEMBER_ATTRIBUTE, OWNER_ATTRIBUTE,
+            MAIL_BOX_ATTRIBUTE, EXTERNAL_CONTACT_EMAIL_ATTRIBUTE)
+            .stream()
+            .findFirst()
+            .map(Throwing.function(this::toMailingList));
+    }
+
+    private MailingList toMailingList(SearchResultEntry entry) throws Exception {
+        Optional<String> businessCategory = Optional.ofNullable(entry.getAttributeValue(BUSINESS_CATEGORY_ATTRIBUTE));
+        List<MailAddress> members;
+        List<MailAddress> owners;
+        if (obmCompatibility) {
+            members = Stream.concat(
+                    mailAttributes(entry, MAIL_BOX_ATTRIBUTE),
+                    mailAttributes(entry, EXTERNAL_CONTACT_EMAIL_ATTRIBUTE))
+                .distinct()
+                .collect(ImmutableList.toImmutableList());
+            owners = ImmutableList.of();
+        } else {
+            members = resolveDnAttribute(entry, MEMBER_ATTRIBUTE);
+            owners = resolveDnAttribute(entry, OWNER_ATTRIBUTE);
+        }
+        return new MailingList(new MailAddress(entry.getAttributeValue(mailAttributeForGroups)),
+            businessCategory, members, owners);
+    }
+
+    private Stream<MailAddress> mailAttributes(SearchResultEntry entry, String attribute) {
+        if (!entry.hasAttribute(attribute)) {
+            return Stream.empty();
+        }
+        return Arrays.stream(entry.getAttribute(attribute).getValues())
+            .map(Throwing.function(MailAddress::new));
+    }
+
+    private List<MailAddress> resolveDnAttribute(SearchResultEntry entry, String attribute) {
+        if (!entry.hasAttribute(attribute)) {
+            return ImmutableList.of();
+        }
+        return Arrays.stream(entry.getAttribute(attribute).getValues())
+            .flatMap(dn -> resolveMail(dn).stream())
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private Optional<MailAddress> resolveMail(String dn) {
+        try {
+            SearchResultEntry entry = ldapConnectionPool.getEntry(dn, ldapConfiguration.getUserIdAttribute());
+            return Optional.ofNullable(entry)
+                .map(e -> e.getAttributeValue(ldapConfiguration.getUserIdAttribute()))
+                .map(Throwing.function(MailAddress::new));
+        } catch (LDAPException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<SearchResultEntry> search(Filter filter, String... attributes) {
+        try {
+            SearchResult searchResult = ldapConnectionPool.search(baseDN, SearchScope.SUB, filter, attributes);
+            return ImmutableList.copyOf(searchResult.getSearchEntries());
+        } catch (LDAPException e) {
+            if (e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
+                return ImmutableList.of();
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingList.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingList.java
@@ -1,0 +1,30 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.james.core.MailAddress;
+
+public record MailingList(MailAddress address,
+                          Optional<String> businessCategory,
+                          List<MailAddress> members,
+                          List<MailAddress> owners) {
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListConfigurationModule.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListConfigurationModule.java
@@ -34,8 +34,9 @@ import com.linagora.tmail.mailet.MailingListConfiguration;
  * Provides the centralized {@link MailingListConfiguration} read from {@code mailingLists.properties}. When the file
  * is absent, an empty configuration is provided so mailing list components fall back to their per-component settings.
  *
- * <p>This module carries no LDAP dependency and is meant to be loaded unconditionally, so that the mailing list
- * mailets and SMTP handler can always resolve their {@link MailingListConfiguration} injection.</p>
+ * <p>This module carries no LDAP dependency of its own, but mailing lists are an LDAP based feature: it is therefore
+ * loaded alongside {@link MailingListRoutesModule} only when LDAP is supported, so that the mailing list mailets and
+ * SMTP handler can resolve their {@link MailingListConfiguration} injection in LDAP deployments.</p>
  */
 public class MailingListConfigurationModule extends AbstractModule {
     private static final Logger LOGGER = LoggerFactory.getLogger(MailingListConfigurationModule.class);

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListConfigurationModule.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListConfigurationModule.java
@@ -1,0 +1,53 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.linagora.tmail.mailet.MailingListConfiguration;
+
+/**
+ * Provides the centralized {@link MailingListConfiguration} read from {@code mailingLists.properties}. When the file
+ * is absent, an empty configuration is provided so mailing list components fall back to their per-component settings.
+ *
+ * <p>This module carries no LDAP dependency and is meant to be loaded unconditionally, so that the mailing list
+ * mailets and SMTP handler can always resolve their {@link MailingListConfiguration} injection.</p>
+ */
+public class MailingListConfigurationModule extends AbstractModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailingListConfigurationModule.class);
+
+    @Provides
+    @Singleton
+    MailingListConfiguration provideMailingListConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            return MailingListConfiguration.from(propertiesProvider.getConfiguration("mailingLists"));
+        } catch (FileNotFoundException e) {
+            LOGGER.info("mailingLists.properties not found, using default mailing list configuration");
+            return MailingListConfiguration.EMPTY;
+        }
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRepository.java
@@ -1,0 +1,33 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+
+public interface MailingListRepository {
+    List<MailAddress> list();
+
+    List<MailAddress> list(Domain domain);
+
+    Optional<MailingList> get(MailAddress address);
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutes.java
@@ -22,9 +22,9 @@ import static org.apache.james.webadmin.Constants.SEPARATOR;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import jakarta.inject.Inject;
-import jakarta.mail.internet.AddressException;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
@@ -104,26 +104,21 @@ public class MailingListRoutes implements Routes {
     }
 
     private Domain parseDomain(String domain) {
-        try {
-            return Domain.of(domain);
-        } catch (IllegalArgumentException e) {
-            throw ErrorResponder.builder()
-                .statusCode(HttpStatus.BAD_REQUEST_400)
-                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
-                .message("Invalid domain '%s'", domain)
-                .cause(e)
-                .haltError();
-        }
+        return parseOrBadRequest(() -> Domain.of(domain), "Invalid domain '%s'", domain);
     }
 
     private MailAddress parseAddress(String address) {
+        return parseOrBadRequest(() -> new MailAddress(address), "Invalid mail address '%s'", address);
+    }
+
+    private <T> T parseOrBadRequest(Callable<T> parser, String errorMessage, String value) {
         try {
-            return new MailAddress(address);
-        } catch (AddressException e) {
+            return parser.call();
+        } catch (Exception e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
-                .message("Invalid mail address '%s'", address)
+                .message(errorMessage, value)
                 .cause(e)
                 .haltError();
         }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutes.java
@@ -1,0 +1,140 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.mail.internet.AddressException;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.google.common.collect.ImmutableList;
+
+import spark.Request;
+import spark.Service;
+
+public class MailingListRoutes implements Routes {
+    public static final String BASE_PATH = SEPARATOR + "mailingLists";
+    private static final String ADDRESS_PARAM = ":address";
+    private static final String SPECIFIC_LIST_PATH = BASE_PATH + SEPARATOR + ADDRESS_PARAM;
+    private static final String DOMAIN_QUERY_PARAM = "domain";
+
+    public record MailingListResponse(String mail, String businessCategory, List<String> members, List<String> owners) {
+        public static MailingListResponse from(MailingList mailingList) {
+            return new MailingListResponse(
+                mailingList.address().asString(),
+                mailingList.businessCategory().orElse(""),
+                mailingList.members().stream().map(MailAddress::asString).collect(ImmutableList.toImmutableList()),
+                mailingList.owners().stream().map(MailAddress::asString).collect(ImmutableList.toImmutableList()));
+        }
+    }
+
+    private final MailingListRepository mailingListRepository;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public MailingListRoutes(MailingListRepository mailingListRepository, JsonTransformer jsonTransformer) {
+        this.mailingListRepository = mailingListRepository;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(BASE_PATH, (req, res) -> listMailingLists(req), jsonTransformer);
+        service.get(SPECIFIC_LIST_PATH, (req, res) -> getMailingList(req), jsonTransformer);
+    }
+
+    private List<String> listMailingLists(Request request) {
+        try {
+            List<MailAddress> addresses = Optional.ofNullable(request.queryParams(DOMAIN_QUERY_PARAM))
+                .map(this::parseDomain)
+                .map(mailingListRepository::list)
+                .orElseGet(mailingListRepository::list);
+            return addresses.stream()
+                .map(MailAddress::asString)
+                .collect(ImmutableList.toImmutableList());
+        } catch (MailingListsNotConfiguredException e) {
+            throw notConfigured(e);
+        }
+    }
+
+    private MailingListResponse getMailingList(Request request) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        try {
+            return mailingListRepository.get(address)
+                .map(MailingListResponse::from)
+                .orElseThrow(() -> ErrorResponder.builder()
+                    .statusCode(HttpStatus.NOT_FOUND_404)
+                    .type(ErrorResponder.ErrorType.NOT_FOUND)
+                    .message("The mailing list '%s' does not exist", address.asString())
+                    .haltError());
+        } catch (MailingListsNotConfiguredException e) {
+            throw notConfigured(e);
+        }
+    }
+
+    private Domain parseDomain(String domain) {
+        try {
+            return Domain.of(domain);
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid domain '%s'", domain)
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private MailAddress parseAddress(String address) {
+        try {
+            return new MailAddress(address);
+        } catch (AddressException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid mail address '%s'", address)
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private RuntimeException notConfigured(MailingListsNotConfiguredException e) {
+        return ErrorResponder.builder()
+            .statusCode(HttpStatus.CONFLICT_409)
+            .type(ErrorResponder.ErrorType.WRONG_STATE)
+            .message(e.getMessage())
+            .cause(e)
+            .haltError();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesModule.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesModule.java
@@ -1,0 +1,55 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.james.webadmin.Routes;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+
+/**
+ * Wires the {@code /mailingLists} webadmin routes on top of LDAP. It relies on {@code LDAPConnectionPool} and
+ * {@code LdapRepositoryConfiguration} being available and should therefore be loaded only for LDAP based deployments.
+ * When no {@code baseDN} is configured (typically because {@code mailingLists.properties} is missing), an
+ * {@link UnconfiguredMailingListRepository} is bound so the routes answer with a {@code 409 Conflict}.
+ */
+public class MailingListRoutesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Routes.class)
+            .addBinding()
+            .to(MailingListRoutes.class);
+    }
+
+    @Provides
+    @Singleton
+    MailingListRepository provideMailingListRepository(LDAPConnectionPool ldapConnectionPool,
+                                                       LdapRepositoryConfiguration ldapConfiguration,
+                                                       MailingListConfiguration mailingListConfiguration) {
+        if (mailingListConfiguration.baseDN().isEmpty()) {
+            return new UnconfiguredMailingListRepository();
+        }
+        return new LdapMailingListRepository(ldapConnectionPool, ldapConfiguration, mailingListConfiguration);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListsNotConfiguredException.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListsNotConfiguredException.java
@@ -1,0 +1,29 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+/**
+ * Thrown when the mailing list routes are queried while no {@code mailingLists.properties} file (or no {@code baseDN})
+ * is configured. Translated to a {@code 409 Conflict} by the routes.
+ */
+public class MailingListsNotConfiguredException extends RuntimeException {
+    public MailingListsNotConfiguredException() {
+        super("Mailing lists are not configured. Please provide a mailingLists.properties file with a baseDN entry.");
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/UnconfiguredMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/UnconfiguredMailingListRepository.java
@@ -1,0 +1,46 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
+
+/**
+ * Repository used when no mailing list configuration is available. Every operation fails, so the routes answer with a
+ * {@code 409 Conflict}.
+ */
+public class UnconfiguredMailingListRepository implements MailingListRepository {
+    @Override
+    public List<MailAddress> list() {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public List<MailAddress> list(Domain domain) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public Optional<MailingList> get(MailAddress address) {
+        throw new MailingListsNotConfiguredException();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
@@ -168,6 +168,50 @@ class MailingListRoutesTest {
     }
 
     @Test
+    void getShouldExpandNestedGroupMembers() {
+        String response = given()
+            .get("/mailingLists/nested@lists.james.org")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .inPath("members").isArray()
+            .containsExactlyInAnyOrder("james-user@james.org", "james-user2@james.org", "james-user5@james.org");
+    }
+
+    @Test
+    void getShouldExpandNestedGroupOwners() {
+        String response = given()
+            .get("/mailingLists/nestedOwner@lists.james.org")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .inPath("owners").isArray()
+            .containsExactlyInAnyOrder("james-user@james.org", "james-user2@james.org");
+        assertThatJson(response)
+            .inPath("members").isArray()
+            .containsExactlyInAnyOrder("james-user3@james.org", "james-user5@james.org");
+    }
+
+    @Test
+    void getShouldNotLoopWhenNestedGroupsReferenceEachOther() {
+        String response = given()
+            .get("/mailingLists/loop1@lists.james.org")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .inPath("members").isArray().isEmpty();
+    }
+
+    @Test
     void getShouldReturnNotFoundWhenUnknownList() {
         given()
             .get("/mailingLists/unknown@lists.james.org")

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
@@ -1,0 +1,206 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
+import static org.eclipse.jetty.http.HttpStatus.CONFLICT_409;
+import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+
+import java.util.Optional;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.plist.PropertyListConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.user.ldap.DockerLdapSingleton;
+import org.apache.james.user.ldap.LDAPConnectionFactory;
+import org.apache.james.user.ldap.LdapGenericContainer;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+
+import io.restassured.RestAssured;
+
+class MailingListRoutesTest {
+    private static final String BASE_DN = "ou=lists,dc=james,dc=org";
+    static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
+
+    private WebAdminServer webAdminServer;
+
+    @BeforeAll
+    static void setUpAll() {
+        ldapContainer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        ldapContainer.stop();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LdapRepositoryConfiguration ldapConfiguration = LdapRepositoryConfiguration.from(
+            ldapRepositoryConfiguration(ldapContainer));
+        LDAPConnectionPool ldapConnectionPool = new LDAPConnectionFactory(ldapConfiguration).getLdapConnectionPool();
+        MailingListConfiguration mailingListConfiguration = new MailingListConfiguration(
+            Optional.of(BASE_DN), "description", false);
+        MailingListRepository repository = new LdapMailingListRepository(ldapConnectionPool, ldapConfiguration, mailingListConfiguration);
+
+        startServer(repository);
+    }
+
+    private void startServer(MailingListRepository repository) {
+        webAdminServer = WebAdminUtils.createWebAdminServer(new MailingListRoutes(repository, new JsonTransformer()))
+            .start();
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Test
+    void listShouldReturnAllMailingLists() {
+        String response = given()
+            .get("/mailingLists")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response).isArray()
+            .contains("mygroup@lists.james.org", "group2@lists.james.org", "group7@localhost");
+    }
+
+    @Test
+    void listShouldFilterByDomain() {
+        String response = given()
+            .queryParam("domain", "localhost")
+            .get("/mailingLists")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response).isArray()
+            .containsExactly("group7@localhost");
+    }
+
+    @Test
+    void listShouldOmitOtherDomains() {
+        String response = given()
+            .queryParam("domain", "lists.james.org")
+            .get("/mailingLists")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response).isArray()
+            .contains("mygroup@lists.james.org")
+            .doesNotContain("group7@localhost");
+    }
+
+    @Test
+    void getShouldReturnMailingListDetails() {
+        String response = given()
+            .get("/mailingLists/mygroup@lists.james.org")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response).isEqualTo("""
+            {
+              "mail": "mygroup@lists.james.org",
+              "businessCategory": "",
+              "members": ["james-user@james.org", "james-user2@james.org"],
+              "owners": []
+            }""");
+    }
+
+    @Test
+    void getShouldReturnOwnersAndBusinessCategory() {
+        String response = given()
+            .get("/mailingLists/group5@lists.james.org")
+        .then()
+            .statusCode(OK_200)
+            .contentType(JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .inPath("businessCategory").isEqualTo("ownerRestrictedList");
+        assertThatJson(response)
+            .inPath("owners").isArray()
+            .containsExactlyInAnyOrder("james-user4@james.org", "james-user2@james.org");
+    }
+
+    @Test
+    void getShouldReturnNotFoundWhenUnknownList() {
+        given()
+            .get("/mailingLists/unknown@lists.james.org")
+        .then()
+            .statusCode(NOT_FOUND_404);
+    }
+
+    @Test
+    void routesShouldReturnConflictWhenNotConfigured() {
+        webAdminServer.destroy();
+        startServer(new UnconfiguredMailingListRepository());
+
+        given()
+            .get("/mailingLists")
+        .then()
+            .statusCode(CONFLICT_409);
+
+        given()
+            .get("/mailingLists/mygroup@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    static HierarchicalConfiguration<ImmutableNode> ldapRepositoryConfiguration(LdapGenericContainer ldapContainer) {
+        PropertyListConfiguration configuration = new PropertyListConfiguration();
+        configuration.addProperty("[@ldapHost]", ldapContainer.getLdapHost());
+        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
+        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
+        configuration.addProperty("[@userBase]", "ou=people,dc=james,dc=org");
+        configuration.addProperty("[@userIdAttribute]", "mail");
+        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
+        configuration.addProperty("[@connectionTimeout]", "2000");
+        configuration.addProperty("[@readTimeout]", "2000");
+        configuration.addProperty("supportsVirtualHosting", true);
+        configuration.addProperty("[@administratorId]", ADMIN.asString());
+        return configuration;
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListRoutesTest.java
@@ -55,6 +55,7 @@ class MailingListRoutesTest {
     static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
 
     private WebAdminServer webAdminServer;
+    private LDAPConnectionPool ldapConnectionPool;
 
     @BeforeAll
     static void setUpAll() {
@@ -70,7 +71,7 @@ class MailingListRoutesTest {
     void setUp() throws Exception {
         LdapRepositoryConfiguration ldapConfiguration = LdapRepositoryConfiguration.from(
             ldapRepositoryConfiguration(ldapContainer));
-        LDAPConnectionPool ldapConnectionPool = new LDAPConnectionFactory(ldapConfiguration).getLdapConnectionPool();
+        ldapConnectionPool = new LDAPConnectionFactory(ldapConfiguration).getLdapConnectionPool();
         MailingListConfiguration mailingListConfiguration = new MailingListConfiguration(
             Optional.of(BASE_DN), "description", false);
         MailingListRepository repository = new LdapMailingListRepository(ldapConnectionPool, ldapConfiguration, mailingListConfiguration);
@@ -87,6 +88,7 @@ class MailingListRoutesTest {
     @AfterEach
     void tearDown() {
         webAdminServer.destroy();
+        ldapConnectionPool.close();
     }
 
     @Test

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/resources/ldif-files/populate.ldif
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/resources/ldif-files/populate.ldif
@@ -1,0 +1,245 @@
+dn: ou=people, dc=james,dc=org
+ou: people
+objectClass: organizationalUnit
+
+dn: ou=empty, dc=james,dc=org
+ou: empty
+objectClass: organizationalUnit
+
+dn: ou=lists, dc=james,dc=org
+ou: lists
+objectClass: organizationalUnit
+
+dn: uid=james-user, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user
+cn: james-user
+sn: james-user
+mail: james-user@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=james-user2, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user2
+cn: james-user2
+sn: james-user2
+mail: james-user2@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=james-user3, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user3
+cn: james-user3
+sn: james-user3
+mail: james-user3@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=james-user4, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user4
+cn: james-user4
+sn: james-user4
+mail: james-user4@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=james-user5, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user5
+cn: james-user5
+sn: james-user5
+mail: james-user5@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=unrelated, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: james-user6
+cn: james-user6
+sn: james-user6
+mail: james-user6@james.org
+userPassword: secret
+description: abcdef
+
+dn: uid=bob, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: bob
+cn: bob
+sn: bob
+mail: bob@james.org
+userPassword: secret
+description: Extra user
+
+dn: uid=john-doe, ou=people, dc=james,dc=org
+objectClass: inetOrgPerson
+uid: john-doe
+cn: john-doe
+sn: Doe
+givenName: John
+displayName: John Doe
+mail: john-doe@james.org
+userPassword: secret
+
+dn: cn=mygroup, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: mygroup
+ou: lists
+description: mygroup@lists.james.org
+member: uid=james-user,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+
+dn: cn=group2, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: openList
+cn: group2
+ou: lists
+description: group2@lists.james.org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+
+dn: cn=group3, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: internalList
+cn: group3
+ou: lists
+description: group3@lists.james.org
+member: uid=james-user4,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+
+dn: cn=group30, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: cn=internalList,ou=twakeListType,ou=nomenclature,o=gov,c=mu
+cn: group30
+ou: lists
+description: group30@lists.james.org
+member: uid=james-user4,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+
+dn: cn=group4, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: memberRestrictedList
+cn: group4
+ou: lists
+description: group4@lists.james.org
+member: uid=james-user4,ou=people,dc=james,dc=org
+member: uid=james-user,ou=people,dc=james,dc=org
+
+dn: cn=group5, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: ownerRestrictedList
+cn: group5
+ou: lists
+description: group5@lists.james.org
+owner: uid=james-user4,ou=people,dc=james,dc=org
+owner: uid=james-user2,ou=people,dc=james,dc=org
+member: uid=james-user,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user4,ou=people,dc=james,dc=org
+
+dn: cn=group5bis, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: memberRestrictedList
+cn: group5bis
+ou: lists
+description: group5bis@lists.james.org
+member: uid=unrelated,ou=people,dc=james,dc=org
+member: uid=james-user4,ou=people,dc=james,dc=org
+
+dn: cn=group5tier, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: memberRestrictedList
+cn: group5tier
+ou: lists
+description: group5tier@lists.james.org
+owner: uid=unrelated,ou=people,dc=james,dc=org
+member: uid=unrelated,ou=people,dc=james,dc=org
+member: uid=james-user4,ou=people,dc=james,dc=org
+
+dn: cn=noowner, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: ownerRestrictedList
+cn: noowner
+ou: lists
+description: noowner@lists.james.org
+member: uid=james-user,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user4,ou=people,dc=james,dc=org
+
+dn: cn=group6, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: domainRestrictedList
+cn: group6
+ou: lists
+description: group6@lists.james.org
+member: uid=james-user5,ou=people,dc=james,dc=org
+member: uid=james-user4,ou=people,dc=james,dc=org
+
+dn: cn=group7, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: group7
+ou: lists
+description: group7@localhost
+member: uid=james-user5,ou=people,dc=james,dc=org
+member: uid=james-user2,ou=people,dc=james,dc=org
+
+dn: cn=group8, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: group8
+ou: lists
+description: group8@lists.james.org
+member: uid=not-found,ou=people,dc=james,dc=org
+member: uid=james-user,ou=people,dc=james,dc=org
+
+dn: cn=nested, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: nested
+ou: lists
+description: nested@lists.james.org
+member: cn=mygroup,ou=lists,dc=james,dc=org
+member: uid=james-user5,ou=people,dc=james,dc=org
+
+dn: cn=nestedOwner, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: nestedOwner
+ou: lists
+description: nestedOwner@lists.james.org
+owner: cn=mygroup,ou=lists,dc=james,dc=org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user5,ou=people,dc=james,dc=org
+
+dn: cn=loop1,ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: loop1
+ou: lists
+description: loop1@lists.james.org
+member: cn=loop2,ou=lists, dc=james,dc=org
+
+dn: cn=loop2,ou=lists, dc=james,dc=org
+objectclass: groupofnames
+cn: loop2
+ou: lists
+description: loop2@lists.james.org
+member: cn=loop1,ou=lists, dc=james,dc=org
+
+dn: cn=unknown-category, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory: unknown
+cn: unknown-category
+ou: lists
+description: unknown-category@lists.james.org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user5,ou=people,dc=james,dc=org
+
+dn: cn=format, ou=lists, dc=james,dc=org
+objectclass: groupofnames
+businessCategory:        memberrestrictedlist
+cn: format
+ou: lists
+description: format@lists.james.org
+member: uid=james-user3,ou=people,dc=james,dc=org
+member: uid=james-user5,ou=people,dc=james,dc=org


### PR DESCRIPTION
Closes #2488

## What

Adds a centralized mailing list configuration and read-only webadmin routes to browse the LDAP mailing lists.

### Commit 1 — Centralized `mailingLists.properties` configuration

Introduces `MailingListConfiguration` loaded from an optional `mailingLists.properties`:

```
# Optional. When set, mailing list components fall back to it instead of requiring a per-component baseDN.
baseDN=ou=lists,dc=linagora,dc=com
# Optional, defaults to "mail".
mailAttributeForGroups=mail
# Optional, defaults to false. Use the OBM schema (obmGroup / mailBox / externalContactEmail).
obm.compatibility=false
```

It is injected into the mailing list components (`LDAPMailingList`, `OBMLDAPMailingList`, `TMailWithMailingListValidRcptHandler`). When `baseDN` is set centrally, those components no longer require their own `baseDN` init parameter and fall back to the centralized value.

### Commit 2 — Webadmin routes

New `webadmin-mailing-list` module exposing:

- `GET /mailingLists` → `["sales@lists.linagora.com", ...]`
- `GET /mailingLists?domain=lists.linagora.com` → domain filtered list
- `GET /mailingLists/{address}` → `{"mail": "...", "businessCategory": "...", "members": [...], "owners": [...]}`

Both the default `groupOfNames` schema and the OBM schema (`obm.compatibility=true`) are supported. The routes answer `409 Conflict` when no `mailingLists.properties` / `baseDN` is configured, and `404` for an unknown list. Wired as an LDAP-only module in the memory, distributed and postgres apps.

## Docs

Documented the new configuration file and the routes under `docs/`.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAdmin read-only LDAP mailing list browsing via the `/mailingLists` API (list all, filter by domain, and fetch address details including members, owners, and business category).
  * Introduced centralized mailing list configuration via `mailingLists.properties` (including shared `baseDN`, group mail attribute, and OBM compatibility behavior).
  * Wired mailing list handling into supported server deployments.
* **Bug Fixes**
  * Improved fallback behavior to centralized configuration when component-specific settings are not provided.
  * When mailing lists are not configured, the API now consistently returns a conflict response (`409 Conflict`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->