### PR TITLE
[TMail] Support subaddressing for LDAP mailing lists

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/features/ldapMailingLists.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/features/ldapMailingLists.adoc
@@ -18,6 +18,11 @@ Twake mail define some sender controls, defined by the business category of the 
 
 Note that member and owner resolution is recursive: LDAP groups will be expended to their members.
 
+Sub-addressing is supported on list addresses: a mail sent to `mylist+detail@lists.james.org` resolves the
+`mylist@lists.james.org` group (the `+detail` part is ignored for the lookup) and the detail is re-appended onto each
+resolved member. For instance if `mylist` has members `alice@james.org` and `bob@james.org`, then a mail to
+`mylist+detail@lists.james.org` is delivered to `alice+detail@james.org` and `bob+detail@james.org`.
+
 
 See xref:tmail-backend/configure/ldap-mailing-list.adoc[this page] in order to configure this feature.
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
@@ -37,6 +37,7 @@ import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.lifecycle.api.LifecycleUtil;
+import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.ldap.LDAPConnectionFactory;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
 import org.apache.james.util.AuditTrail;
@@ -234,8 +235,8 @@ public class LDAPMailingList extends GenericMailet {
         mail.getRecipients()
             .stream()
             .filter(mailingListPredicate)
-            .flatMap(Throwing.function(list -> resolveListDN(list).stream()))
-            .map(entry -> listToMailTransformation(mail.getMaybeSender(), entry))
+            .flatMap(Throwing.function(recipient -> resolveListDN(recipient).stream()
+                .map(entry -> listToMailTransformation(mail.getMaybeSender(), recipient, entry))))
             .reduce(MailTransformation.NOOP, MailTransformation::doCompose)
             .transform(mail);
     }
@@ -313,10 +314,11 @@ public class LDAPMailingList extends GenericMailet {
     }
 
     private Optional<SearchResultEntry> resolveListDN(MailAddress rcpt) throws LDAPSearchException {
+        MailAddress strippedRcpt = rcpt.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
         try {
             SearchResult searchResult = ldapConnectionPool.search(baseDN,
                 SearchScope.SUB,
-                createFilter(rcpt.asString(), mailAttributeForGroups),
+                createFilter(strippedRcpt.asString(), mailAttributeForGroups),
                 listAttributes);
 
             return searchResult.getSearchEntries().stream().findFirst();
@@ -328,6 +330,23 @@ public class LDAPMailingList extends GenericMailet {
         }
     }
 
+    private static Optional<String> extractDetail(MailAddress recipient) {
+        String localPart = recipient.getLocalPart();
+        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        if (detailStart < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(localPart.substring(detailStart));
+    }
+
+    private static MailAddress appendDetail(MailAddress member, String detail) {
+        try {
+            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
+        } catch (AddressException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private Filter createFilter(String retrievalName, String ldapUserRetrievalAttribute) {
         Filter specificUserFilter = Filter.createEqualityFilter(ldapUserRetrievalAttribute, retrievalName);
         return extraFilter
@@ -335,15 +354,16 @@ public class LDAPMailingList extends GenericMailet {
             .orElseGet(() -> Filter.createANDFilter(objectClassFilter, specificUserFilter));
     }
 
-    private MailTransformation listToMailTransformation(MaybeSender maybeSender, SearchResultEntry list) {
+    private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, SearchResultEntry list) {
         try {
             MailAddress listAddress = new MailAddress(list.getAttributeValue(mailAttributeForGroups));
+            Optional<String> detail = extractDetail(recipient);
             boolean authorized = chooseSenderValidationPolicy(list)
                 .validate(maybeSender, list);
 
             if (!authorized) {
                 return toRejectedProcessor(listAddress)
-                    .doCompose(MailTransformation.removeRecipient.apply(listAddress))
+                    .doCompose(MailTransformation.removeRecipient.apply(recipient))
                     .doCompose(mail -> {
                         AuditTrail.entry()
                             .protocol("mailetcontainer")
@@ -364,9 +384,10 @@ public class LDAPMailingList extends GenericMailet {
                 .flatMap(attribute -> Stream.of(attribute.getValues()))
                 .map(Throwing.function(this::resolveUserMail))
                 .flatMap(Collection::stream)
+                .map(member -> detail.map(value -> appendDetail(member, value)).orElse(member))
                 .collect(ImmutableList.toImmutableList());
 
-            return MailTransformation.removeRecipient.apply(listAddress)
+            return MailTransformation.removeRecipient.apply(recipient)
                 .doComposeIf(
                     mail -> {
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
@@ -340,7 +340,7 @@ public class LDAPMailingList extends GenericMailet {
     private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, SearchResultEntry list) {
         try {
             MailAddress listAddress = new MailAddress(list.getAttributeValue(mailAttributeForGroups));
-            Optional<String> detail = SubAddressing.extractDetail(recipient);
+            Optional<String> detail = recipient.getLocalPartDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
             boolean authorized = chooseSenderValidationPolicy(list)
                 .validate(maybeSender, list);
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/LDAPMailingList.java
@@ -330,23 +330,6 @@ public class LDAPMailingList extends GenericMailet {
         }
     }
 
-    private static Optional<String> extractDetail(MailAddress recipient) {
-        String localPart = recipient.getLocalPart();
-        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
-        if (detailStart < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(localPart.substring(detailStart));
-    }
-
-    private static MailAddress appendDetail(MailAddress member, String detail) {
-        try {
-            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
-        } catch (AddressException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private Filter createFilter(String retrievalName, String ldapUserRetrievalAttribute) {
         Filter specificUserFilter = Filter.createEqualityFilter(ldapUserRetrievalAttribute, retrievalName);
         return extraFilter
@@ -357,7 +340,7 @@ public class LDAPMailingList extends GenericMailet {
     private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, SearchResultEntry list) {
         try {
             MailAddress listAddress = new MailAddress(list.getAttributeValue(mailAttributeForGroups));
-            Optional<String> detail = extractDetail(recipient);
+            Optional<String> detail = SubAddressing.extractDetail(recipient);
             boolean authorized = chooseSenderValidationPolicy(list)
                 .validate(maybeSender, list);
 
@@ -384,7 +367,7 @@ public class LDAPMailingList extends GenericMailet {
                 .flatMap(attribute -> Stream.of(attribute.getValues()))
                 .map(Throwing.function(this::resolveUserMail))
                 .flatMap(Collection::stream)
-                .map(member -> detail.map(value -> appendDetail(member, value)).orElse(member))
+                .map(member -> detail.map(value -> SubAddressing.appendDetail(member, value)).orElse(member))
                 .collect(ImmutableList.toImmutableList());
 
             return MailTransformation.removeRecipient.apply(recipient)

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -257,23 +257,6 @@ public class OBMLDAPMailingList extends GenericMailet {
         }
     }
 
-    private static Optional<String> extractDetail(MailAddress recipient) {
-        String localPart = recipient.getLocalPart();
-        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
-        if (detailStart < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(localPart.substring(detailStart));
-    }
-
-    private static MailAddress appendDetail(MailAddress member, String detail) {
-        try {
-            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
-        } catch (AddressException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private Filter createFilter(String retrievalName, String ldapUserRetrievalAttribute) {
         Filter specificUserFilter = Filter.createEqualityFilter(ldapUserRetrievalAttribute, retrievalName);
         return extraFilter
@@ -283,7 +266,7 @@ public class OBMLDAPMailingList extends GenericMailet {
 
     private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, GroupResolutionResult list) {
         MailAddress listAddress = list.listAddress();
-        Optional<String> detail = extractDetail(recipient);
+        Optional<String> detail = SubAddressing.extractDetail(recipient);
 
         boolean authorized = list.isPublic()
             || maybeSender.isNullSender()
@@ -309,7 +292,7 @@ public class OBMLDAPMailingList extends GenericMailet {
 
         List<MailAddress> memberAddresses = detail
             .<List<MailAddress>>map(value -> list.members().stream()
-                .map(member -> appendDetail(member, value))
+                .map(member -> SubAddressing.appendDetail(member, value))
                 .collect(ImmutableList.toImmutableList()))
             .orElseGet(list::members);
 

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -34,6 +34,7 @@ import jakarta.mail.internet.MimeMessage;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.lifecycle.api.LifecycleUtil;
+import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.ldap.LDAPConnectionFactory;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
 import org.apache.james.util.AuditTrail;
@@ -173,10 +174,10 @@ public class OBMLDAPMailingList extends GenericMailet {
         mail.getRecipients()
             .stream()
             .filter(recipient -> getMailetContext().isLocalServer(recipient.getDomain()))
-            .flatMap(Throwing.function(list -> resolveListDN(list).stream()))
-            .map(Throwing.function(this::asGroupResolutionResult))
-            .flatMap(Optional::stream)
-            .map(entry -> listToMailTransformation(mail.getMaybeSender(), entry))
+            .flatMap(Throwing.function(recipient -> resolveListDN(recipient).stream()
+                .map(Throwing.function(this::asGroupResolutionResult))
+                .flatMap(Optional::stream)
+                .map(result -> listToMailTransformation(mail.getMaybeSender(), recipient, result))))
             .reduce(MailTransformation.NOOP, MailTransformation::doCompose)
             .transform(mail);
     }
@@ -240,10 +241,11 @@ public class OBMLDAPMailingList extends GenericMailet {
     }
 
     private Optional<SearchResultEntry> resolveListDN(MailAddress rcpt) throws LDAPSearchException {
+        MailAddress strippedRcpt = rcpt.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
         try {
             SearchResult searchResult = ldapConnectionPool.search(baseDN,
                 SearchScope.SUB,
-                createFilter(rcpt.asString(), mailAttributeForGroups),
+                createFilter(strippedRcpt.asString(), mailAttributeForGroups),
                 listAttributes);
 
             return searchResult.getSearchEntries().stream().findFirst();
@@ -255,6 +257,23 @@ public class OBMLDAPMailingList extends GenericMailet {
         }
     }
 
+    private static Optional<String> extractDetail(MailAddress recipient) {
+        String localPart = recipient.getLocalPart();
+        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        if (detailStart < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(localPart.substring(detailStart));
+    }
+
+    private static MailAddress appendDetail(MailAddress member, String detail) {
+        try {
+            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
+        } catch (AddressException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private Filter createFilter(String retrievalName, String ldapUserRetrievalAttribute) {
         Filter specificUserFilter = Filter.createEqualityFilter(ldapUserRetrievalAttribute, retrievalName);
         return extraFilter
@@ -262,8 +281,9 @@ public class OBMLDAPMailingList extends GenericMailet {
             .orElseGet(() -> Filter.createANDFilter(objectClassFilter, specificUserFilter));
     }
 
-    private MailTransformation listToMailTransformation(MaybeSender maybeSender, GroupResolutionResult list) {
+    private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, GroupResolutionResult list) {
         MailAddress listAddress = list.listAddress();
+        Optional<String> detail = extractDetail(recipient);
 
         boolean authorized = list.isPublic()
             || maybeSender.isNullSender()
@@ -271,7 +291,7 @@ public class OBMLDAPMailingList extends GenericMailet {
 
         if (!authorized) {
             return toRejectedProcessor(listAddress)
-                .doCompose(MailTransformation.removeRecipient.apply(listAddress))
+                .doCompose(MailTransformation.removeRecipient.apply(recipient))
                 .doCompose(mail -> {
                     AuditTrail.entry()
                         .protocol("mailetcontainer")
@@ -287,7 +307,11 @@ public class OBMLDAPMailingList extends GenericMailet {
                 });
         }
 
-        List<MailAddress> memberAddresses = list.members();
+        List<MailAddress> memberAddresses = detail
+            .<List<MailAddress>>map(value -> list.members().stream()
+                .map(member -> appendDetail(member, value))
+                .collect(ImmutableList.toImmutableList()))
+            .orElseGet(list::members);
 
         MailTransformation sendEmailToGroup = mail -> {
             if (!memberAddresses.isEmpty()) {
@@ -314,7 +338,7 @@ public class OBMLDAPMailingList extends GenericMailet {
 
             return mail;
         };
-        return MailTransformation.removeRecipient.apply(listAddress)
+        return MailTransformation.removeRecipient.apply(recipient)
             .doComposeIf(
                 sendEmailToGroup.doCompose(MailTransformation.removeRecipients.apply(memberAddresses)),
                 mail -> !LoopPrevention.RecordedRecipients.fromMail(mail).getRecipients().contains(listAddress));

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/OBMLDAPMailingList.java
@@ -266,7 +266,7 @@ public class OBMLDAPMailingList extends GenericMailet {
 
     private MailTransformation listToMailTransformation(MaybeSender maybeSender, MailAddress recipient, GroupResolutionResult list) {
         MailAddress listAddress = list.listAddress();
-        Optional<String> detail = SubAddressing.extractDetail(recipient);
+        Optional<String> detail = recipient.getLocalPartDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
 
         boolean authorized = list.isPublic()
             || maybeSender.isNullSender()

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SubAddressing.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SubAddressing.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import java.util.Optional;
+
+import jakarta.mail.internet.AddressException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.user.api.UsersRepository;
+
+public class SubAddressing {
+    public static Optional<String> extractDetail(MailAddress recipient) {
+        String localPart = recipient.getLocalPart();
+        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+        if (detailStart < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(localPart.substring(detailStart));
+    }
+
+    public static MailAddress appendDetail(MailAddress member, String detail) {
+        try {
+            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
+        } catch (AddressException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SubAddressing.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SubAddressing.java
@@ -18,26 +18,16 @@
 
 package com.linagora.tmail.mailet;
 
-import java.util.Optional;
-
 import jakarta.mail.internet.AddressException;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.user.api.UsersRepository;
 
 public class SubAddressing {
-    public static Optional<String> extractDetail(MailAddress recipient) {
-        String localPart = recipient.getLocalPart();
-        int detailStart = localPart.indexOf(UsersRepository.LOCALPART_DETAIL_DELIMITER);
-        if (detailStart < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(localPart.substring(detailStart));
-    }
-
     public static MailAddress appendDetail(MailAddress member, String detail) {
         try {
-            return new MailAddress(member.getLocalPart() + detail + "@" + member.getDomain().asString());
+            return new MailAddress(member.getLocalPart() + UsersRepository.LOCALPART_DETAIL_DELIMITER + detail
+                + "@" + member.getDomain().asString());
         } catch (AddressException e) {
             throw new RuntimeException(e);
         }

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
@@ -96,6 +96,41 @@ class LDAPMailingListTest {
     }
 
     @Test
+    void shouldResolveGroupWhenSubAddressingAndReAppendDetailToMembers() throws Exception {
+        LDAPMailingList testee = new LDAPMailingList(LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)));
+        FakeMailContext mailetContext = FakeMailContext.defaultContext();
+        FakeMailetConfig config = FakeMailetConfig.builder()
+            .mailetName("LDAPMailingList")
+            .setProperty("baseDN", "ou=lists,dc=james,dc=org")
+            .setProperty("rejectedSenderProcessor", "rejectedSender")
+            .setProperty("mailingListPredicate", "lists-prefix")
+            .setProperty("mailAttributeForGroups", "description")
+            .mailetContext(mailetContext)
+            .build();
+        testee.init(config);
+
+        FakeMail mail = FakeMail.builder()
+            .name("test-mail")
+            .state(FakeMail.DEFAULT)
+            .sender("bob@james.org")
+            .recipient("mygroup+zabbix@lists.james.org")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setSubject("test")
+                .setText(MESSAGE_CONTENT)
+                .build())
+            .build();
+        testee.service(mail);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(mailetContext.getSentMails()).hasSize(1);
+            softly.assertThat(mailetContext.getSentMails().get(0).getRecipients())
+                .containsOnly(new MailAddress("james-user+zabbix@james.org"),
+                    new MailAddress("james-user2+zabbix@james.org"));
+            softly.assertThat(mail.getRecipients()).isEmpty();
+        }));
+    }
+
+    @Test
     void shouldFallbackToMailingListConfigurationWhenBaseDNAndAttributeNotSetAsInitParameters() throws Exception {
         LDAPMailingList testee = new LDAPMailingList(
             LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)),

--- a/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
+++ b/tmail-backend/mailets/src/test/java/com/linagora/tmail/mailet/LDAPMailingListTest.java
@@ -131,6 +131,75 @@ class LDAPMailingListTest {
     }
 
     @Test
+    void shouldRejectSubAddressedRecipientToBaseListAddress() throws Exception {
+        LDAPMailingList testee = new LDAPMailingList(LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)));
+        FakeMailContext mailetContext = FakeMailContext.defaultContext();
+
+        FakeMailetConfig config = FakeMailetConfig.builder()
+            .mailetName("LDAPMailingList")
+            .setProperty("baseDN", "ou=lists,dc=james,dc=org")
+            .setProperty("rejectedSenderProcessor", "rejectedSender")
+            .setProperty("mailingListPredicate", "lists-prefix")
+            .setProperty("mailAttributeForGroups", "description")
+            .mailetContext(mailetContext)
+            .build();
+        testee.init(config);
+
+        FakeMail mail = FakeMail.builder()
+            .name("test-mail")
+            .state(FakeMail.DEFAULT)
+            .sender("james-user3@james.org")
+            .recipient("group4+zabbix@lists.james.org")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setSubject("test")
+                .setText(MESSAGE_CONTENT)
+                .build())
+            .build();
+        testee.service(mail);
+
+        assertThat(mail.getRecipients()).isEmpty();
+        assertThat(mailetContext.getSentMails()).hasSize(1);
+        FakeMailContext.SentMail sentMail = mailetContext.getSentMails().get(0);
+        assertThat(sentMail.getState()).isEqualTo("rejectedSender");
+        assertThat(sentMail.getSender()).isEqualTo(new MailAddress("james-user3@james.org"));
+        assertThat(sentMail.getRecipients()).containsOnly(new MailAddress("group4@lists.james.org"));
+    }
+
+    @Test
+    void shouldAvoidLoopUsingRecordedRecipientsWhenSubAddressing() throws Exception {
+        LDAPMailingList testee = new LDAPMailingList(LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)));
+        FakeMailContext mailetContext = FakeMailContext.defaultContext();
+        FakeMailetConfig config = FakeMailetConfig.builder()
+            .mailetName("LDAPMailingList")
+            .setProperty("baseDN", "ou=lists,dc=james,dc=org")
+            .setProperty("rejectedSenderProcessor", "rejectedSender")
+            .setProperty("mailingListPredicate", "lists-prefix")
+            .setProperty("mailAttributeForGroups", "description")
+            .mailetContext(mailetContext)
+            .build();
+        testee.init(config);
+
+        FakeMail mail = FakeMail.builder()
+            .name("test-mail")
+            .state(FakeMail.DEFAULT)
+            .sender("bob@james.org")
+            .recipient("group2+zabbix@lists.james.org")
+            .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                .setSubject("test")
+                .setText(MESSAGE_CONTENT)
+                .build())
+            .build();
+        LoopPrevention.RecordedRecipients recordedRecipients = LoopPrevention.RecordedRecipients.fromMail(mail);
+        recordedRecipients.merge(new MailAddress("group2@lists.james.org")).recordOn(mail);
+        testee.service(mail);
+
+        SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(mail.getRecipients()).isEmpty();
+            softly.assertThat(mailetContext.getSentMails()).isEmpty();
+        }));
+    }
+
+    @Test
     void shouldFallbackToMailingListConfigurationWhenBaseDNAndAttributeNotSetAsInitParameters() throws Exception {
         LDAPMailingList testee = new LDAPMailingList(
             LdapRepositoryConfiguration.from(ldapRepositoryConfigurationWithVirtualHosting(ldapContainer)),

--- a/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
+++ b/tmail-backend/smtp-extensions/src/main/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandler.java
@@ -113,7 +113,8 @@ public class TMailWithMailingListValidRcptHandler extends ValidRcptHandler {
 
     private boolean isAGroup(MailAddress recipient) {
         try {
-            return resolveListDN(recipient).isPresent();
+            MailAddress strippedRecipient = recipient.stripDetails(UsersRepository.LOCALPART_DETAIL_DELIMITER);
+            return resolveListDN(strippedRecipient).isPresent();
         } catch (LDAPSearchException e) {
             throw new RuntimeException(e);
         }

--- a/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
+++ b/tmail-backend/smtp-extensions/src/test/java/com/linagora/tmail/smtp/TMailWithMailingListValidRcptHandlerTest.java
@@ -129,7 +129,8 @@ class TMailWithMailingListValidRcptHandlerTest {
         "address-alias@linagora.com",
         "sales@linagora.com",
         "sales+detail@linagora.com",
-        "mygroup@lists.james.org"
+        "mygroup@lists.james.org",
+        "mygroup+detail@lists.james.org"
     })
     void shouldHandeLocalResources(String address) throws Exception {
         assertThat(testee.isValidRecipient(mock(SMTPSession.class), new MailAddress(address)))


### PR DESCRIPTION
Closes #2495

## Problem

A mail sent to `noc+zabbix@linagora.com`, where `noc@linagora.com` is a mailing list, was **not** resolved: the `+zabbix` detail was neither stripped for the group lookup nor re-appended to members, so the list lookup failed entirely (for both `LDAPMailingList` and `OBMLDAPMailingList`). The `TMailWithMailingListValidRcptHandler` shared the same blind spot, rejecting `RCPT TO:<noc+zabbix@…>` with a 5xx when `noc` was a list-only address.

## Fix

Sub-addressing is now supported on list addresses:

- `resolveListDN` strips the local-part detail (via `UsersRepository.LOCALPART_DETAIL_DELIMITER`) before building the LDAP filter, so `noc+zabbix@…` resolves the `noc@…` group.
- The detail is re-appended onto each resolved member: `noc+zabbix@` → `abc+zabbix@` and `bcd+zabbix@`, matching the behavior described in the ticket. This is meaningful for members that support subaddressing (typically local mailboxes).
- The original recipient (with detail) is the one removed from the mail once expanded.
- `TMailWithMailingListValidRcptHandler#isAGroup` strips the detail before the LDAP lookup, so list-only subaddressed recipients are accepted.

Sender authorization checks are unchanged (they still compare against the un-detailed member/owner addresses).

## Scope

This covers the TMail LDAP/OBM mailing lists and the TMail valid-rcpt handler — the parts living in this repository. Regular RRT groups/aliases are resolved by `AbstractRecipientRewriteTable` in the `james-project` core and are out of scope here.

## Tests

- `LDAPMailingListTest#shouldResolveGroupWhenSubAddressingAndReAppendDetailToMembers` — end-to-end against the LDAP container: `mygroup+zabbix@lists.james.org` is delivered to `james-user+zabbix@james.org` and `james-user2+zabbix@james.org`.
- `TMailWithMailingListValidRcptHandlerTest#shouldHandeLocalResources` — extended with `mygroup+detail@lists.james.org`.

All existing mailing-list and valid-rcpt tests still pass.

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailing list addresses now support `+detail` sub-addressing: messages sent to `group+tag@...` resolve via the base LDAP mailing list and deliver to member addresses with `+tag` re-appended.
* **Bug Fixes**
  * Recipient validation and LDAP group expansion now correctly ignore sub-addressing during lookup while preserving it for delivery, including rejection flows and loop detection behavior.
* **Documentation**
  * Added documentation for how `+detail` sub-addressing is handled for LDAP mailing lists.
* **Tests**
  * Added/updated tests covering `+detail` resolution and member delivery for LDAP mailing lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->