### PR TITLE
[TMail] ISSUE-2515 Mailing list management (write) webadmin routes

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1948,3 +1948,82 @@ Return codes:
 - `404` The mailing list does not exist
 - `409` Mailing lists are not configured (no `mailingLists.properties` file or no `baseDN`)
 
+=== Managing mailing lists (create, delete, members, owners)
+
+The write routes below let an operator create/delete mailing lists and manage their members and owners. Unlike the
+read routes, they are *not* exposed by default: an operator must opt-in by listing
+`com.linagora.tmail.webadmin.mailinglist.MailingListManagementRoutes` under `additional.routes` in
+`webadmin.properties`. They apply to the default `groupOfNames` schema only (OBM `obmGroup` lists are rejected with
+`409 Conflict`) and require the configured LDAP bind user to hold write ACLs on the lists subtree.
+
+Members and owners are supplied as mail addresses and resolved to the matching user entries (a `userBase` search on the
+LDAP `userIdAttribute`); an address that does not resolve to any user is rejected with `400 Bad Request`.
+
+==== Creating a mailing list
+
+....
+curl -XPUT 'http://ip:port/mailingLists/sales@lists.linagora.com' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "businessCategory": "openList",
+    "members": ["bob@linagora.com", "alice@linagora.com"],
+    "owners": ["alice@linagora.com"]
+  }'
+....
+
+The `members` array is mandatory and must hold at least one address (a `groupOfNames` list cannot be empty).
+`businessCategory` and `owners` are optional. `businessCategory`, when set, must be one of `openList`, `internalList`,
+`memberRestrictedList`, `ownerRestrictedList` or `domainRestrictedList`. The list `cn` is derived from the address
+local-part.
+
+Return codes:
+
+- `204` The mailing list was created
+- `400` Invalid mail address, invalid `businessCategory`, empty `members`, or a member/owner that is not a user
+- `409` The mailing list already exists, the schema is OBM, or mailing lists are not configured
+
+==== Deleting a mailing list
+
+....
+curl -XDELETE 'http://ip:port/mailingLists/sales@lists.linagora.com'
+....
+
+Return codes:
+
+- `204` The mailing list was deleted
+- `400` Invalid mail address
+- `404` The mailing list does not exist
+- `409` The schema is OBM, or mailing lists are not configured
+
+==== Adding or removing a member
+
+....
+curl -XPUT 'http://ip:port/mailingLists/sales@lists.linagora.com/members/bob@linagora.com'
+curl -XDELETE 'http://ip:port/mailingLists/sales@lists.linagora.com/members/bob@linagora.com'
+....
+
+Both operations are idempotent: adding an already present member or removing an absent one answers `204`.
+
+Return codes:
+
+- `204` The member was added/removed
+- `400` Invalid mail address, or the member is not a user
+- `404` The mailing list does not exist
+- `409` Removing the last member (a list cannot be left empty), the schema is OBM, or mailing lists are not configured
+
+==== Adding or removing an owner
+
+....
+curl -XPUT 'http://ip:port/mailingLists/sales@lists.linagora.com/owners/alice@linagora.com'
+curl -XDELETE 'http://ip:port/mailingLists/sales@lists.linagora.com/owners/alice@linagora.com'
+....
+
+Both operations are idempotent.
+
+Return codes:
+
+- `204` The owner was added/removed
+- `400` Invalid mail address, or the owner is not a user
+- `404` The mailing list does not exist
+- `409` The schema is OBM, or mailing lists are not configured
+

--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -1953,11 +1953,17 @@ Return codes:
 The write routes below let an operator create/delete mailing lists and manage their members and owners. Unlike the
 read routes, they are *not* exposed by default: an operator must opt-in by listing
 `com.linagora.tmail.webadmin.mailinglist.MailingListManagementRoutes` under `additional.routes` in
-`webadmin.properties`. They apply to the default `groupOfNames` schema only (OBM `obmGroup` lists are rejected with
-`409 Conflict`) and require the configured LDAP bind user to hold write ACLs on the lists subtree.
+`webadmin.properties`. They require the configured LDAP bind user to hold write ACLs on the lists subtree, and support
+both the default `groupOfNames` schema and the OBM `obmGroup` schema:
 
-Members and owners are supplied as mail addresses and resolved to the matching user entries (a `userBase` search on the
-LDAP `userIdAttribute`); an address that does not resolve to any user is rejected with `400 Bad Request`.
+- For the default `groupOfNames` schema, members and owners are supplied as mail addresses and resolved to the matching
+user entries (a `userBase` search on the LDAP `userIdAttribute`); an address that does not resolve to any user is
+rejected with `400 Bad Request`.
+- For the OBM `obmGroup` schema, members are stored as mail values: an address that resolves to a user is stored as a
+`mailBox`, an unresolved address is stored as an `externalContactEmail` (so external contacts are accepted). The
+`obmGroup` schema has no owner concept, so owner management is rejected with `409 Conflict`. OBM lists are created with a
+minimal set of attributes (a default `gidNumber`, `mailAccess=PERMIT` and the `obmDomain` derived from the list
+address).
 
 ==== Creating a mailing list
 
@@ -1971,16 +1977,16 @@ curl -XPUT 'http://ip:port/mailingLists/sales@lists.linagora.com' \
   }'
 ....
 
-The `members` array is mandatory and must hold at least one address (a `groupOfNames` list cannot be empty).
-`businessCategory` and `owners` are optional. `businessCategory`, when set, must be one of `openList`, `internalList`,
-`memberRestrictedList`, `ownerRestrictedList` or `domainRestrictedList`. The list `cn` is derived from the address
-local-part.
+The `members` array is mandatory and must hold at least one address. `businessCategory` and `owners` are optional.
+`businessCategory`, when set, must be one of `openList`, `internalList`, `memberRestrictedList`, `ownerRestrictedList`
+or `domainRestrictedList`. The list `cn` is derived from the address local-part. For OBM lists, the `owners` field is
+ignored (the `obmGroup` schema has no owner concept).
 
 Return codes:
 
 - `204` The mailing list was created
-- `400` Invalid mail address, invalid `businessCategory`, empty `members`, or a member/owner that is not a user
-- `409` The mailing list already exists, the schema is OBM, or mailing lists are not configured
+- `400` Invalid mail address, invalid `businessCategory`, empty `members`, or (for `groupOfNames`) a member/owner that is not a user
+- `409` The mailing list already exists, or mailing lists are not configured
 
 ==== Deleting a mailing list
 
@@ -1993,7 +1999,7 @@ Return codes:
 - `204` The mailing list was deleted
 - `400` Invalid mail address
 - `404` The mailing list does not exist
-- `409` The schema is OBM, or mailing lists are not configured
+- `409` Mailing lists are not configured
 
 ==== Adding or removing a member
 
@@ -2004,12 +2010,15 @@ curl -XDELETE 'http://ip:port/mailingLists/sales@lists.linagora.com/members/bob@
 
 Both operations are idempotent: adding an already present member or removing an absent one answers `204`.
 
+For OBM lists, an added member that does not resolve to a user is accepted and stored as an `externalContactEmail`; a
+removed member is stripped from both the `mailBox` and `externalContactEmail` attributes.
+
 Return codes:
 
 - `204` The member was added/removed
-- `400` Invalid mail address, or the member is not a user
+- `400` Invalid mail address, or (for `groupOfNames`) the member is not a user
 - `404` The mailing list does not exist
-- `409` Removing the last member (a list cannot be left empty), the schema is OBM, or mailing lists are not configured
+- `409` Removing the last member of a `groupOfNames` list (it cannot be left empty), or mailing lists are not configured
 
 ==== Adding or removing an owner
 
@@ -2018,7 +2027,8 @@ curl -XPUT 'http://ip:port/mailingLists/sales@lists.linagora.com/owners/alice@li
 curl -XDELETE 'http://ip:port/mailingLists/sales@lists.linagora.com/owners/alice@linagora.com'
 ....
 
-Both operations are idempotent.
+Both operations are idempotent. Owner management is only available for the default `groupOfNames` schema; the OBM
+`obmGroup` schema has no owner concept and rejects these routes with `409 Conflict`.
 
 Return codes:
 

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
@@ -18,6 +18,7 @@
 
 package com.linagora.tmail.webadmin.mailinglist;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -57,14 +58,24 @@ import com.unboundid.ldap.sdk.SearchScope;
  * the OBM schema (members resolved from the {@code mailBox} / {@code externalContactEmail} mail attributes) are
  * supported for reads, depending on the {@code obm.compatibility} flag of the {@link MailingListConfiguration}.</p>
  *
- * <p>Write operations (create/delete a list, add/remove members and owners) are only implemented for the default
- * groupOfNames schema; they reject OBM lists with a {@link MailingListManagementException.WriteNotSupported}. They rely
- * on single valued LDAP {@code MODIFY} to remain idempotent and require the configured bind user to hold write ACLs on
- * the lists subtree.</p>
+ * <p>Write operations (create/delete a list, add/remove members and owners) are supported for both schemas:</p>
+ * <ul>
+ *     <li>For the default groupOfNames schema, members and owners are stored as {@code member} / {@code owner} DN
+ *     attributes; an address that does not resolve to a user is rejected.</li>
+ *     <li>For the OBM schema, members are stored as mail values: an address resolving to a user goes to
+ *     {@code mailBox}, an unresolved address goes to {@code externalContactEmail}. The {@code obmGroup} schema has no
+ *     owner concept, so owner management is rejected with a {@link MailingListManagementException.WriteNotSupported}.
+ *     OBM lists are created with a minimal set of attributes ({@code mailAccess=PERMIT}, a default {@code gidNumber}
+ *     and the {@code obmDomain} derived from the list address).</li>
+ * </ul>
+ *
+ * <p>They rely on single valued LDAP {@code MODIFY} to remain idempotent and require the configured bind user to hold
+ * write ACLs on the lists subtree.</p>
  */
 public class LdapMailingListRepository implements MailingListRepository {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapMailingListRepository.class);
     private static final String OBM_GROUP_OBJECT_CLASS = "obmGroup";
+    private static final String POSIX_GROUP_OBJECT_CLASS = "posixGroup";
     private static final String GROUP_OF_NAMES_OBJECT_CLASS = "groupofnames";
     private static final String OBJECT_CLASS_ATTRIBUTE = "objectClass";
     private static final String CN_ATTRIBUTE = "cn";
@@ -73,6 +84,11 @@ public class LdapMailingListRepository implements MailingListRepository {
     private static final String OWNER_ATTRIBUTE = "owner";
     private static final String MAIL_BOX_ATTRIBUTE = "mailBox";
     private static final String EXTERNAL_CONTACT_EMAIL_ATTRIBUTE = "externalContactEmail";
+    private static final String GID_NUMBER_ATTRIBUTE = "gidNumber";
+    private static final String OBM_DOMAIN_ATTRIBUTE = "obmDomain";
+    private static final String MAIL_ACCESS_ATTRIBUTE = "mailAccess";
+    private static final String DEFAULT_GID_NUMBER = "1000";
+    private static final String MAIL_ACCESS_PERMIT = "PERMIT";
 
     private final LDAPConnectionPool ldapConnectionPool;
     private final LdapRepositoryConfiguration ldapConfiguration;
@@ -190,7 +206,14 @@ public class LdapMailingListRepository implements MailingListRepository {
 
     @Override
     public void create(MailingList mailingList) {
-        assertNotObm("Creating a mailing list");
+        if (obmCompatibility) {
+            createObmList(mailingList);
+        } else {
+            createGroupOfNamesList(mailingList);
+        }
+    }
+
+    private void createGroupOfNamesList(MailingList mailingList) {
         MailAddress address = mailingList.address();
         if (resolveListDN(address).isPresent()) {
             throw new MailingListManagementException.AlreadyExists(address);
@@ -210,6 +233,51 @@ public class LdapMailingListRepository implements MailingListRepository {
             entry.addAttribute(OWNER_ATTRIBUTE, resolveUserDNs(mailingList.owners()));
         }
 
+        addEntry(entry, address);
+    }
+
+    /**
+     * Creates an OBM {@code obmGroup} list with a minimal set of attributes: a default {@code gidNumber}, a
+     * {@code mailAccess} of {@code PERMIT} and the {@code obmDomain} derived from the list address. Members are stored
+     * as mail values rather than DNs: an address resolving to a user goes to {@code mailBox}, an unresolved address to
+     * {@code externalContactEmail}. Owners are ignored: the {@code obmGroup} schema has no owner concept.
+     */
+    private void createObmList(MailingList mailingList) {
+        MailAddress address = mailingList.address();
+        if (resolveListDN(address).isPresent()) {
+            throw new MailingListManagementException.AlreadyExists(address);
+        }
+
+        Entry entry = new Entry(newListDN(address));
+        entry.addAttribute(OBJECT_CLASS_ATTRIBUTE, OBM_GROUP_OBJECT_CLASS, POSIX_GROUP_OBJECT_CLASS);
+        entry.addAttribute(CN_ATTRIBUTE, address.getLocalPart());
+        entry.addAttribute(GID_NUMBER_ATTRIBUTE, DEFAULT_GID_NUMBER);
+        entry.addAttribute(MAIL_ACCESS_ATTRIBUTE, MAIL_ACCESS_PERMIT);
+        entry.addAttribute(OBM_DOMAIN_ATTRIBUTE, address.getDomain().asString());
+        entry.addAttribute(mailAttributeForGroups, address.asString());
+        mailingList.businessCategory()
+            .ifPresent(category -> entry.addAttribute(BUSINESS_CATEGORY_ATTRIBUTE, category));
+
+        List<String> internalMembers = new ArrayList<>();
+        List<String> externalMembers = new ArrayList<>();
+        mailingList.members().forEach(member -> {
+            if (isInternalUser(member)) {
+                internalMembers.add(member.asString());
+            } else {
+                externalMembers.add(member.asString());
+            }
+        });
+        if (!internalMembers.isEmpty()) {
+            entry.addAttribute(MAIL_BOX_ATTRIBUTE, internalMembers.toArray(String[]::new));
+        }
+        if (!externalMembers.isEmpty()) {
+            entry.addAttribute(EXTERNAL_CONTACT_EMAIL_ATTRIBUTE, externalMembers.toArray(String[]::new));
+        }
+
+        addEntry(entry, address);
+    }
+
+    private void addEntry(Entry entry, MailAddress address) {
         try {
             ldapConnectionPool.add(entry);
         } catch (LDAPException e) {
@@ -223,7 +291,6 @@ public class LdapMailingListRepository implements MailingListRepository {
 
     @Override
     public void delete(MailAddress address) {
-        assertNotObm("Deleting a mailing list");
         String listDN = resolveListDN(address)
             .orElseThrow(() -> new MailingListManagementException.NotFound(address));
         try {
@@ -239,22 +306,78 @@ public class LdapMailingListRepository implements MailingListRepository {
 
     @Override
     public void addMember(MailAddress listAddress, MailAddress member) {
-        modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.ADD, "addMember");
+        if (obmCompatibility) {
+            addObmMember(listAddress, member);
+        } else {
+            modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.ADD, "addMember");
+        }
     }
 
     @Override
     public void removeMember(MailAddress listAddress, MailAddress member) {
-        modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.DELETE, "removeMember");
+        if (obmCompatibility) {
+            removeObmMember(listAddress, member);
+        } else {
+            modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.DELETE, "removeMember");
+        }
     }
 
     @Override
     public void addOwner(MailAddress listAddress, MailAddress owner) {
+        assertOwnerSupported();
         modifyMembership(listAddress, owner, OWNER_ATTRIBUTE, ModificationType.ADD, "addOwner");
     }
 
     @Override
     public void removeOwner(MailAddress listAddress, MailAddress owner) {
+        assertOwnerSupported();
         modifyMembership(listAddress, owner, OWNER_ATTRIBUTE, ModificationType.DELETE, "removeOwner");
+    }
+
+    /**
+     * Adds a member to an OBM list, storing it as a {@code mailBox} value when it resolves to a user and as an
+     * {@code externalContactEmail} value otherwise. The single valued LDAP {@code MODIFY} stays idempotent.
+     */
+    private void addObmMember(MailAddress listAddress, MailAddress member) {
+        String listDN = resolveListDN(listAddress)
+            .orElseThrow(() -> new MailingListManagementException.NotFound(listAddress));
+        String attribute = isInternalUser(member) ? MAIL_BOX_ATTRIBUTE : EXTERNAL_CONTACT_EMAIL_ATTRIBUTE;
+        modifyMailValue(listDN, attribute, member.asString(), ModificationType.ADD);
+        auditTrail("addMember", listAddress, ImmutableMap.of(MEMBER_ATTRIBUTE, member.asString()));
+    }
+
+    /**
+     * Removes a member from an OBM list. As the address may have been stored either as an internal {@code mailBox} or
+     * an external contact, it is stripped from both attributes; each removal is idempotent.
+     */
+    private void removeObmMember(MailAddress listAddress, MailAddress member) {
+        String listDN = resolveListDN(listAddress)
+            .orElseThrow(() -> new MailingListManagementException.NotFound(listAddress));
+        modifyMailValue(listDN, MAIL_BOX_ATTRIBUTE, member.asString(), ModificationType.DELETE);
+        modifyMailValue(listDN, EXTERNAL_CONTACT_EMAIL_ATTRIBUTE, member.asString(), ModificationType.DELETE);
+        auditTrail("removeMember", listAddress, ImmutableMap.of(MEMBER_ATTRIBUTE, member.asString()));
+    }
+
+    private void modifyMailValue(String listDN, String attribute, String value, ModificationType type) {
+        try {
+            ldapConnectionPool.modify(listDN, new Modification(type, attribute, value));
+        } catch (LDAPException e) {
+            ResultCode resultCode = e.getResultCode();
+            if (type == ModificationType.ADD && resultCode.equals(ResultCode.ATTRIBUTE_OR_VALUE_EXISTS)) {
+                return;
+            }
+            if (type == ModificationType.DELETE && resultCode.equals(ResultCode.NO_SUCH_ATTRIBUTE)) {
+                return;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertOwnerSupported() {
+        if (obmCompatibility) {
+            throw new MailingListManagementException.WriteNotSupported(
+                "Owner management is not supported for OBM (obmGroup) mailing lists");
+        }
     }
 
     /**
@@ -264,7 +387,6 @@ public class LdapMailingListRepository implements MailingListRepository {
      */
     private void modifyMembership(MailAddress listAddress, MailAddress user, String attribute,
                                   ModificationType type, String action) {
-        assertNotObm("Managing " + attribute + "s");
         String listDN = resolveListDN(listAddress)
             .orElseThrow(() -> new MailingListManagementException.NotFound(listAddress));
         String userDN = resolveUserDN(user);
@@ -286,13 +408,6 @@ public class LdapMailingListRepository implements MailingListRepository {
         auditTrail(action, listAddress, ImmutableMap.of(attribute, user.asString()));
     }
 
-    private void assertNotObm(String operation) {
-        if (obmCompatibility) {
-            throw new MailingListManagementException.WriteNotSupported(
-                operation + " is not supported for OBM (obmGroup) mailing lists");
-        }
-    }
-
     private String newListDN(MailAddress address) {
         return new RDN(CN_ATTRIBUTE, address.getLocalPart()) + "," + baseDN;
     }
@@ -309,6 +424,23 @@ public class LdapMailingListRepository implements MailingListRepository {
         return addresses.stream()
             .map(this::resolveUserDN)
             .toArray(String[]::new);
+    }
+
+    /**
+     * Tells whether an address resolves to a user entry in the configured {@code userBase}. Used by the OBM writes to
+     * decide between storing an address as an internal {@code mailBox} or an external {@code externalContactEmail}.
+     */
+    private boolean isInternalUser(MailAddress user) {
+        Filter filter = Filter.createEqualityFilter(ldapConfiguration.getUserIdAttribute(), user.asString());
+        try {
+            return !ldapConnectionPool.search(ldapConfiguration.getUserBase(), SearchScope.SUB, filter)
+                .getSearchEntries().isEmpty();
+        } catch (LDAPException e) {
+            if (e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
+                return false;
+            }
+            throw new RuntimeException(e);
+        }
     }
 
     private String resolveUserDN(MailAddress user) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
@@ -65,8 +65,9 @@ import com.unboundid.ldap.sdk.SearchScope;
  *     <li>For the OBM schema, members are stored as mail values: an address resolving to a user goes to
  *     {@code mailBox}, an unresolved address goes to {@code externalContactEmail}. The {@code obmGroup} schema has no
  *     owner concept, so owner management is rejected with a {@link MailingListManagementException.WriteNotSupported}.
- *     OBM lists are created with a minimal set of attributes ({@code mailAccess=PERMIT}, a default {@code gidNumber}
- *     and the {@code obmDomain} derived from the list address).</li>
+ *     OBM lists are created with a minimal set of attributes (a {@code mailAccess} derived from the requested
+ *     {@code businessCategory}, a default {@code gidNumber} and the {@code obmDomain} derived from the list
+ *     address).</li>
  * </ul>
  *
  * <p>They rely on single valued LDAP {@code MODIFY} to remain idempotent and require the configured bind user to hold
@@ -89,6 +90,9 @@ public class LdapMailingListRepository implements MailingListRepository {
     private static final String MAIL_ACCESS_ATTRIBUTE = "mailAccess";
     private static final String DEFAULT_GID_NUMBER = "1000";
     private static final String MAIL_ACCESS_PERMIT = "PERMIT";
+    private static final String MAIL_ACCESS_REJECT = "REJECT";
+    private static final String OPEN_LIST_CATEGORY = "openlist";
+    private static final String MEMBER_RESTRICTED_LIST_CATEGORY = "memberrestrictedlist";
 
     private final LDAPConnectionPool ldapConnectionPool;
     private final LdapRepositoryConfiguration ldapConfiguration;
@@ -238,21 +242,31 @@ public class LdapMailingListRepository implements MailingListRepository {
 
     /**
      * Creates an OBM {@code obmGroup} list with a minimal set of attributes: a default {@code gidNumber}, a
-     * {@code mailAccess} of {@code PERMIT} and the {@code obmDomain} derived from the list address. Members are stored
-     * as mail values rather than DNs: an address resolving to a user goes to {@code mailBox}, an unresolved address to
-     * {@code externalContactEmail}. Owners are ignored: the {@code obmGroup} schema has no owner concept.
+     * {@code mailAccess} derived from the requested {@code businessCategory} and the {@code obmDomain} derived from the
+     * list address. Members are stored as mail values rather than DNs: an address resolving to a user goes to
+     * {@code mailBox}, an unresolved address to {@code externalContactEmail}. Owners are ignored: the {@code obmGroup}
+     * schema has no owner concept.
+     *
+     * <p>The OBM mailet authorizes senders solely from {@code mailAccess} (see {@code OBMLDAPMailingList}), so the
+     * {@code businessCategory} is mapped to it: {@code openList} (or no category) yields {@code PERMIT} (public), while
+     * {@code memberRestrictedList} yields {@code REJECT} (only members may post). The remaining categories
+     * ({@code internalList}, {@code ownerRestrictedList}, {@code domainRestrictedList}) have no OBM equivalent and are
+     * rejected rather than silently created as public.</p>
      */
     private void createObmList(MailingList mailingList) {
         MailAddress address = mailingList.address();
         if (resolveListDN(address).isPresent()) {
             throw new MailingListManagementException.AlreadyExists(address);
         }
+        String mailAccess = mailingList.businessCategory()
+            .map(this::toObmMailAccess)
+            .orElse(MAIL_ACCESS_PERMIT);
 
         Entry entry = new Entry(newListDN(address));
         entry.addAttribute(OBJECT_CLASS_ATTRIBUTE, OBM_GROUP_OBJECT_CLASS, POSIX_GROUP_OBJECT_CLASS);
         entry.addAttribute(CN_ATTRIBUTE, address.getLocalPart());
         entry.addAttribute(GID_NUMBER_ATTRIBUTE, DEFAULT_GID_NUMBER);
-        entry.addAttribute(MAIL_ACCESS_ATTRIBUTE, MAIL_ACCESS_PERMIT);
+        entry.addAttribute(MAIL_ACCESS_ATTRIBUTE, mailAccess);
         entry.addAttribute(OBM_DOMAIN_ATTRIBUTE, address.getDomain().asString());
         entry.addAttribute(mailAttributeForGroups, address.asString());
         mailingList.businessCategory()
@@ -408,8 +422,30 @@ public class LdapMailingListRepository implements MailingListRepository {
         auditTrail(action, listAddress, ImmutableMap.of(attribute, user.asString()));
     }
 
+    /**
+     * Maps a webadmin {@code businessCategory} to an OBM {@code mailAccess} value. Only the two categories that OBM can
+     * represent are supported; the others are rejected so that a restricted list is never silently created as public.
+     */
+    private String toObmMailAccess(String businessCategory) {
+        return switch (businessCategory.toLowerCase().trim()) {
+            case OPEN_LIST_CATEGORY -> MAIL_ACCESS_PERMIT;
+            case MEMBER_RESTRICTED_LIST_CATEGORY -> MAIL_ACCESS_REJECT;
+            default -> throw new MailingListManagementException.WriteNotSupported(
+                "businessCategory '" + businessCategory + "' is not supported for OBM (obmGroup) mailing lists; "
+                    + "only openList and memberRestrictedList are supported");
+        };
+    }
+
+    /**
+     * Builds the DN of a new list. The RDN combines {@code cn} (the local part, keeping the group naming) with the mail
+     * attribute (the full address) so that two lists sharing a local part in different domains map to distinct DNs
+     * under the same {@code baseDN}. Lookups still rely on the mail attribute, so this only affects entry creation.
+     */
     private String newListDN(MailAddress address) {
-        return new RDN(CN_ATTRIBUTE, address.getLocalPart()) + "," + baseDN;
+        RDN rdn = new RDN(
+            new String[]{CN_ATTRIBUTE, mailAttributeForGroups},
+            new String[]{address.getLocalPart(), address.asString()});
+        return rdn + "," + baseDN;
     }
 
     private Optional<String> resolveListDN(MailAddress address) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/LdapMailingListRepository.java
@@ -21,6 +21,7 @@ package com.linagora.tmail.webadmin.mailinglist;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -29,31 +30,44 @@ import java.util.stream.Stream;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.james.util.AuditTrail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPConnectionPool;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.Modification;
+import com.unboundid.ldap.sdk.ModificationType;
+import com.unboundid.ldap.sdk.RDN;
 import com.unboundid.ldap.sdk.ResultCode;
 import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
 
 /**
- * <p>Read only view of the mailing lists stored in LDAP, backing the {@code /mailingLists} webadmin routes.</p>
+ * <p>View of the mailing lists stored in LDAP, backing the {@code /mailingLists} webadmin routes.</p>
  *
  * <p>Both the default groupOfNames schema (members resolved from the {@code member} / {@code owner} DN attributes) and
  * the OBM schema (members resolved from the {@code mailBox} / {@code externalContactEmail} mail attributes) are
- * supported, depending on the {@code obm.compatibility} flag of the {@link MailingListConfiguration}.</p>
+ * supported for reads, depending on the {@code obm.compatibility} flag of the {@link MailingListConfiguration}.</p>
+ *
+ * <p>Write operations (create/delete a list, add/remove members and owners) are only implemented for the default
+ * groupOfNames schema; they reject OBM lists with a {@link MailingListManagementException.WriteNotSupported}. They rely
+ * on single valued LDAP {@code MODIFY} to remain idempotent and require the configured bind user to hold write ACLs on
+ * the lists subtree.</p>
  */
 public class LdapMailingListRepository implements MailingListRepository {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapMailingListRepository.class);
     private static final String OBM_GROUP_OBJECT_CLASS = "obmGroup";
     private static final String GROUP_OF_NAMES_OBJECT_CLASS = "groupofnames";
+    private static final String OBJECT_CLASS_ATTRIBUTE = "objectClass";
+    private static final String CN_ATTRIBUTE = "cn";
     private static final String BUSINESS_CATEGORY_ATTRIBUTE = "businessCategory";
     private static final String MEMBER_ATTRIBUTE = "member";
     private static final String OWNER_ATTRIBUTE = "owner";
@@ -172,6 +186,161 @@ public class LdapMailingListRepository implements MailingListRepository {
         } catch (LDAPException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void create(MailingList mailingList) {
+        assertNotObm("Creating a mailing list");
+        MailAddress address = mailingList.address();
+        if (resolveListDN(address).isPresent()) {
+            throw new MailingListManagementException.AlreadyExists(address);
+        }
+        if (mailingList.members().isEmpty()) {
+            throw new MailingListManagementException.EmptyList(address);
+        }
+
+        Entry entry = new Entry(newListDN(address));
+        entry.addAttribute(OBJECT_CLASS_ATTRIBUTE, GROUP_OF_NAMES_OBJECT_CLASS);
+        entry.addAttribute(CN_ATTRIBUTE, address.getLocalPart());
+        entry.addAttribute(mailAttributeForGroups, address.asString());
+        mailingList.businessCategory()
+            .ifPresent(category -> entry.addAttribute(BUSINESS_CATEGORY_ATTRIBUTE, category));
+        entry.addAttribute(MEMBER_ATTRIBUTE, resolveUserDNs(mailingList.members()));
+        if (!mailingList.owners().isEmpty()) {
+            entry.addAttribute(OWNER_ATTRIBUTE, resolveUserDNs(mailingList.owners()));
+        }
+
+        try {
+            ldapConnectionPool.add(entry);
+        } catch (LDAPException e) {
+            if (e.getResultCode().equals(ResultCode.ENTRY_ALREADY_EXISTS)) {
+                throw new MailingListManagementException.AlreadyExists(address);
+            }
+            throw new RuntimeException(e);
+        }
+        auditTrail("createMailingList", address, ImmutableMap.of());
+    }
+
+    @Override
+    public void delete(MailAddress address) {
+        assertNotObm("Deleting a mailing list");
+        String listDN = resolveListDN(address)
+            .orElseThrow(() -> new MailingListManagementException.NotFound(address));
+        try {
+            ldapConnectionPool.delete(listDN);
+        } catch (LDAPException e) {
+            if (e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
+                throw new MailingListManagementException.NotFound(address);
+            }
+            throw new RuntimeException(e);
+        }
+        auditTrail("deleteMailingList", address, ImmutableMap.of());
+    }
+
+    @Override
+    public void addMember(MailAddress listAddress, MailAddress member) {
+        modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.ADD, "addMember");
+    }
+
+    @Override
+    public void removeMember(MailAddress listAddress, MailAddress member) {
+        modifyMembership(listAddress, member, MEMBER_ATTRIBUTE, ModificationType.DELETE, "removeMember");
+    }
+
+    @Override
+    public void addOwner(MailAddress listAddress, MailAddress owner) {
+        modifyMembership(listAddress, owner, OWNER_ATTRIBUTE, ModificationType.ADD, "addOwner");
+    }
+
+    @Override
+    public void removeOwner(MailAddress listAddress, MailAddress owner) {
+        modifyMembership(listAddress, owner, OWNER_ATTRIBUTE, ModificationType.DELETE, "removeOwner");
+    }
+
+    /**
+     * Adds or removes a single {@code member} / {@code owner} DN value on a list, relying on LDAP {@code MODIFY} of a
+     * single attribute value to stay naturally atomic and idempotent: adding an already present value or removing an
+     * absent one is a no-op success rather than an error.
+     */
+    private void modifyMembership(MailAddress listAddress, MailAddress user, String attribute,
+                                  ModificationType type, String action) {
+        assertNotObm("Managing " + attribute + "s");
+        String listDN = resolveListDN(listAddress)
+            .orElseThrow(() -> new MailingListManagementException.NotFound(listAddress));
+        String userDN = resolveUserDN(user);
+        try {
+            ldapConnectionPool.modify(listDN, new Modification(type, attribute, userDN));
+        } catch (LDAPException e) {
+            ResultCode resultCode = e.getResultCode();
+            if (type == ModificationType.ADD && resultCode.equals(ResultCode.ATTRIBUTE_OR_VALUE_EXISTS)) {
+                return;
+            }
+            if (type == ModificationType.DELETE && resultCode.equals(ResultCode.NO_SUCH_ATTRIBUTE)) {
+                return;
+            }
+            if (resultCode.equals(ResultCode.OBJECT_CLASS_VIOLATION)) {
+                throw new MailingListManagementException.EmptyList(listAddress);
+            }
+            throw new RuntimeException(e);
+        }
+        auditTrail(action, listAddress, ImmutableMap.of(attribute, user.asString()));
+    }
+
+    private void assertNotObm(String operation) {
+        if (obmCompatibility) {
+            throw new MailingListManagementException.WriteNotSupported(
+                operation + " is not supported for OBM (obmGroup) mailing lists");
+        }
+    }
+
+    private String newListDN(MailAddress address) {
+        return new RDN(CN_ATTRIBUTE, address.getLocalPart()) + "," + baseDN;
+    }
+
+    private Optional<String> resolveListDN(MailAddress address) {
+        Filter filter = Filter.createANDFilter(objectClassFilter,
+            Filter.createEqualityFilter(mailAttributeForGroups, address.asString()));
+        return search(filter, mailAttributeForGroups).stream()
+            .findFirst()
+            .map(SearchResultEntry::getDN);
+    }
+
+    private String[] resolveUserDNs(List<MailAddress> addresses) {
+        return addresses.stream()
+            .map(this::resolveUserDN)
+            .toArray(String[]::new);
+    }
+
+    private String resolveUserDN(MailAddress user) {
+        Filter filter = Filter.createEqualityFilter(ldapConfiguration.getUserIdAttribute(), user.asString());
+        List<SearchResultEntry> entries;
+        try {
+            entries = ldapConnectionPool.search(ldapConfiguration.getUserBase(), SearchScope.SUB, filter)
+                .getSearchEntries();
+        } catch (LDAPException e) {
+            if (e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
+                throw new MailingListManagementException.UnknownMember(user);
+            }
+            throw new RuntimeException(e);
+        }
+        if (entries.isEmpty()) {
+            throw new MailingListManagementException.UnknownMember(user);
+        }
+        if (entries.size() > 1) {
+            LOGGER.warn("The address {} resolves to several LDAP entries, picking the first one", user.asString());
+        }
+        return entries.get(0).getDN();
+    }
+
+    private void auditTrail(String action, MailAddress listAddress, Map<String, String> extraParameters) {
+        AuditTrail.entry()
+            .protocol("webadmin")
+            .action(action)
+            .parameters(() -> ImmutableMap.<String, String>builder()
+                .put("listAddress", listAddress.asString())
+                .putAll(extraParameters)
+                .build())
+            .log("Mailing list management operation.");
     }
 
     private List<SearchResultEntry> search(Filter filter, String... attributes) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementException.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementException.java
@@ -53,8 +53,8 @@ public abstract class MailingListManagementException extends RuntimeException {
     }
 
     /**
-     * The requested write is not supported for this LDAP schema (typically owner management, or any write against an
-     * OBM {@code obmGroup} list). Translated to a {@code 409 Conflict}.
+     * The requested write is not supported for this LDAP schema (owner management against an OBM {@code obmGroup}
+     * list, which has no owner concept). Translated to a {@code 409 Conflict}.
      */
     public static class WriteNotSupported extends MailingListManagementException {
         public WriteNotSupported(String message) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementException.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementException.java
@@ -1,0 +1,78 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import org.apache.james.core.MailAddress;
+
+/**
+ * Base class for the failures the mailing list management (write) routes can surface. Each subclass maps to a
+ * dedicated HTTP status in {@link MailingListManagementRoutes}, keeping the repository layer free of HTTP concerns.
+ */
+public abstract class MailingListManagementException extends RuntimeException {
+    /**
+     * The targeted mailing list already exists. Translated to a {@code 409 Conflict}.
+     */
+    public static class AlreadyExists extends MailingListManagementException {
+        public AlreadyExists(MailAddress address) {
+            super(String.format("The mailing list '%s' already exists", address.asString()));
+        }
+    }
+
+    /**
+     * The targeted mailing list does not exist. Translated to a {@code 404 Not Found}.
+     */
+    public static class NotFound extends MailingListManagementException {
+        public NotFound(MailAddress address) {
+            super(String.format("The mailing list '%s' does not exist", address.asString()));
+        }
+    }
+
+    /**
+     * A member/owner address does not resolve to any user entry. Translated to a {@code 400 Bad Request}.
+     */
+    public static class UnknownMember extends MailingListManagementException {
+        public UnknownMember(MailAddress address) {
+            super(String.format("The address '%s' does not resolve to any user", address.asString()));
+        }
+    }
+
+    /**
+     * The requested write is not supported for this LDAP schema (typically owner management, or any write against an
+     * OBM {@code obmGroup} list). Translated to a {@code 409 Conflict}.
+     */
+    public static class WriteNotSupported extends MailingListManagementException {
+        public WriteNotSupported(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * The write would leave a {@code groupOfNames} list without any member, which the schema forbids. Translated to a
+     * {@code 409 Conflict}.
+     */
+    public static class EmptyList extends MailingListManagementException {
+        public EmptyList(MailAddress address) {
+            super(String.format("A mailing list cannot be left without any member (list '%s')", address.asString()));
+        }
+    }
+
+    protected MailingListManagementException(String message) {
+        super(message);
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutes.java
@@ -1,0 +1,212 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
+import org.apache.james.webadmin.utils.JsonExtractException;
+import org.apache.james.webadmin.utils.JsonExtractor;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.apache.james.webadmin.utils.Responses;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+/**
+ * <p>Write routes for managing LDAP mailing lists: create/delete a list and add/remove members and owners.</p>
+ *
+ * <p>Unlike the read only {@link MailingListRoutes}, this class is <b>not</b> registered in the {@code Multibinder<Routes>}.
+ * It is only exposed when an operator lists its fully qualified class name under {@code additional.routes} in
+ * {@code webadmin.properties}, which gives the opt-in the issue asks for while the read routes stay always on. It
+ * requires the configured LDAP bind user to hold write ACLs on the lists subtree.</p>
+ */
+public class MailingListManagementRoutes implements Routes {
+    private static final String ADDRESS_PARAM = ":address";
+    private static final String MEMBER_PARAM = ":memberAddress";
+    private static final String OWNER_PARAM = ":ownerAddress";
+    private static final String SPECIFIC_LIST_PATH = MailingListRoutes.BASE_PATH + SEPARATOR + ADDRESS_PARAM;
+    private static final String MEMBER_PATH = SPECIFIC_LIST_PATH + SEPARATOR + "members" + SEPARATOR + MEMBER_PARAM;
+    private static final String OWNER_PATH = SPECIFIC_LIST_PATH + SEPARATOR + "owners" + SEPARATOR + OWNER_PARAM;
+    private static final Set<String> VALID_BUSINESS_CATEGORIES = ImmutableSet.of(
+        "openlist", "internallist", "memberrestrictedlist", "ownerrestrictedlist", "domainrestrictedlist");
+
+    public record MailingListCreationRequest(String businessCategory, List<String> members, List<String> owners) {
+    }
+
+    private final MailingListRepository mailingListRepository;
+    private final JsonTransformer jsonTransformer;
+    private final JsonExtractor<MailingListCreationRequest> jsonExtractor;
+
+    @Inject
+    public MailingListManagementRoutes(MailingListRepository mailingListRepository, JsonTransformer jsonTransformer) {
+        this.mailingListRepository = mailingListRepository;
+        this.jsonTransformer = jsonTransformer;
+        this.jsonExtractor = new JsonExtractor<>(MailingListCreationRequest.class);
+    }
+
+    @Override
+    public String getBasePath() {
+        return MailingListRoutes.BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.put(SPECIFIC_LIST_PATH, this::createMailingList, jsonTransformer);
+        service.delete(SPECIFIC_LIST_PATH, this::deleteMailingList, jsonTransformer);
+        service.put(MEMBER_PATH, this::addMember, jsonTransformer);
+        service.delete(MEMBER_PATH, this::removeMember, jsonTransformer);
+        service.put(OWNER_PATH, this::addOwner, jsonTransformer);
+        service.delete(OWNER_PATH, this::removeOwner, jsonTransformer);
+    }
+
+    private String createMailingList(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        MailingListCreationRequest creationRequest = parseBody(request);
+        Optional<String> businessCategory = Optional.ofNullable(creationRequest.businessCategory())
+            .map(String::trim)
+            .filter(value -> !value.isEmpty());
+        businessCategory.ifPresent(this::validateBusinessCategory);
+        List<MailAddress> members = parseAddresses(creationRequest.members());
+        if (members.isEmpty()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorType.INVALID_ARGUMENT)
+                .message("A mailing list must be created with at least one member")
+                .haltError();
+        }
+        MailingList mailingList = new MailingList(address, businessCategory, members,
+            parseAddresses(creationRequest.owners()));
+        return execute(response, () -> mailingListRepository.create(mailingList));
+    }
+
+    private String deleteMailingList(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        return execute(response, () -> mailingListRepository.delete(address));
+    }
+
+    private String addMember(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        MailAddress member = parseAddress(request.params(MEMBER_PARAM));
+        return execute(response, () -> mailingListRepository.addMember(address, member));
+    }
+
+    private String removeMember(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        MailAddress member = parseAddress(request.params(MEMBER_PARAM));
+        return execute(response, () -> mailingListRepository.removeMember(address, member));
+    }
+
+    private String addOwner(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        MailAddress owner = parseAddress(request.params(OWNER_PARAM));
+        return execute(response, () -> mailingListRepository.addOwner(address, owner));
+    }
+
+    private String removeOwner(Request request, Response response) {
+        MailAddress address = parseAddress(request.params(ADDRESS_PARAM));
+        MailAddress owner = parseAddress(request.params(OWNER_PARAM));
+        return execute(response, () -> mailingListRepository.removeOwner(address, owner));
+    }
+
+    private String execute(Response response, Runnable action) {
+        try {
+            action.run();
+            return Responses.returnNoContent(response);
+        } catch (MailingListsNotConfiguredException e) {
+            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
+        } catch (MailingListManagementException.AlreadyExists e) {
+            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
+        } catch (MailingListManagementException.NotFound e) {
+            throw halt(HttpStatus.NOT_FOUND_404, ErrorType.NOT_FOUND, e);
+        } catch (MailingListManagementException.UnknownMember e) {
+            throw halt(HttpStatus.BAD_REQUEST_400, ErrorType.INVALID_ARGUMENT, e);
+        } catch (MailingListManagementException e) {
+            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
+        }
+    }
+
+    private MailingListCreationRequest parseBody(Request request) {
+        try {
+            return jsonExtractor.parse(request.body());
+        } catch (JsonExtractException e) {
+            throw halt(HttpStatus.BAD_REQUEST_400, ErrorType.INVALID_ARGUMENT, e);
+        }
+    }
+
+    private void validateBusinessCategory(String businessCategory) {
+        if (!VALID_BUSINESS_CATEGORIES.contains(businessCategory.toLowerCase())) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorType.INVALID_ARGUMENT)
+                .message("Invalid businessCategory '%s'. Expected one of openList, internalList, "
+                    + "memberRestrictedList, ownerRestrictedList, domainRestrictedList", businessCategory)
+                .haltError();
+        }
+    }
+
+    private List<MailAddress> parseAddresses(List<String> addresses) {
+        return Optional.ofNullable(addresses)
+            .orElseGet(List::of)
+            .stream()
+            .map(this::parseAddress)
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private MailAddress parseAddress(String address) {
+        return parseOrBadRequest(() -> new MailAddress(address), "Invalid mail address '%s'", address);
+    }
+
+    private <T> T parseOrBadRequest(Callable<T> parser, String errorMessage, String value) {
+        try {
+            return parser.call();
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorType.INVALID_ARGUMENT)
+                .message(errorMessage, value)
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private RuntimeException halt(int statusCode, ErrorType errorType, Exception e) {
+        return ErrorResponder.builder()
+            .statusCode(statusCode)
+            .type(errorType)
+            .message(e.getMessage())
+            .cause(e)
+            .haltError();
+    }
+}

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutes.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutes.java
@@ -144,17 +144,19 @@ public class MailingListManagementRoutes implements Routes {
         try {
             action.run();
             return Responses.returnNoContent(response);
-        } catch (MailingListsNotConfiguredException e) {
-            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
-        } catch (MailingListManagementException.AlreadyExists e) {
-            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
-        } catch (MailingListManagementException.NotFound e) {
-            throw halt(HttpStatus.NOT_FOUND_404, ErrorType.NOT_FOUND, e);
-        } catch (MailingListManagementException.UnknownMember e) {
-            throw halt(HttpStatus.BAD_REQUEST_400, ErrorType.INVALID_ARGUMENT, e);
-        } catch (MailingListManagementException e) {
-            throw halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
+        } catch (MailingListsNotConfiguredException | MailingListManagementException e) {
+            throw haltFor(e);
         }
+    }
+
+    private RuntimeException haltFor(RuntimeException e) {
+        if (e instanceof MailingListManagementException.NotFound) {
+            return halt(HttpStatus.NOT_FOUND_404, ErrorType.NOT_FOUND, e);
+        }
+        if (e instanceof MailingListManagementException.UnknownMember) {
+            return halt(HttpStatus.BAD_REQUEST_400, ErrorType.INVALID_ARGUMENT, e);
+        }
+        return halt(HttpStatus.CONFLICT_409, ErrorType.WRONG_STATE, e);
     }
 
     private MailingListCreationRequest parseBody(Request request) {

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/MailingListRepository.java
@@ -30,4 +30,16 @@ public interface MailingListRepository {
     List<MailAddress> list(Domain domain);
 
     Optional<MailingList> get(MailAddress address);
+
+    void create(MailingList mailingList);
+
+    void delete(MailAddress address);
+
+    void addMember(MailAddress listAddress, MailAddress member);
+
+    void removeMember(MailAddress listAddress, MailAddress member);
+
+    void addOwner(MailAddress listAddress, MailAddress owner);
+
+    void removeOwner(MailAddress listAddress, MailAddress owner);
 }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/UnconfiguredMailingListRepository.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/main/java/com/linagora/tmail/webadmin/mailinglist/UnconfiguredMailingListRepository.java
@@ -43,4 +43,34 @@ public class UnconfiguredMailingListRepository implements MailingListRepository 
     public Optional<MailingList> get(MailAddress address) {
         throw new MailingListsNotConfiguredException();
     }
+
+    @Override
+    public void create(MailingList mailingList) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public void delete(MailAddress address) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public void addMember(MailAddress listAddress, MailAddress member) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public void removeMember(MailAddress listAddress, MailAddress member) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public void addOwner(MailAddress listAddress, MailAddress owner) {
+        throw new MailingListsNotConfiguredException();
+    }
+
+    @Override
+    public void removeOwner(MailAddress listAddress, MailAddress owner) {
+        throw new MailingListsNotConfiguredException();
+    }
 }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
@@ -48,16 +48,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPConnectionPool;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import com.unboundid.ldap.sdk.SearchScope;
 
 import io.restassured.RestAssured;
 
 class MailingListManagementRoutesTest {
     private static final String BASE_DN = "ou=lists,dc=james,dc=org";
     private static final List<String> CREATED_LIST_LOCAL_PARTS = List.of("newlist", "twomembers", "onemember",
-        "ownerlist");
+        "ownerlist", "sharedlocal");
 
     static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
 
@@ -106,7 +110,11 @@ class MailingListManagementRoutesTest {
 
     private void deleteListEntryQuietly(String localPart) {
         try {
-            ldapConnectionPool.delete("cn=" + localPart + "," + BASE_DN);
+            SearchResult searchResult = ldapConnectionPool.search(BASE_DN, SearchScope.SUB,
+                Filter.createEqualityFilter("cn", localPart));
+            for (SearchResultEntry entry : searchResult.getSearchEntries()) {
+                ldapConnectionPool.delete(entry.getDN());
+            }
         } catch (LDAPException e) {
             if (!e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
                 throw new RuntimeException(e);
@@ -145,6 +153,33 @@ class MailingListManagementRoutesTest {
             .body("""
                 {"members": ["james-user@james.org"]}""")
             .put("/mailingLists/mygroup@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    @Test
+    void createShouldAllowSameLocalPartInDifferentDomains() {
+        createList("sharedlocal@lists.james.org", "james-user@james.org");
+
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": ["james-user@james.org"]}""")
+            .put("/mailingLists/sharedlocal@other.james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+    }
+
+    @Test
+    void createObmListShouldReturnConflictForUnsupportedBusinessCategory() {
+        webAdminServer.destroy();
+        startServer(repository(true));
+
+        given()
+            .contentType(JSON)
+            .body("""
+                {"businessCategory": "internalList", "members": ["james-user@james.org"]}""")
+            .put("/mailingLists/whatever@lists.james.org")
         .then()
             .statusCode(CONFLICT_409);
     }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
@@ -57,7 +57,7 @@ import io.restassured.RestAssured;
 class MailingListManagementRoutesTest {
     private static final String BASE_DN = "ou=lists,dc=james,dc=org";
     private static final List<String> CREATED_LIST_LOCAL_PARTS = List.of("newlist", "twomembers", "onemember",
-        "ownerlist", "obmless");
+        "ownerlist");
 
     static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
 
@@ -332,15 +332,17 @@ class MailingListManagementRoutesTest {
     }
 
     @Test
-    void writesShouldReturnConflictForObmLists() {
+    void ownerWritesShouldReturnConflictForObmLists() {
         webAdminServer.destroy();
         startServer(repository(true));
 
         given()
-            .contentType(JSON)
-            .body("""
-                {"members": ["james-user@james.org"]}""")
-            .put("/mailingLists/obmless@lists.james.org")
+            .put("/mailingLists/whatever@lists.james.org/owners/james-user@james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+
+        given()
+            .delete("/mailingLists/whatever@lists.james.org/owners/james-user@james.org")
         .then()
             .statusCode(CONFLICT_409);
     }

--- a/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
+++ b/tmail-backend/webadmin/webadmin-mailing-list/src/test/java/com/linagora/tmail/webadmin/mailinglist/MailingListManagementRoutesTest.java
@@ -1,0 +1,386 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.webadmin.mailinglist;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN;
+import static org.apache.james.user.ldap.DockerLdapSingleton.ADMIN_PASSWORD;
+import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
+import static org.eclipse.jetty.http.HttpStatus.CONFLICT_409;
+import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
+import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.plist.PropertyListConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.user.ldap.DockerLdapSingleton;
+import org.apache.james.user.ldap.LDAPConnectionFactory;
+import org.apache.james.user.ldap.LdapGenericContainer;
+import org.apache.james.user.ldap.LdapRepositoryConfiguration;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.tmail.mailet.MailingListConfiguration;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import io.restassured.RestAssured;
+
+class MailingListManagementRoutesTest {
+    private static final String BASE_DN = "ou=lists,dc=james,dc=org";
+    private static final List<String> CREATED_LIST_LOCAL_PARTS = List.of("newlist", "twomembers", "onemember",
+        "ownerlist", "obmless");
+
+    static LdapGenericContainer ldapContainer = DockerLdapSingleton.ldapContainer;
+
+    private WebAdminServer webAdminServer;
+    private LDAPConnectionPool ldapConnectionPool;
+    private LdapRepositoryConfiguration ldapConfiguration;
+
+    @BeforeAll
+    static void setUpAll() {
+        ldapContainer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        ldapContainer.stop();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ldapConfiguration = LdapRepositoryConfiguration.from(ldapRepositoryConfiguration(ldapContainer));
+        ldapConnectionPool = new LDAPConnectionFactory(ldapConfiguration).getLdapConnectionPool();
+        startServer(repository(false));
+    }
+
+    private MailingListRepository repository(boolean obmCompatibility) {
+        MailingListConfiguration mailingListConfiguration = new MailingListConfiguration(
+            Optional.of(BASE_DN), "description", obmCompatibility);
+        return new LdapMailingListRepository(ldapConnectionPool, ldapConfiguration, mailingListConfiguration);
+    }
+
+    private void startServer(MailingListRepository repository) {
+        JsonTransformer jsonTransformer = new JsonTransformer();
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new MailingListRoutes(repository, jsonTransformer),
+                new MailingListManagementRoutes(repository, jsonTransformer))
+            .start();
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        CREATED_LIST_LOCAL_PARTS.forEach(this::deleteListEntryQuietly);
+        webAdminServer.destroy();
+        ldapConnectionPool.close();
+    }
+
+    private void deleteListEntryQuietly(String localPart) {
+        try {
+            ldapConnectionPool.delete("cn=" + localPart + "," + BASE_DN);
+        } catch (LDAPException e) {
+            if (!e.getResultCode().equals(ResultCode.NO_SUCH_OBJECT)) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    void createShouldPersistTheMailingList() {
+        given()
+            .contentType(JSON)
+            .body("""
+                {
+                  "businessCategory": "openList",
+                  "members": ["james-user@james.org", "james-user2@james.org"],
+                  "owners": ["james-user4@james.org"]
+                }""")
+            .put("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        String response = getList("newlist@lists.james.org");
+
+        assertThatJson(response).inPath("mail").isEqualTo("newlist@lists.james.org");
+        assertThatJson(response).inPath("businessCategory").isEqualTo("openList");
+        assertThatJson(response).inPath("members").isArray()
+            .containsExactlyInAnyOrder("james-user@james.org", "james-user2@james.org");
+        assertThatJson(response).inPath("owners").isArray()
+            .containsExactly("james-user4@james.org");
+    }
+
+    @Test
+    void createShouldReturnConflictWhenListAlreadyExists() {
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": ["james-user@james.org"]}""")
+            .put("/mailingLists/mygroup@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    @Test
+    void createShouldReturnBadRequestWhenNoMember() {
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": []}""")
+            .put("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(BAD_REQUEST_400);
+    }
+
+    @Test
+    void createShouldReturnBadRequestWhenInvalidBusinessCategory() {
+        given()
+            .contentType(JSON)
+            .body("""
+                {"businessCategory": "invalid", "members": ["james-user@james.org"]}""")
+            .put("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(BAD_REQUEST_400);
+    }
+
+    @Test
+    void createShouldReturnBadRequestWhenMemberIsNotAUser() {
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": ["not-a-user@james.org"]}""")
+            .put("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(BAD_REQUEST_400);
+    }
+
+    @Test
+    void deleteShouldRemoveTheMailingList() {
+        createList("newlist@lists.james.org", "james-user@james.org");
+
+        given()
+            .delete("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        given()
+            .get("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(NOT_FOUND_404);
+    }
+
+    @Test
+    void deleteShouldReturnNotFoundWhenUnknownList() {
+        given()
+            .delete("/mailingLists/unknown@lists.james.org")
+        .then()
+            .statusCode(NOT_FOUND_404);
+    }
+
+    @Test
+    void addMemberShouldAddTheMember() {
+        createList("onemember@lists.james.org", "james-user@james.org");
+
+        given()
+            .put("/mailingLists/onemember@lists.james.org/members/james-user2@james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        assertThatJson(getList("onemember@lists.james.org"))
+            .inPath("members").isArray()
+            .containsExactlyInAnyOrder("james-user@james.org", "james-user2@james.org");
+    }
+
+    @Test
+    void addMemberShouldBeIdempotent() {
+        createList("onemember@lists.james.org", "james-user@james.org");
+
+        given().put("/mailingLists/onemember@lists.james.org/members/james-user2@james.org")
+            .then().statusCode(NO_CONTENT_204);
+        given().put("/mailingLists/onemember@lists.james.org/members/james-user2@james.org")
+            .then().statusCode(NO_CONTENT_204);
+
+        assertThatJson(getList("onemember@lists.james.org"))
+            .inPath("members").isArray()
+            .containsExactlyInAnyOrder("james-user@james.org", "james-user2@james.org");
+    }
+
+    @Test
+    void addMemberShouldReturnNotFoundWhenUnknownList() {
+        given()
+            .put("/mailingLists/unknown@lists.james.org/members/james-user@james.org")
+        .then()
+            .statusCode(NOT_FOUND_404);
+    }
+
+    @Test
+    void addMemberShouldReturnBadRequestWhenMemberIsNotAUser() {
+        createList("onemember@lists.james.org", "james-user@james.org");
+
+        given()
+            .put("/mailingLists/onemember@lists.james.org/members/not-a-user@james.org")
+        .then()
+            .statusCode(BAD_REQUEST_400);
+    }
+
+    @Test
+    void removeMemberShouldRemoveTheMember() {
+        createList("twomembers@lists.james.org", "james-user@james.org", "james-user2@james.org");
+
+        given()
+            .delete("/mailingLists/twomembers@lists.james.org/members/james-user2@james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        assertThatJson(getList("twomembers@lists.james.org"))
+            .inPath("members").isArray()
+            .containsExactly("james-user@james.org");
+    }
+
+    @Test
+    void removeMemberShouldBeIdempotent() {
+        createList("twomembers@lists.james.org", "james-user@james.org", "james-user2@james.org");
+
+        given().delete("/mailingLists/twomembers@lists.james.org/members/james-user3@james.org")
+            .then().statusCode(NO_CONTENT_204);
+    }
+
+    @Test
+    void removeMemberShouldReturnConflictWhenRemovingLastMember() {
+        createList("onemember@lists.james.org", "james-user@james.org");
+
+        given()
+            .delete("/mailingLists/onemember@lists.james.org/members/james-user@james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    @Test
+    void addOwnerShouldAddTheOwner() {
+        createList("ownerlist@lists.james.org", "james-user@james.org");
+
+        given()
+            .put("/mailingLists/ownerlist@lists.james.org/owners/james-user4@james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        assertThatJson(getList("ownerlist@lists.james.org"))
+            .inPath("owners").isArray()
+            .containsExactly("james-user4@james.org");
+    }
+
+    @Test
+    void removeOwnerShouldRemoveTheOwner() {
+        createList("ownerlist@lists.james.org", "james-user@james.org");
+        given().put("/mailingLists/ownerlist@lists.james.org/owners/james-user4@james.org")
+            .then().statusCode(NO_CONTENT_204);
+
+        given()
+            .delete("/mailingLists/ownerlist@lists.james.org/owners/james-user4@james.org")
+        .then()
+            .statusCode(NO_CONTENT_204);
+
+        assertThatJson(getList("ownerlist@lists.james.org"))
+            .inPath("owners").isArray().isEmpty();
+    }
+
+    @Test
+    void writesShouldReturnConflictWhenNotConfigured() {
+        webAdminServer.destroy();
+        startServer(new UnconfiguredMailingListRepository());
+
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": ["james-user@james.org"]}""")
+            .put("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+
+        given()
+            .delete("/mailingLists/newlist@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    @Test
+    void writesShouldReturnConflictForObmLists() {
+        webAdminServer.destroy();
+        startServer(repository(true));
+
+        given()
+            .contentType(JSON)
+            .body("""
+                {"members": ["james-user@james.org"]}""")
+            .put("/mailingLists/obmless@lists.james.org")
+        .then()
+            .statusCode(CONFLICT_409);
+    }
+
+    private void createList(String address, String... members) {
+        StringBuilder memberArray = new StringBuilder();
+        for (int i = 0; i < members.length; i++) {
+            if (i > 0) {
+                memberArray.append(", ");
+            }
+            memberArray.append('"').append(members[i]).append('"');
+        }
+        given()
+            .contentType(JSON)
+            .body("{\"members\": [" + memberArray + "]}")
+            .put("/mailingLists/" + address)
+        .then()
+            .statusCode(NO_CONTENT_204);
+    }
+
+    private String getList(String address) {
+        return given()
+            .get("/mailingLists/" + address)
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+    }
+
+    static HierarchicalConfiguration<ImmutableNode> ldapRepositoryConfiguration(LdapGenericContainer ldapContainer) {
+        PropertyListConfiguration configuration = new PropertyListConfiguration();
+        configuration.addProperty("[@ldapHost]", ldapContainer.getLdapHost());
+        configuration.addProperty("[@principal]", "cn=admin,dc=james,dc=org");
+        configuration.addProperty("[@credentials]", ADMIN_PASSWORD);
+        configuration.addProperty("[@userBase]", "ou=people,dc=james,dc=org");
+        configuration.addProperty("[@userIdAttribute]", "mail");
+        configuration.addProperty("[@userObjectClass]", "inetOrgPerson");
+        configuration.addProperty("[@connectionTimeout]", "2000");
+        configuration.addProperty("[@readTimeout]", "2000");
+        configuration.addProperty("supportsVirtualHosting", true);
+        configuration.addProperty("[@administratorId]", ADMIN.asString());
+        return configuration;
+    }
+}


### PR DESCRIPTION
Closes #2515

Follow-up to #2489 (read-only `/mailingLists` routes). This adds the **write** side.

## HTTP surface

Exposed by a **separate** `MailingListManagementRoutes` class that is **not** in the `Multibinder<Routes>`: operators opt-in by listing `com.linagora.tmail.webadmin.mailinglist.MailingListManagementRoutes` under `additional.routes` in `webadmin.properties` (as the issue asks). The read routes stay always-on.

- `PUT /mailingLists/{address}` — create. Body: `{"businessCategory": "openList", "members": [...], "owners": [...]}`. `members` mandatory (≥1, a `groupOfNames` list cannot be empty); `businessCategory`/`owners` optional. `409` if it exists.
- `DELETE /mailingLists/{address}` — delete.
- `PUT|DELETE /mailingLists/{address}/members/{memberAddress}` — add/remove member (idempotent).
- `PUT|DELETE /mailingLists/{address}/owners/{ownerAddress}` — add/remove owner (idempotent).

Payloads are detailed in `webadmin.adoc`.

## Design decisions (answering the open questions in the issue thread)

- **First member mandatory on create** to satisfy the `groupOfNames` MUST `member`. Empty `members` → `400`; removing the last member → `409`.
- **OBM (`obmGroup`) lists are read-only for writes** in this iteration: every write is rejected with `409` (`WriteNotSupported`). Owner management is therefore N/A under OBM, matching the issue's "if applicable".
- **Member/owner email → DN** via a `userBase` search on `userIdAttribute` (reusing `LdapRepositoryConfiguration`). No match → `400`; several matches → first one is used (logged).
- **DN/RDN**: new lists are created at `cn=<local-part>,<baseDN>`; existing lists are always resolved by their mail attribute (never reconstructed) so a mismatching `cn` is handled.
- **Idempotency**: single-valued LDAP `MODIFY ADD/DELETE`; `ATTRIBUTE_OR_VALUE_EXISTS` / `NO_SUCH_ATTRIBUTE` map to `204`, `OBJECT_CLASS_VIOLATION` (last member) to `409`.
- `AuditTrail` entries for create/delete/membership changes; the not-configured guard (`409`) is preserved, and `UnconfiguredMailingListRepository` throws for the new write methods too.

## Tests

`MailingListManagementRoutesTest` runs against the real `DockerLdapSingleton` with the `ADMIN` bind (write ACLs), cleaning up created entries in `@AfterEach`. 18 cases cover create/delete/add/remove for members and owners, idempotency, validation, not-found/conflict, OBM rejection and the not-configured case. Existing `MailingListRoutesTest` still green; checkstyle clean.

## Deployment note

Writes require the configured LDAP bind user to hold write ACLs on the lists subtree (documented).

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in WebAdmin routes for creating and deleting LDAP-backed mailing lists.
  * Added endpoints to add or remove mailing list members and owners.
  * Added support for `groupOfNames` and OBM mailing list schemas, including external contacts where applicable.
  * Added validation and clear error responses for invalid requests, missing lists, conflicts, unsupported operations, and unknown members.

* **Documentation**
  * Documented route configuration, permissions, supported schemas, endpoints, request requirements, and response codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->