### PR TITLE
[TMail] ISSUE-2508 Downgrade CalDavCollect parse failures to WARN

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
@@ -46,6 +46,7 @@ import com.linagora.tmail.dav.DavUser;
 import com.linagora.tmail.dav.DavUserProvider;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.data.ParserException;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
@@ -119,6 +120,8 @@ public class CalDavCollect extends GenericMailet {
                         .flatMap(davUser -> synchronizeWithDavServer(json, davUser))
                         .block();
                 }
+            } catch (ParserException e) {
+                LOGGER.warn("Failed to parse calendar in mail {} with recipient {}: malformed iCalendar payload", mail.getName(), recipient, e);
             } catch (Exception e) {
                 LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e);
             }


### PR DESCRIPTION
Closes #2508

## Problem

`CalDavCollect` logged an `ERROR` when ical4j failed to parse an incoming iCalendar payload:

```
net.fortuna.ical4j.data.ParserException: Error at line 13:No enum constant net.fortuna.ical4j.transform.recurrence.Frequency.3DYEARLY
```

`3DYEARLY` is the tell-tale of an undecoded **quoted-printable** payload (`=3D` is the QP escape for `=`), so the original property was `RRULE:FREQ=YEARLY`. This is a malformed / mis-decoded input (client / upstream MIME-decoding fault), not a system fault.

The exception was already caught in `handleCalendarInMail`: the mail keeps flowing and the only effect is that ITIP synchronization for this one calendar is skipped. So the real harm was the `ERROR` log line itself, which tripped a false-positive loki alert.

## Fix

Per maintainer decision on the issue, split the catch so `ParserException` (malformed-payload condition) logs at `WARN`, keeping `ERROR` for genuine system/IO faults such as a failed Dav sync.

---
*Generated automatically*
2436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed calendar invitations.
  * Calendar parsing failures now generate a clear warning instead of being treated as generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->