### PR TITLE
[TMail] Fix IllegalStateException when a download stream fails after commit (#2501)

### DIFF
--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
@@ -29,7 +29,7 @@ import com.google.inject.multibindings.Multibinder
 import com.linagora.tmail.james.jmap.ZipUtil
 import com.linagora.tmail.james.jmap.ZipUtil.ZipEntryStreamSource
 import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_DOWNLOAD_ALL
-import com.linagora.tmail.james.jmap.routes.DownloadAllRoutes.{DEFAULT_FILE_NAME, ZIP_CONTENT_TYPE}
+import com.linagora.tmail.james.jmap.routes.DownloadAllRoutes.{DEFAULT_FILE_NAME, ZIP_CONTENT_TYPE, respondDetails}
 import io.netty.buffer.Unpooled
 import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
 import io.netty.handler.codec.http.HttpResponseStatus.{FORBIDDEN, INTERNAL_SERVER_ERROR, NOT_FOUND, OK, UNAUTHORIZED}
@@ -69,6 +69,25 @@ import scala.util.Try
 object DownloadAllRoutes {
   val DEFAULT_FILE_NAME = "noname"
   val ZIP_CONTENT_TYPE = "application/zip"
+
+  def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
+    if (httpServerResponse.hasSentHeaders) {
+      // Response already committed (e.g. an error occurred while streaming the ZIP body):
+      // status and headers are already on the wire, so we cannot rewrite them into an error response.
+      // Attempting to do so would throw `IllegalStateException: Status and headers already sent`, masking
+      // the original error. The real cause is already logged by the caller; let the connection be closed.
+      SMono.empty
+    } else {
+      SMono.fromCallable(() => ResponseSerializer.serialize(details))
+        .map(Json.stringify)
+        .map(_.getBytes(StandardCharsets.UTF_8))
+        .flatMap(bytes =>
+          SMono.fromPublisher(httpServerResponse.status(details.status)
+            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
+            .header(CONTENT_LENGTH, Integer.toString(bytes.length))
+            .sendByteArray(SMono.just(bytes))
+            .`then`).`then`)
+    }
 }
 
 case class BlobWithName(blob: Blob, name: String)
@@ -253,15 +272,4 @@ class DownloadAllRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticat
       .toList
       .flatMap(_.asScala)
       .headOption
-
-  private def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
-    SMono.fromCallable(() => ResponseSerializer.serialize(details))
-      .map(Json.stringify)
-      .map(_.getBytes(StandardCharsets.UTF_8))
-      .flatMap(bytes =>
-        SMono.fromPublisher(httpServerResponse.status(details.status)
-          .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
-          .header(CONTENT_LENGTH, Integer.toString(bytes.length))
-          .sendByteArray(SMono.just(bytes))
-          .`then`).`then`)
 }

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadAllRoutes.scala
@@ -18,7 +18,6 @@
 
 package com.linagora.tmail.james.jmap.routes
 
-import java.nio.charset.StandardCharsets
 import java.util.stream
 import java.util.stream.Stream
 
@@ -31,19 +30,17 @@ import com.linagora.tmail.james.jmap.ZipUtil.ZipEntryStreamSource
 import com.linagora.tmail.james.jmap.method.CapabilityIdentifier.LINAGORA_DOWNLOAD_ALL
 import com.linagora.tmail.james.jmap.routes.DownloadAllRoutes.{DEFAULT_FILE_NAME, ZIP_CONTENT_TYPE, respondDetails}
 import io.netty.buffer.Unpooled
-import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
+import io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
 import io.netty.handler.codec.http.HttpResponseStatus.{FORBIDDEN, INTERNAL_SERVER_ERROR, NOT_FOUND, OK, UNAUTHORIZED}
 import io.netty.handler.codec.http.{HttpHeaderNames, HttpMethod, QueryStringDecoder}
 import jakarta.inject.{Inject, Named}
 import org.apache.james.core.Username
-import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Id.Id
 import org.apache.james.jmap.core.{AccountId, Capability, CapabilityFactory, CapabilityProperties, Id, ProblemDetails, SessionTranslator, URL, UrlPrefixes}
 import org.apache.james.jmap.exceptions.UnauthorizedException
 import org.apache.james.jmap.http.Authenticator
 import org.apache.james.jmap.http.rfc8621.InjectionKeys
-import org.apache.james.jmap.json.ResponseSerializer
 import org.apache.james.jmap.method.AccountNotFoundException
 import org.apache.james.jmap.routes.DownloadRoutes.LOGGER
 import org.apache.james.jmap.routes.{AttachmentBlob, Blob, ForbiddenException}
@@ -71,23 +68,7 @@ object DownloadAllRoutes {
   val ZIP_CONTENT_TYPE = "application/zip"
 
   def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
-    if (httpServerResponse.hasSentHeaders) {
-      // Response already committed (e.g. an error occurred while streaming the ZIP body):
-      // status and headers are already on the wire, so we cannot rewrite them into an error response.
-      // Attempting to do so would throw `IllegalStateException: Status and headers already sent`, masking
-      // the original error. The real cause is already logged by the caller; let the connection be closed.
-      SMono.empty
-    } else {
-      SMono.fromCallable(() => ResponseSerializer.serialize(details))
-        .map(Json.stringify)
-        .map(_.getBytes(StandardCharsets.UTF_8))
-        .flatMap(bytes =>
-          SMono.fromPublisher(httpServerResponse.status(details.status)
-            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
-            .header(CONTENT_LENGTH, Integer.toString(bytes.length))
-            .sendByteArray(SMono.just(bytes))
-            .`then`).`then`)
-    }
+    DownloadResponseUtils.respondDetails(httpServerResponse, details)
 }
 
 case class BlobWithName(blob: Blob, name: String)

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadResponseUtils.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/DownloadResponseUtils.scala
@@ -1,0 +1,50 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.routes
+
+import java.nio.charset.StandardCharsets
+
+import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
+import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
+import org.apache.james.jmap.core.ProblemDetails
+import org.apache.james.jmap.json.ResponseSerializer
+import play.api.libs.json.Json
+import reactor.core.scala.publisher.SMono
+import reactor.netty.http.server.HttpServerResponse
+
+object DownloadResponseUtils {
+  def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
+    if (httpServerResponse.hasSentHeaders) {
+      // Response already committed (e.g. an error occurred while streaming the download body):
+      // status and headers are already on the wire, so we cannot rewrite them into an error response.
+      // Attempting to do so would throw `IllegalStateException: Status and headers already sent`, masking
+      // the original error. The real cause is already logged by the caller; let the connection be closed.
+      SMono.empty
+    } else {
+      SMono.fromCallable(() => ResponseSerializer.serialize(details))
+        .map(Json.stringify)
+        .map(_.getBytes(StandardCharsets.UTF_8))
+        .flatMap(bytes =>
+          SMono.fromPublisher(httpServerResponse.status(details.status)
+            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
+            .header(CONTENT_LENGTH, Integer.toString(bytes.length))
+            .sendByteArray(SMono.just(bytes))
+            .`then`).`then`)
+    }
+}

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
@@ -19,7 +19,6 @@
 package com.linagora.tmail.james.jmap.routes
 
 import java.io.InputStream
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.Callable
 import java.util.function.Consumer
 import java.util.stream.Stream
@@ -27,17 +26,15 @@ import java.util.{UUID, stream}
 
 import com.linagora.tmail.james.jmap.blob.{UnauthenticatedBlobDownloadToken, UnauthenticatedBlobDownloadTokenRepository}
 import io.netty.buffer.Unpooled
-import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
+import io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
 import io.netty.handler.codec.http.HttpResponseStatus.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK, UNAUTHORIZED}
 import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValidationUtil, HttpMethod, QueryStringDecoder}
 import jakarta.inject.Inject
 import org.apache.james.blob.api.{BlobId => BlobStoreBlobId}
 import org.apache.james.core.Username
-import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
 import org.apache.james.jmap.api.model.Size.Size
 import org.apache.james.jmap.api.model.{AccountId => JavaAccountId}
 import org.apache.james.jmap.core.{AccountId, Id, ProblemDetails}
-import org.apache.james.jmap.json.ResponseSerializer
 import org.apache.james.jmap.mail.{BlobId => JmapBlobId}
 import org.apache.james.jmap.routes.DownloadRoutes.BUFFER_SIZE
 import org.apache.james.jmap.routes.{Blob, BlobNotFoundException, BlobResolvers}
@@ -46,7 +43,6 @@ import org.apache.james.mailbox.{MailboxSession, SessionProvider}
 import org.apache.james.metrics.api.{Metric, MetricFactory}
 import org.apache.james.util.ReactorUtils
 import org.slf4j.{Logger, LoggerFactory}
-import play.api.libs.json.Json
 import reactor.core.publisher.Mono
 import reactor.core.scala.publisher.SMono
 import reactor.core.scheduler.Schedulers
@@ -60,23 +56,7 @@ object UnauthenticatedBlobAccessDownloadRoutes {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnauthenticatedBlobAccessDownloadRoutes])
 
   def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
-    if (httpServerResponse.hasSentHeaders) {
-      // Response already committed (e.g. an error occurred while streaming the blob body):
-      // status and headers are already on the wire, so we cannot rewrite them into an error response.
-      // Attempting to do so would throw `IllegalStateException: Status and headers already sent`, masking
-      // the original error. The real cause is already logged by the caller; let the connection be closed.
-      SMono.empty
-    } else {
-      SMono.fromCallable(() => ResponseSerializer.serialize(details))
-        .map(Json.stringify)
-        .map(_.getBytes(StandardCharsets.UTF_8))
-        .flatMap(bytes =>
-          SMono.fromPublisher(httpServerResponse.status(details.status)
-            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
-            .header(CONTENT_LENGTH, Integer.toString(bytes.length))
-            .sendByteArray(SMono.just(bytes))
-            .`then`).`then`)
-    }
+    DownloadResponseUtils.respondDetails(httpServerResponse, details)
 }
 
 case class InvalidUnauthenticatedBlobAccessTokenException() extends RuntimeException

--- a/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
+++ b/tmail-backend/jmap/extensions/src/main/scala/com/linagora/tmail/james/jmap/routes/UnauthenticatedBlobAccessDownloadRoutes.scala
@@ -58,6 +58,25 @@ import scala.util.{Failure, Success, Try}
 
 object UnauthenticatedBlobAccessDownloadRoutes {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnauthenticatedBlobAccessDownloadRoutes])
+
+  def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
+    if (httpServerResponse.hasSentHeaders) {
+      // Response already committed (e.g. an error occurred while streaming the blob body):
+      // status and headers are already on the wire, so we cannot rewrite them into an error response.
+      // Attempting to do so would throw `IllegalStateException: Status and headers already sent`, masking
+      // the original error. The real cause is already logged by the caller; let the connection be closed.
+      SMono.empty
+    } else {
+      SMono.fromCallable(() => ResponseSerializer.serialize(details))
+        .map(Json.stringify)
+        .map(_.getBytes(StandardCharsets.UTF_8))
+        .flatMap(bytes =>
+          SMono.fromPublisher(httpServerResponse.status(details.status)
+            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
+            .header(CONTENT_LENGTH, Integer.toString(bytes.length))
+            .sendByteArray(SMono.just(bytes))
+            .`then`).`then`)
+    }
 }
 
 case class InvalidUnauthenticatedBlobAccessTokenException() extends RuntimeException
@@ -70,7 +89,7 @@ class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: Una
                                                         val blobIdFactory: BlobStoreBlobId.Factory,
                                                         val sessionProvider: SessionProvider,
                                                         val metricFactory: MetricFactory) extends JMAPRoutes {
-  import UnauthenticatedBlobAccessDownloadRoutes.LOGGER
+  import UnauthenticatedBlobAccessDownloadRoutes.{LOGGER, respondDetails}
 
   private val accountIdParam: String = "accountId"
   private val blobIdParam: String = "blobId"
@@ -181,15 +200,4 @@ class UnauthenticatedBlobAccessDownloadRoutes @Inject()(val tokenRepository: Una
       .toList
       .flatMap(_.asScala)
       .headOption
-
-  private def respondDetails(httpServerResponse: HttpServerResponse, details: ProblemDetails): SMono[Unit] =
-    SMono.fromCallable(() => ResponseSerializer.serialize(details))
-      .map(Json.stringify)
-      .map(_.getBytes(StandardCharsets.UTF_8))
-      .flatMap(bytes =>
-        SMono.fromPublisher(httpServerResponse.status(details.status)
-          .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
-          .header(CONTENT_LENGTH, Integer.toString(bytes.length))
-          .sendByteArray(SMono.just(bytes))
-          .`then`).`then`)
 }

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/routes/RespondDetailsTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/routes/RespondDetailsTest.scala
@@ -1,0 +1,77 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.jmap.routes
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import org.apache.james.jmap.core.ProblemDetails
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.{mock, never, verify, when}
+import reactor.core.publisher.Mono
+import reactor.netty.NettyOutbound
+import reactor.netty.http.server.HttpServerResponse
+
+trait RespondDetailsContract {
+  def respondDetails(response: HttpServerResponse, details: ProblemDetails): Unit
+
+  private val details: ProblemDetails = ProblemDetails(status = INTERNAL_SERVER_ERROR, detail = "boom")
+
+  @Test
+  def respondDetailsShouldNotRewriteResponseWhenHeadersAlreadySent(): Unit = {
+    // Reproduces https://github.com/linagora/tmail-backend/issues/2501:
+    // when a download stream fails after the response has been committed, `status()` throws
+    // `IllegalStateException: Status and headers already sent`. `respondDetails` must not attempt
+    // to rewrite the already committed response.
+    val response: HttpServerResponse = mock(classOf[HttpServerResponse])
+    when(response.hasSentHeaders).thenReturn(true)
+    when(response.status(any(classOf[HttpResponseStatus]))).thenThrow(new IllegalStateException("Status and headers already sent"))
+
+    assertThatCode(() => respondDetails(response, details))
+      .doesNotThrowAnyException()
+
+    verify(response, never()).status(any(classOf[HttpResponseStatus]))
+  }
+
+  @Test
+  def respondDetailsShouldWriteErrorResponseWhenHeadersNotSentYet(): Unit = {
+    val response: HttpServerResponse = mock(classOf[HttpServerResponse])
+    val outbound: NettyOutbound = mock(classOf[NettyOutbound])
+    when(response.hasSentHeaders).thenReturn(false)
+    when(response.status(any(classOf[HttpResponseStatus]))).thenReturn(response)
+    when(response.header(any(), anyString())).thenReturn(response)
+    when(response.sendByteArray(any())).thenReturn(outbound)
+    when(outbound.`then`()).thenReturn(Mono.empty())
+
+    respondDetails(response, details)
+
+    verify(response).status(INTERNAL_SERVER_ERROR)
+  }
+}
+
+class DownloadAllRespondDetailsTest extends RespondDetailsContract {
+  override def respondDetails(response: HttpServerResponse, details: ProblemDetails): Unit =
+    DownloadAllRoutes.respondDetails(response, details).block()
+}
+
+class UnauthenticatedBlobAccessRespondDetailsTest extends RespondDetailsContract {
+  override def respondDetails(response: HttpServerResponse, details: ProblemDetails): Unit =
+    UnauthenticatedBlobAccessDownloadRoutes.respondDetails(response, details).block()
+}


### PR DESCRIPTION
Closes #2501

## Problem

The streaming download routes `DownloadAllRoutes` (`/downloadAll/{accountId}/{emailId}`) and `UnauthenticatedBlobAccessDownloadRoutes` (`/unauthenticatedDownload/{accountId}/{blobId}`) commit the HTTP response — status line + headers — as soon as the first body chunk is flushed to the socket. If the reactive stream then fails **mid-body** (a blob failing to load, an I/O error, or, most frequently, the client disconnecting during a large download), the error propagates to the top-level `onErrorResume`, which unconditionally calls `respondDetails(...)` to write a fresh error response.

Since the response is already committed, `HttpServerOperations.status()` throws `IllegalStateException: Status and headers already sent`. This:
- masks the **original** error that actually aborted the stream, and
- surfaces as the reactor-netty `Error finishing response. Closing connection` ERROR that triggered this ticket.

## Fix

Guard `respondDetails` with reactor-netty's `HttpServerResponse.hasSentHeaders()`. Once the response is committed there is nothing we can do — HTTP semantics make it impossible to change a status that is already on the wire — so we simply complete and let the connection be closed. The real cause remains visible via the existing `LOGGER.error("Unexpected error upon download ...", e)` that runs *before* `respondDetails`.

Pre-commit error paths (unauthenticated, forbidden, account-not-found, message-not-found, invalid token, ...) are untouched: `hasSentHeaders()` is `false` there, so they keep returning proper Problem Details responses.

The same shape existed in both streaming routes, so both are fixed identically.

## Answering "is this behaviour tested?"

Yes. `respondDetails` is moved into the companion objects and covered by `RespondDetailsTest` (a shared contract run against both routes):

- `respondDetailsShouldNotRewriteResponseWhenHeadersAlreadySent` — reproduces the ticket: the mocked response reports `hasSentHeaders == true` and its `status()` is stubbed to throw `IllegalStateException: Status and headers already sent`. The test asserts `respondDetails` does **not** throw and never calls `status()`. Without the guard this test fails with the exact exception from the report.
- `respondDetailsShouldWriteErrorResponseWhenHeadersNotSentYet` — asserts the normal pre-commit path still writes the error response (`status()` is invoked).

Note on HTTP semantics (raised in the issue discussion): a mid-stream failure on an already-committed response cannot be reported to the client as an error status — that is inherent to streaming responses. The download is already broken by the underlying failure regardless; this change only removes the misleading secondary exception and the log noise, without altering any client-visible behaviour on the pre-commit paths.

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses during download flows so the app handles already-sent HTTP headers more safely and avoids response-writing failures.
  * Ensured server errors are returned consistently when a download request cannot be completed.

* **Tests**
  * Added coverage for error-response behavior in download-related routes, including cases where headers are already committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->