### PR TITLE
[TMail] JAMES-4210 Fix startup race between Redis binding and pub/sub subscription

### DIFF
--- a/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyRegistrationHandler.java
+++ b/tmail-backend/event-bus-redis/src/main/java/org/apache/james/events/RedisKeyRegistrationHandler.java
@@ -92,8 +92,18 @@ public class RedisKeyRegistrationHandler {
 
         declarePubSubChannel();
 
-        Disposable newSubscription = Mono.from(redisSubscriber.subscribe(registrationChannel.asString()))
-            .thenMany(redisSubscriber.observeChannels())
+        // Await the SUBSCRIBE acknowledgement so that start() has a real "channel is active" postcondition.
+        // Otherwise the registration binding (awaited SADD) can be visible while the Redis channel is not yet
+        // listed by PUBSUB CHANNELS, which would make CleanRedisEventBusService misclassify it as dangling.
+        Mono.from(redisSubscriber.subscribe(registrationChannel.asString()))
+            .timeout(redisEventBusConfiguration.durationTimeout())
+            .onErrorResume(REDIS_ERROR_PREDICATE.and(e -> redisEventBusConfiguration.failureIgnore()), e -> {
+                LOGGER.warn("Error while subscribing to channel", e);
+                return Mono.empty();
+            })
+            .block();
+
+        Disposable newSubscription = redisSubscriber.observeChannels()
             .flatMap(this::handleChannelMessage, EventBus.DEFAULT_MAX_CONCURRENCY)
             .doOnError(throwable -> LOGGER.error("Error while handling notification message for eventBus={}", eventBusName.value(), throwable))
             .subscribeOn(scheduler)


### PR DESCRIPTION
Closes #2493

## Problem

`shouldNotCleanBindingsToActiveChannels` is flaky (`expected: 0L but was: 1L`) because of a startup race between the Redis registration binding and the pub/sub subscription.

`RedisKeyRegistrationHandler.start()` fired the Redis `SUBSCRIBE` as a fire-and-forget reactive subscription:

```java
Mono.from(redisSubscriber.subscribe(registrationChannel.asString()))
    .thenMany(redisSubscriber.observeChannels())
    ...
    .subscribeOn(scheduler)
    .subscribe(); // start() returns immediately, never awaits the SUBSCRIBE ack
```

So `start()` returns with no happens-before on the `SUBSCRIBE` ack. Meanwhile `register()` **awaits** the `SADD` binding. When `CleanRedisEventBusService.cleanUp()` snapshots the active channels via `PUBSUB CHANNELS`, a binding whose `SUBSCRIBE` is still pending is not yet listed, so it is misclassified as dangling → the intermittent `1L`.

Under CI contention the window is wide: the `SUBSCRIBE` runs `subscribeOn` a scheduler created in the same `start()`, so it may not even have been dispatched by the time the fast single-`SADD` `register().block()` calls return.

## Fix

Await the `SUBSCRIBE` acknowledgement before returning from `start()`, wrapped with the same `timeout` + `failureIgnore` resilience already used in `stop()`/`registerIfNeeded`, then start `observeChannels()` as the ongoing stream. This gives `start()` a real "channel is active" postcondition for every caller and removes the misclassification-during-startup window.

`cleanUp` still removes bindings of genuinely stopped/crashed nodes (their channels drop out of `PUBSUB CHANNELS`), so production cleanup semantics are unchanged.

## Test

`CleanRedisEventBusServiceTest` — all 8 tests pass.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis event handling startup reliability by waiting for channel subscription to be fully acknowledged before processing messages.
  * Reduced the chance of missed or delayed event delivery when Redis subscription setup is slow or temporarily fails.
  * Added safer handling for ignored subscription errors, with warnings logged instead of interrupting startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->