### PR TITLE
[TMail] feat : configuration for scribe activation only for paying users

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -21,6 +21,7 @@ Sample `ai.properties` configuration:
 apiKey=demo
 model=lucie
 baseURL=https://chat.lucie.example.com
+ai.jmap.capability.applyWhen=com.linagora.tmail.saas.filter.SaaSPayingUser
 ```
 
 **Parameter explanation:**
@@ -29,6 +30,7 @@ baseURL=https://chat.lucie.example.com
 * `baseURL`: The URL of an LLM API compatible with OpenAI, e.g. https://ai.linagora.com/api. If left blank, defaults to the official OpenAI API base URL.
 * `model`: The identifier of the LLM that generates the replies. Defaults to `gpt-4o-mini`.
 * `timeout`: Optional, duration, defaults to 10 seconds. Timeout for LLM requests.
+* `ai.jmap.capability.applyWhen`: Optional, fully qualified class name of an `ApplyWhenFilter` implementation that determines which users are eligible for the AI bot JMAP capability and ChatCompletion route. If not set, defaults to `com.linagora.tmail.james.jmap.event.ApplyWhenFilter$Always` (all authenticated users are eligible). For SaaS deployments, use `com.linagora.tmail.saas.filter.SaaSPayingUser` to restrict access to paying users only. Custom implementations must implement the `com.linagora.tmail.james.jmap.event.ApplyWhenFilter` interface.
 
 You can use the langchain4j demo API at http://langchain4j.dev/demo/openai/v1 with the `gpt-4o-mini` model and `demo` API key for testing purposes.
 

--- a/tmail-backend/tmail-third-party/ai-bot/pom.xml
+++ b/tmail-backend/tmail-third-party/ai-bot/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>tmail-saas-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/tmail-backend/tmail-third-party/ai-bot/sample_conf/ai.properties
+++ b/tmail-backend/tmail-third-party/ai-bot/sample_conf/ai.properties
@@ -5,3 +5,4 @@ openrag.url=https://ragondin.linagora.com
 openrag.token=fake-token
 openrag.ssl.trust.all.certs=false
 openrag.partition.pattern={localPart}.twake.{domainName}
+ai.jmap.capability.applyWhen=com.linagora.tmail.saas.filter.SaaSPayingUser

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
@@ -35,6 +35,9 @@ import org.apache.james.events.EventSerializer;
 import org.apache.james.events.Group;
 import org.apache.james.modules.mailbox.ListenerConfiguration;
 import org.apache.james.modules.mailbox.ListenersConfiguration;
+import org.apache.james.utils.ClassName;
+import org.apache.james.utils.GuiceLoader;
+import org.apache.james.utils.NamingScheme;
 import org.apache.james.utils.PropertiesProvider;
 
 import com.google.inject.AbstractModule;
@@ -44,6 +47,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.listener.rag.LlmMailBackendClassifierListener;
 import com.linagora.tmail.listener.rag.LlmMailClassifierListener;
 import com.linagora.tmail.listener.rag.event.AIAnalysisNeededEventSerializer;
@@ -61,6 +65,8 @@ import com.linagora.tmail.mailet.rag.httpclient.Partition;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 
 public class AIBaseModule extends AbstractModule {
+    private static final String AI_JMAP_CAPABILITY_APPLY_WHEN = "ai.jmap.capability.applyWhen";
+
     @Override
     protected void configure() {
         bind(AIRedactionalHelper.class).to(LangchainAIRedactionalHelper.class);
@@ -104,6 +110,24 @@ public class AIBaseModule extends AbstractModule {
     @Provides
     public static AIBotConfig provideAiBotExtensionConfiguration(@Named("ai") Configuration configuration) {
         return AIBotConfig.from(configuration);
+    }
+
+    @Provides
+    @Singleton
+    public ApplyWhenFilter provideApplyWhenFilter(@Named("ai") Configuration configuration, GuiceLoader guiceLoader) {
+        return Optional.ofNullable(configuration.getString(AI_JMAP_CAPABILITY_APPLY_WHEN))
+            .filter(name -> !name.isBlank())
+            .map(name -> loadApplyWhenFilter(name, guiceLoader))
+            .orElse(new ApplyWhenFilter.Always());
+    }
+
+    private ApplyWhenFilter loadApplyWhenFilter(String className, GuiceLoader guiceLoader) {
+        try {
+            return guiceLoader.<ApplyWhenFilter>withNamingSheme(NamingScheme.IDENTITY)
+                .instantiate(new ClassName(className));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to load ApplyWhenFilter `" + className + "`", e);
+        }
     }
 
     @Provides

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AIChatCompletionRoutes.scala
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AIChatCompletionRoutes.scala
@@ -21,6 +21,7 @@ package com.linagora.tmail.jmap.aibot
 import java.nio.charset.StandardCharsets
 import java.util.stream
 import java.util.stream.Stream
+import com.linagora.tmail.james.jmap.event.ApplyWhenFilter
 import com.linagora.tmail.jmap.aibot.AIChatCompletionRoutes.LOGGER
 import com.linagora.tmail.mailet.rag.RagConfig
 import com.linagora.tmail.mailet.rag.httpclient.{ChatCompletionResult, OpenRagHttpClient}
@@ -48,7 +49,8 @@ object AIChatCompletionRoutes {
 
 class AIChatCompletionRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
                                        val ragConfig: RagConfig,
-                                       val metricFactory: MetricFactory) extends JMAPRoutes {
+                                       val metricFactory: MetricFactory,
+                                       val applyWhenFilter: ApplyWhenFilter) extends JMAPRoutes {
   private val openRagHttpClient = new OpenRagHttpClient(ragConfig)
   private val jmapAiUri = "/ai/v1/chat/completions"
 
@@ -64,7 +66,14 @@ class AIChatCompletionRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authen
 
   private def post(request: HttpServerRequest, response: HttpServerResponse): Mono[Void] =
     SMono(authenticator.authenticate(request))
-      .flatMap(_ => postRequest(request, response))
+      .flatMap(mailbox =>
+        SMono(applyWhenFilter.isEligible(mailbox.getUser))
+          .map(_.booleanValue())
+          .flatMap {
+            case true => postRequest(request, response)
+            case false =>
+              respondDetails(response, ProblemDetails(status = UNAUTHORIZED, detail = "User is not eligible for AI chat completion"))
+          })
       .onErrorResume {
         case e: UnauthorizedException =>
           LOGGER.warn("Unauthorized", e)

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AiBotCapability.scala
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AiBotCapability.scala
@@ -18,15 +18,18 @@
 package com.linagora.tmail.jmap.aibot
 
 import com.google.inject.AbstractModule
-import com.google.inject.multibindings.{Multibinder, ProvidesIntoSet}
+import com.google.inject.multibindings.Multibinder
+import com.linagora.tmail.james.jmap.event.ApplyWhenFilter
 import com.linagora.tmail.jmap.aibot.CapabilityIdentifier.LINAGORA_AIBOT
 import eu.timepit.refined.auto._
+import jakarta.inject.Inject
 import org.apache.james.core.Username
 import org.apache.james.jmap.JMAPRoutes
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.{Capability, CapabilityFactory, CapabilityProperties, URL, UrlPrefixes}
 import org.apache.james.jmap.method.Method
 import play.api.libs.json.{JsObject, Json}
+import reactor.core.scala.publisher.SMono
 
 object CapabilityIdentifier {
   val LINAGORA_AIBOT: CapabilityIdentifier = "com:linagora:params:jmap:aibot"
@@ -40,13 +43,22 @@ case class AiBotCapability(properties: AiBotCapabilityProperties,
                            identifier: CapabilityIdentifier = LINAGORA_AIBOT) extends Capability
 
 class AiBotCapabilitiesModule extends AbstractModule {
-  @ProvidesIntoSet
-  private def capability(): CapabilityFactory = AiBotCapabilityFactory
+  override def configure(): Unit = {
+    Multibinder.newSetBinder(binder(), classOf[CapabilityFactory])
+      .addBinding()
+      .to(classOf[AiBotCapabilityFactory])
+  }
 }
 
-case object AiBotCapabilityFactory extends CapabilityFactory {
+class AiBotCapabilityFactory @Inject()(val applyWhenFilter: ApplyWhenFilter) extends CapabilityFactory {
   override def create(urlPrefixes: UrlPrefixes, username: Username): Capability =
-    AiBotCapability(AiBotCapabilityProperties(URL(urlPrefixes.httpUrlPrefix.toString + "/ai/v1/chat/completions")))
+    this.createReactive(urlPrefixes, username).block()
+
+  override def createReactive(urlPrefixes: UrlPrefixes, username: Username): SMono[Capability] = {
+    SMono(applyWhenFilter.isEligible(username))
+      .filter(_.booleanValue())
+      .map(_ => AiBotCapability(AiBotCapabilityProperties(URL(urlPrefixes.httpUrlPrefix.toString + "/ai/v1/chat/completions"))))
+  }
 
   override def id(): CapabilityIdentifier = LINAGORA_AIBOT
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilityFactoryIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilityFactoryIntegrationTest.java
@@ -1,0 +1,114 @@
+///********************************************************************
+// *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+// *                                                                  *
+// *  https://twake-mail.com/                                         *
+// *  https://linagora.com                                            *
+// *                                                                  *
+// *  This file is subject to The Affero Gnu Public License           *
+// *  version 3.                                                      *
+// *                                                                  *
+// *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+// *                                                                  *
+// *  This program is distributed in the hope that it will be         *
+// *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+// *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+// *  PURPOSE. See the GNU Affero General Public License for          *
+// *  more details.                                                   *
+// ********************************************************************/
+//
+//package com.linagora.tmail.jmap.aibot;
+//
+//import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+//import static io.restassured.RestAssured.given;
+//import static org.apache.http.HttpStatus.SC_OK;
+//import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+//import static org.apache.james.jmap.rfc8621.contract.Fixture.ACCEPT_RFC8621_VERSION_HEADER;
+//import static org.apache.james.jmap.rfc8621.contract.Fixture.authScheme;
+//import static org.apache.james.jmap.rfc8621.contract.Fixture.baseRequestSpecBuilder;
+//import static org.hamcrest.Matchers.equalTo;
+//import static org.hamcrest.Matchers.hasKey;
+//
+//import org.apache.james.GuiceJamesServer;
+//import org.apache.james.JamesServerBuilder;
+//import org.apache.james.JamesServerExtension;
+//import org.apache.james.core.Username;
+//import org.apache.james.jmap.http.UserCredential;
+//import org.apache.james.utils.DataProbeImpl;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.RegisterExtension;
+//
+//import com.google.inject.util.Modules;
+//import com.linagora.tmail.james.app.MemoryConfiguration;
+//import com.linagora.tmail.james.app.MemoryServer;
+//import com.linagora.tmail.mailet.AIRedactionalHelper;
+//import com.linagora.tmail.mailet.AIRedactionalHelperForTest;
+//import com.linagora.tmail.mailet.conf.AIBaseModule;
+//import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+//
+//import io.restassured.specification.RequestSpecification;
+//
+//class AiBotCapabilityFactoryIntegrationTest {
+//
+//    static final String DOMAIN = "domain.tld";
+//    static final String PASSWORD = "secret";
+//    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+//
+//    @RegisterExtension
+//    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+//        MemoryConfiguration.builder()
+//            .workingDirectory(tmpDir)
+//            .configurationFromClasspath()
+//            .usersRepository(DEFAULT)
+//            .build())
+//        .server(configuration -> MemoryServer.createServer(configuration)
+//            .overrideWith(new LinagoraTestJMAPServerModule())
+//            .overrideWith(Modules.override(new AIBaseModule())
+//                .with(binder -> binder.bind(AIRedactionalHelper.class).to(AIRedactionalHelperForTest.class))))
+//        .build();
+//
+//    private RequestSpecification requestSpec;
+//
+//    @BeforeEach
+//    void setUp(GuiceJamesServer jamesServer) throws Exception {
+//        jamesServer.getProbe(DataProbeImpl.class).fluent()
+//            .addDomain(DOMAIN)
+//            .addUser(BOB.asString(), PASSWORD);
+//
+//        requestSpec = baseRequestSpecBuilder(jamesServer)
+//            .setAuth(authScheme(new UserCredential(BOB, PASSWORD)))
+//            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
+//            .build();
+//    }
+//
+//    @Test
+//    void shouldReturnAiBotCapabilityInSession(GuiceJamesServer jamesServer) {
+//        given(requestSpec)
+//            .when()
+//            .get("/session")
+//        .then()
+//            .statusCode(SC_OK)
+//            .body("capabilities", hasKey("com:linagora:params:jmap:aibot"));
+//    }
+//
+//    @Test
+//    void shouldReturnCorrectScribeEndpointInCapability(GuiceJamesServer jamesServer) {
+//        given(requestSpec)
+//            .when()
+//            .get("/session")
+//        .then()
+//            .statusCode(SC_OK)
+//            .body("capabilities.'com:linagora:params:jmap:aibot'.scribeEndpoint",
+//                equalTo("http://localhost:8000/ai/v1/chat/completions"));
+//    }
+//
+//    @Test
+//    void shouldReturnAiBotCapabilityInAccountCapabilities(GuiceJamesServer jamesServer) {
+//        given(requestSpec)
+//            .when()
+//            .get("/session")
+//        .then()
+//            .statusCode(SC_OK)
+//            .body("accounts.'*'.accountCapabilities", hasKey("com:linagora:params:jmap:aibot"));
+//    }
+//}

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilityFactoryIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilityFactoryIntegrationTest.java
@@ -1,114 +1,119 @@
-///********************************************************************
-// *  As a subpart of Twake Mail, this file is edited by Linagora.    *
-// *                                                                  *
-// *  https://twake-mail.com/                                         *
-// *  https://linagora.com                                            *
-// *                                                                  *
-// *  This file is subject to The Affero Gnu Public License           *
-// *  version 3.                                                      *
-// *                                                                  *
-// *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
-// *                                                                  *
-// *  This program is distributed in the hope that it will be         *
-// *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
-// *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
-// *  PURPOSE. See the GNU Affero General Public License for          *
-// *  more details.                                                   *
-// ********************************************************************/
-//
-//package com.linagora.tmail.jmap.aibot;
-//
-//import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
-//import static io.restassured.RestAssured.given;
-//import static org.apache.http.HttpStatus.SC_OK;
-//import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
-//import static org.apache.james.jmap.rfc8621.contract.Fixture.ACCEPT_RFC8621_VERSION_HEADER;
-//import static org.apache.james.jmap.rfc8621.contract.Fixture.authScheme;
-//import static org.apache.james.jmap.rfc8621.contract.Fixture.baseRequestSpecBuilder;
-//import static org.hamcrest.Matchers.equalTo;
-//import static org.hamcrest.Matchers.hasKey;
-//
-//import org.apache.james.GuiceJamesServer;
-//import org.apache.james.JamesServerBuilder;
-//import org.apache.james.JamesServerExtension;
-//import org.apache.james.core.Username;
-//import org.apache.james.jmap.http.UserCredential;
-//import org.apache.james.utils.DataProbeImpl;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.RegisterExtension;
-//
-//import com.google.inject.util.Modules;
-//import com.linagora.tmail.james.app.MemoryConfiguration;
-//import com.linagora.tmail.james.app.MemoryServer;
-//import com.linagora.tmail.mailet.AIRedactionalHelper;
-//import com.linagora.tmail.mailet.AIRedactionalHelperForTest;
-//import com.linagora.tmail.mailet.conf.AIBaseModule;
-//import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
-//
-//import io.restassured.specification.RequestSpecification;
-//
-//class AiBotCapabilityFactoryIntegrationTest {
-//
-//    static final String DOMAIN = "domain.tld";
-//    static final String PASSWORD = "secret";
-//    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
-//
-//    @RegisterExtension
-//    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
-//        MemoryConfiguration.builder()
-//            .workingDirectory(tmpDir)
-//            .configurationFromClasspath()
-//            .usersRepository(DEFAULT)
-//            .build())
-//        .server(configuration -> MemoryServer.createServer(configuration)
-//            .overrideWith(new LinagoraTestJMAPServerModule())
-//            .overrideWith(Modules.override(new AIBaseModule())
-//                .with(binder -> binder.bind(AIRedactionalHelper.class).to(AIRedactionalHelperForTest.class))))
-//        .build();
-//
-//    private RequestSpecification requestSpec;
-//
-//    @BeforeEach
-//    void setUp(GuiceJamesServer jamesServer) throws Exception {
-//        jamesServer.getProbe(DataProbeImpl.class).fluent()
-//            .addDomain(DOMAIN)
-//            .addUser(BOB.asString(), PASSWORD);
-//
-//        requestSpec = baseRequestSpecBuilder(jamesServer)
-//            .setAuth(authScheme(new UserCredential(BOB, PASSWORD)))
-//            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
-//            .build();
-//    }
-//
-//    @Test
-//    void shouldReturnAiBotCapabilityInSession(GuiceJamesServer jamesServer) {
-//        given(requestSpec)
-//            .when()
-//            .get("/session")
-//        .then()
-//            .statusCode(SC_OK)
-//            .body("capabilities", hasKey("com:linagora:params:jmap:aibot"));
-//    }
-//
-//    @Test
-//    void shouldReturnCorrectScribeEndpointInCapability(GuiceJamesServer jamesServer) {
-//        given(requestSpec)
-//            .when()
-//            .get("/session")
-//        .then()
-//            .statusCode(SC_OK)
-//            .body("capabilities.'com:linagora:params:jmap:aibot'.scribeEndpoint",
-//                equalTo("http://localhost:8000/ai/v1/chat/completions"));
-//    }
-//
-//    @Test
-//    void shouldReturnAiBotCapabilityInAccountCapabilities(GuiceJamesServer jamesServer) {
-//        given(requestSpec)
-//            .when()
-//            .get("/session")
-//        .then()
-//            .statusCode(SC_OK)
-//            .body("accounts.'*'.accountCapabilities", hasKey("com:linagora:params:jmap:aibot"));
-//    }
-//}
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.jmap.aibot;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.ACCEPT_RFC8621_VERSION_HEADER;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.authScheme;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.baseRequestSpecBuilder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.http.UserCredential;
+import org.apache.james.utils.DataProbeImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.util.Modules;
+import com.linagora.tmail.james.app.MemoryConfiguration;
+import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.mailet.AIRedactionalHelper;
+import com.linagora.tmail.mailet.AIRedactionalHelperForTest;
+import com.linagora.tmail.mailet.conf.AIBaseModule;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+import io.restassured.specification.RequestSpecification;
+
+class AiBotCapabilityFactoryIntegrationTest {
+
+    static final String DOMAIN = "domain.tld";
+    static final String PASSWORD = "secret";
+    private static final Username BOB = Username.fromLocalPartWithDomain("bob", DOMAIN);
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+        MemoryConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .usersRepository(DEFAULT)
+            .build())
+        .server(configuration -> MemoryServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(Modules.override(new AIBaseModule())
+                .with(binder -> binder.bind(AIRedactionalHelper.class).to(AIRedactionalHelperForTest.class))))
+        .build();
+
+    private RequestSpecification requestSpec;
+
+    @BeforeEach
+    void setUp(GuiceJamesServer jamesServer) throws Exception {
+        jamesServer.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(BOB.asString(), PASSWORD);
+
+        requestSpec = baseRequestSpecBuilder(jamesServer)
+            .setAuth(authScheme(new UserCredential(BOB, PASSWORD)))
+            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
+            .build();
+    }
+
+    @Test
+    void shouldReturnAiBotCapabilityInSession(GuiceJamesServer jamesServer) {
+        given(requestSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .body("capabilities", hasKey("com:linagora:params:jmap:aibot"));
+    }
+
+    @Test
+    void shouldReturnCorrectScribeEndpointInCapability(GuiceJamesServer jamesServer) {
+        given(requestSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .body("capabilities.'com:linagora:params:jmap:aibot'.scribeEndpoint",
+                equalTo("http://localhost/ai/v1/chat/completions"));
+    }
+
+    @Test
+    void shouldReturnAiBotCapabilityInAccountCapabilities(GuiceJamesServer jamesServer) {
+        String body = given(requestSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .extract().body().asString();
+
+        assertThat(body).contains("\"accountCapabilities\"");
+        assertThat(body).contains("\"com:linagora:params:jmap:aibot\"");
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilitySaaSFilterIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/jmap/aibot/AiBotCapabilitySaaSFilterIntegrationTest.java
@@ -1,0 +1,141 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.jmap.aibot;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.ACCEPT_RFC8621_VERSION_HEADER;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.authScheme;
+import static org.apache.james.jmap.rfc8621.contract.Fixture.baseRequestSpecBuilder;
+import static org.hamcrest.Matchers.hasKey;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.http.UserCredential;
+import org.apache.james.utils.DataProbeImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
+import com.linagora.tmail.james.app.MemoryConfiguration;
+import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
+import com.linagora.tmail.mailet.AIRedactionalHelper;
+import com.linagora.tmail.mailet.AIRedactionalHelperForTest;
+import com.linagora.tmail.mailet.conf.AIBaseModule;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+import com.linagora.tmail.saas.api.SaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.filter.SaaSPayingUser;
+import com.linagora.tmail.saas.model.SaaSAccount;
+
+import io.restassured.specification.RequestSpecification;
+import reactor.core.publisher.Mono;
+
+class AiBotCapabilitySaaSFilterIntegrationTest {
+
+    static final String DOMAIN = "domain.tld";
+    static final String PASSWORD = "secret";
+    private static final Username PAYING_USER = Username.fromLocalPartWithDomain("paying", DOMAIN);
+    private static final Username NON_PAYING_USER = Username.fromLocalPartWithDomain("nonpaying", DOMAIN);
+
+    static final MemorySaaSAccountRepository SAAS_REPOSITORY = new MemorySaaSAccountRepository();
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+        MemoryConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .usersRepository(DEFAULT)
+            .build())
+        .server(configuration -> MemoryServer.createServer(configuration)
+            .overrideWith(new LinagoraTestJMAPServerModule())
+            .overrideWith(Modules.override(new AIBaseModule())
+                .with(binder -> {
+                    binder.bind(SaaSAccountRepository.class).toInstance(SAAS_REPOSITORY);
+                    binder.bind(ApplyWhenFilter.class).toInstance(new SaaSPayingUser(SAAS_REPOSITORY));
+                })))
+        .build();
+
+    @BeforeEach
+    void setUp(GuiceJamesServer jamesServer) throws Exception {
+        jamesServer.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(PAYING_USER.asString(), PASSWORD)
+            .addUser(NON_PAYING_USER.asString(), PASSWORD);
+
+        Mono.from(SAAS_REPOSITORY.upsertSaasAccount(PAYING_USER, new SaaSAccount(true, true))).block();
+        Mono.from(SAAS_REPOSITORY.upsertSaasAccount(NON_PAYING_USER, new SaaSAccount(true, false))).block();
+    }
+
+    @Test
+    void shouldReturnAiBotCapabilityForPayingUser(GuiceJamesServer jamesServer) {
+        RequestSpecification payingSpec = baseRequestSpecBuilder(jamesServer)
+            .setAuth(authScheme(new UserCredential(PAYING_USER, PASSWORD)))
+            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
+            .build();
+
+        given(payingSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .body("capabilities", hasKey("com:linagora:params:jmap:aibot"));
+    }
+
+    @Test
+    void shouldNotReturnAiBotCapabilityForNonPayingUser(GuiceJamesServer jamesServer) {
+        RequestSpecification nonPayingSpec = baseRequestSpecBuilder(jamesServer)
+            .setAuth(authScheme(new UserCredential(NON_PAYING_USER, PASSWORD)))
+            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
+            .build();
+
+        given(nonPayingSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .body("capabilities.'com:linagora:params:jmap:aibot'", org.hamcrest.Matchers.nullValue());
+    }
+
+    @Test
+    void shouldNotReturnAiBotCapabilityForUserWithNoSaaSAccount(GuiceJamesServer jamesServer) throws Exception {
+        Username unknownUser = Username.fromLocalPartWithDomain("unknown", DOMAIN);
+        jamesServer.getProbe(DataProbeImpl.class).fluent()
+            .addUser(unknownUser.asString(), PASSWORD);
+
+        RequestSpecification unknownSpec = baseRequestSpecBuilder(jamesServer)
+            .setAuth(authScheme(new UserCredential(unknownUser, PASSWORD)))
+            .addHeader(ACCEPT.toString(), ACCEPT_RFC8621_VERSION_HEADER())
+            .build();
+
+        given(unknownSpec)
+            .when()
+            .get("/session")
+        .then()
+            .statusCode(SC_OK)
+            .body("capabilities.'com:linagora:params:jmap:aibot'", org.hamcrest.Matchers.nullValue());
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
@@ -27,31 +27,43 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
 import static org.apache.james.jmap.JMAPTestingConstants.ALICE;
 import static org.apache.james.jmap.JMAPTestingConstants.ALICE_PASSWORD;
-import static org.apache.james.jmap.JMAPTestingConstants.BOB;
-import static org.apache.james.jmap.JMAPTestingConstants.BOB_PASSWORD;
-import static org.apache.james.jmap.JMAPTestingConstants.DOMAIN;
 import static org.apache.james.jmap.rfc8621.contract.Fixture.authScheme;
 import static org.apache.james.jmap.rfc8621.contract.Fixture.baseRequestSpecBuilder;
+import static org.hamcrest.Matchers.equalTo;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
+import org.apache.james.core.Username;
 import org.apache.james.jmap.http.UserCredential;
 import org.apache.james.utils.DataProbeImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.inject.util.Modules;
 import com.linagora.tmail.extension.WireMockRagServerExtension;
 import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
+import com.linagora.tmail.mailet.conf.AIBaseModule;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+import com.linagora.tmail.saas.api.SaaSAccountRepository;
+import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
+import com.linagora.tmail.saas.filter.SaaSPayingUser;
+import com.linagora.tmail.saas.model.SaaSAccount;
 
 import io.restassured.specification.RequestSpecification;
+import reactor.core.publisher.Mono;
 
 class AIChatCompletionRoutesTest {
     private static final String JMAP_CHAT_COMPLETIONS_ENDPOINT = "/ai/v1/chat/completions";
+    static final String DOMAIN = "domain.tld";
+    static final String PASSWORD = "secret";
+    private static final Username PAYING_USER = Username.fromLocalPartWithDomain("paying", DOMAIN);
+    private static final Username NON_PAYING_USER = Username.fromLocalPartWithDomain("nonpaying", DOMAIN);
 
+    private static final MemorySaaSAccountRepository SAAS_REPOSITORY = new MemorySaaSAccountRepository();
     @RegisterExtension
     static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
 
@@ -63,7 +75,12 @@ class AIChatCompletionRoutesTest {
                 .usersRepository(DEFAULT)
                 .build())
             .server(configuration -> MemoryServer.createServer(configuration)
-                .overrideWith(new LinagoraTestJMAPServerModule()))
+                .overrideWith(new LinagoraTestJMAPServerModule())
+                .overrideWith(Modules.override(new AIBaseModule())
+                    .with(binder -> {
+                        binder.bind(ApplyWhenFilter.class).toInstance(new SaaSPayingUser(SAAS_REPOSITORY));
+                        binder.bind(SaaSAccountRepository.class).toInstance(SAAS_REPOSITORY);
+                    })))
             .extension(wireMockRagServerExtension)
             .build();
 
@@ -71,11 +88,15 @@ class AIChatCompletionRoutesTest {
     void setUp(GuiceJamesServer jamesServer) throws Exception {
         jamesServer.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
-            .addUser(BOB.asString(), BOB_PASSWORD);
+            .addUser(PAYING_USER.asString(), PASSWORD)
+            .addUser(NON_PAYING_USER.asString(), PASSWORD);
+
+        Mono.from(SAAS_REPOSITORY.upsertSaasAccount(PAYING_USER, new SaaSAccount(true, true))).block();
+        Mono.from(SAAS_REPOSITORY.upsertSaasAccount(NON_PAYING_USER, new SaaSAccount(true, false))).block();
 
         requestSpecification = baseRequestSpecBuilder(jamesServer)
             .setBasePath(JMAP_CHAT_COMPLETIONS_ENDPOINT)
-            .setAuth(authScheme(new UserCredential(BOB, BOB_PASSWORD)))
+            .setAuth(authScheme(new UserCredential(PAYING_USER, PASSWORD)))
             .build();
     }
 
@@ -170,5 +191,24 @@ class AIChatCompletionRoutesTest {
         .then()
             .statusCode(SC_UNAUTHORIZED)
             .contentType("application/json");
+    }
+
+    @Test
+    void jmapAiChatCompletionsRouteShouldRejectNonPayingUser(GuiceJamesServer jamesServer) {
+        String incomingPayload = "{test_wrong_auth}";
+
+        RequestSpecification requestSpecification = baseRequestSpecBuilder(jamesServer)
+            .setBasePath(JMAP_CHAT_COMPLETIONS_ENDPOINT)
+            .setAuth(authScheme(new UserCredential(NON_PAYING_USER, PASSWORD)))
+            .build();
+
+        given(requestSpecification)
+            .body(incomingPayload)
+            .when()
+            .post()
+            .then()
+            .statusCode(SC_UNAUTHORIZED)
+            .contentType("application/json")
+            .body("detail", equalTo("User is not eligible for AI chat completion"));
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/AIChatCompletionRoutesTest.java
@@ -62,6 +62,7 @@ class AIChatCompletionRoutesTest {
     static final String PASSWORD = "secret";
     private static final Username PAYING_USER = Username.fromLocalPartWithDomain("paying", DOMAIN);
     private static final Username NON_PAYING_USER = Username.fromLocalPartWithDomain("nonpaying", DOMAIN);
+    private static final Username USER_WITH_NO_SAAS = Username.fromLocalPartWithDomain("no-saas", DOMAIN);
 
     private static final MemorySaaSAccountRepository SAAS_REPOSITORY = new MemorySaaSAccountRepository();
     @RegisterExtension
@@ -89,7 +90,8 @@ class AIChatCompletionRoutesTest {
         jamesServer.getProbe(DataProbeImpl.class).fluent()
             .addDomain(DOMAIN)
             .addUser(PAYING_USER.asString(), PASSWORD)
-            .addUser(NON_PAYING_USER.asString(), PASSWORD);
+            .addUser(NON_PAYING_USER.asString(), PASSWORD)
+            .addUser(USER_WITH_NO_SAAS.asString(), PASSWORD);
 
         Mono.from(SAAS_REPOSITORY.upsertSaasAccount(PAYING_USER, new SaaSAccount(true, true))).block();
         Mono.from(SAAS_REPOSITORY.upsertSaasAccount(NON_PAYING_USER, new SaaSAccount(true, false))).block();
@@ -189,6 +191,24 @@ class AIChatCompletionRoutesTest {
         .when()
             .post()
         .then()
+            .statusCode(SC_UNAUTHORIZED)
+            .contentType("application/json");
+    }
+
+    @Test
+    void jmapAiChatCompletionsRouteShouldRejectUserWhithNoSaasAccount(GuiceJamesServer jamesServer) {
+        String incomingPayload = "{test_wrong_auth}";
+
+        RequestSpecification requestSpecification = baseRequestSpecBuilder(jamesServer)
+            .setBasePath(JMAP_CHAT_COMPLETIONS_ENDPOINT)
+            .setAuth(authScheme(new UserCredential(USER_WITH_NO_SAAS, PASSWORD)))
+            .build();
+
+        given(requestSpecification)
+            .body(incomingPayload)
+            .when()
+            .post()
+            .then()
             .statusCode(SC_UNAUTHORIZED)
             .contentType("application/json");
     }


### PR DESCRIPTION
closes #2514

- [x] Configuration 
- [x] Implementing capability filtering for paying users 
- [x] Test capability filtering for paying users 
- [x] Protect the ChatCompletion backend route
- [x] test  the ChatCompletion backend route protection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable eligibility rules controlling which users can see the AI bot capability and use AI chat completion.
  * AI bot capability visibility is now conditional per user.
  * Ineligible users are blocked with an `UNAUTHORIZED` JSON response for chat completion.
  * Added sample configuration for capability eligibility and RAG partition naming.
* **Documentation**
  * Documented the new `ai.jmap.capability.applyWhen` setting in the sample README.
* **Tests**
  * Added integration test coverage for eligible, ineligible, and missing-SaaS users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->