### PR TITLE
Issue 2524 : fixing coupling between scribe and rag indexation configuration

### DIFF
--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -298,6 +298,25 @@ To enable this functionality, add the following mount to your Docker command:
       linagora/tmail-backend-memory
 ```
 
+### Scribe Configuration
+
+The Scribe feature provides a JMAP endpoint for AI chat completions (`/ai/v1/chat/completions`). It is decoupled from the RAG configuration to allow using a different AI endpoint.
+
+To enable Scribe, add the following keys in your `ai.properties` file:
+
+```properties
+scribe.url=https://chat.lucie.example.com
+scribe.token=fake-token
+scribe.ssl.trust.all.certs=false
+```
+
+**Parameters explanation:**
+
+* `scribe.url`: The URL of the AI endpoint for chat completions (e.g., Mistral API). Mandatory.
+* `scribe.token`: The authorization token for the Scribe AI endpoint. Mandatory.
+* `scribe.ssl.trust.all.certs`: Whether to trust all SSL certificates. Optional, defaults to `true`.
+
+
 ### With the demo server
 
 You can test the AIBot extension with the demo server.

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -262,7 +262,7 @@ openrag.partition.pattern={localPart}.twake.{domainName}
 
 * `openrag.url`: The URL to access the OpenRAG server. Mandatory.
 * `openrag.token`: The token for authorization access to the OpenRAG server. Mandatory.
-* `openrag.ssl.trust.all.certs`: Bypass OpenRAG ssl certificate validation or not. Optional, defaults to true.
+* `openrag.ssl.trust.all.certs`: Bypass OpenRAG ssl certificate validation or not. Optional, defaults to `false` (secure by default). Set to `false` only for local/test deployments with self-signed certificates.
 * `openrag.partition.pattern`: Partition pattern for OpenRAG listener. It must contain `{localPart}` and `{domainName}`. Optional, defaults to `{localPart}.twake.{domainName}`.
 
 The RagListener is responsible for processing mailbox events. It is designed to listen for messages being added to a mailbox, at which point it extracts the message content and sends it to the RAG database for indexing and future retrieval. It also listens for message deletion events to remove the corresponding content from the RAG database.

--- a/tmail-backend/tmail-third-party/ai-bot/README.md
+++ b/tmail-backend/tmail-third-party/ai-bot/README.md
@@ -314,7 +314,9 @@ scribe.ssl.trust.all.certs=false
 
 * `scribe.url`: The URL of the AI endpoint for chat completions (e.g., Mistral API). Mandatory.
 * `scribe.token`: The authorization token for the Scribe AI endpoint. Mandatory.
-* `scribe.ssl.trust.all.certs`: Whether to trust all SSL certificates. Optional, defaults to `true`.
+* `scribe.ssl.trust.all.certs`: Whether to trust all SSL certificates. Optional, defaults to `false` (secure by default). Set to `true` only for local/test deployments with self-signed certificates.
+
+**Backward compatibility:** If `scribe.token` and `scribe.url` are not provided, Scribe falls back to the legacy properties `apiKey` and `baseURL`.
 
 
 ### With the demo server

--- a/tmail-backend/tmail-third-party/ai-bot/sample_conf/ai.properties
+++ b/tmail-backend/tmail-third-party/ai-bot/sample_conf/ai.properties
@@ -5,4 +5,7 @@ openrag.url=https://ragondin.linagora.com
 openrag.token=fake-token
 openrag.ssl.trust.all.certs=false
 openrag.partition.pattern={localPart}.twake.{domainName}
+scribe.url= https://chat.lucie.exemple.com
+scribe.token=fake-token
+scribe.ssl.trust.all.certs=false
 ai.jmap.capability.applyWhen=com.linagora.tmail.saas.filter.SaaSPayingUser

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
@@ -61,6 +61,8 @@ import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.mailet.rag.RagListener;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
+import com.linagora.tmail.scribe.ScribeConfiguration;
+import com.linagora.tmail.scribe.ScribeHttpClient;
 
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 
@@ -145,6 +147,17 @@ public class AIBaseModule extends AbstractModule {
     @Singleton
     public OpenRagHttpClient provideOpenRagHttpClient(RagConfig ragConfig) {
         return new OpenRagHttpClient(ragConfig);
+    }
+
+    @Provides
+    public static ScribeConfiguration provideScribeConfiguration(@Named("ai") Configuration configuration) {
+        return ScribeConfiguration.from(configuration);
+    }
+
+    @Provides
+    @Singleton
+    public ScribeHttpClient provideScribeHttpClient(ScribeConfiguration scribeConfig) {
+        return new ScribeHttpClient(scribeConfig);
     }
 
     @Provides

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
@@ -59,7 +59,7 @@ import com.linagora.tmail.mailet.LangchainAIRedactionalHelper;
 import com.linagora.tmail.mailet.StreamChatLanguageModelFactory;
 import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.mailet.rag.RagListener;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 import com.linagora.tmail.scribe.ScribeClient;
 import com.linagora.tmail.scribe.ScribeConfiguration;
@@ -145,8 +145,8 @@ public class AIBaseModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public OpenRagHttpClient provideOpenRagHttpClient(RagConfig ragConfig) {
-        return new OpenRagHttpClient(ragConfig);
+    public OpenRagClient provideOpenRagClient(RagConfig ragConfig) {
+        return new OpenRagClient(ragConfig);
     }
 
     @Provides

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AIBaseModule.java
@@ -61,8 +61,8 @@ import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.mailet.rag.RagListener;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
+import com.linagora.tmail.scribe.ScribeClient;
 import com.linagora.tmail.scribe.ScribeConfiguration;
-import com.linagora.tmail.scribe.ScribeHttpClient;
 
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 
@@ -156,8 +156,8 @@ public class AIBaseModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public ScribeHttpClient provideScribeHttpClient(ScribeConfiguration scribeConfig) {
-        return new ScribeHttpClient(scribeConfig);
+    public ScribeClient provideScribeClient(ScribeConfiguration scribeConfig) {
+        return new ScribeClient(scribeConfig);
     }
 
     @Provides

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AiHttpClientConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AiHttpClientConfiguration.java
@@ -1,0 +1,62 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.mailet.conf;
+
+import java.net.URL;
+import java.util.Optional;
+
+import com.linagora.tmail.mailet.rag.RagConfig;
+import com.linagora.tmail.scribe.ScribeConfiguration;
+
+public class AiHttpClientConfiguration {
+
+    private String authorizationToken;
+    private Optional<URL> baseUrl;
+    private boolean trustAllCertificates;
+
+    private AiHttpClientConfiguration(String authorizationToken, Optional<URL> baseUrl, boolean trustAllCertificates) {
+        this.authorizationToken = authorizationToken;
+        this.baseUrl = baseUrl;
+        this.trustAllCertificates = trustAllCertificates;
+    }
+
+    public static AiHttpClientConfiguration from(RagConfig ragConfig) {
+        return new AiHttpClientConfiguration(ragConfig.getAuthorizationToken(),
+            ragConfig.getBaseURLOpt(),
+            ragConfig.getTrustAllCertificates());
+    }
+
+    public static AiHttpClientConfiguration from(ScribeConfiguration scribeConfig) {
+        return new AiHttpClientConfiguration(scribeConfig.getAuthorizationToken(),
+            scribeConfig.getBaseURLOpt(),
+            scribeConfig.getTrustAllCertificates());
+    }
+
+
+    public String getAuthorizationToken() {
+        return authorizationToken;
+    }
+
+    public Optional<URL> getBaseURLOpt() {
+        return baseUrl;
+    }
+
+    public boolean getTrustAllCertificates() {
+        return trustAllCertificates;
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AiHttpClientConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/conf/AiHttpClientConfiguration.java
@@ -23,17 +23,9 @@ import java.util.Optional;
 import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.scribe.ScribeConfiguration;
 
-public class AiHttpClientConfiguration {
-
-    private String authorizationToken;
-    private Optional<URL> baseUrl;
-    private boolean trustAllCertificates;
-
-    private AiHttpClientConfiguration(String authorizationToken, Optional<URL> baseUrl, boolean trustAllCertificates) {
-        this.authorizationToken = authorizationToken;
-        this.baseUrl = baseUrl;
-        this.trustAllCertificates = trustAllCertificates;
-    }
+public record AiHttpClientConfiguration(String authorizationToken,
+                                        Optional<URL> baseURLOpt,
+                                        boolean trustAllCertificates) {
 
     public static AiHttpClientConfiguration from(RagConfig ragConfig) {
         return new AiHttpClientConfiguration(ragConfig.getAuthorizationToken(),
@@ -42,21 +34,8 @@ public class AiHttpClientConfiguration {
     }
 
     public static AiHttpClientConfiguration from(ScribeConfiguration scribeConfig) {
-        return new AiHttpClientConfiguration(scribeConfig.getAuthorizationToken(),
-            scribeConfig.getBaseURLOpt(),
-            scribeConfig.getTrustAllCertificates());
-    }
-
-
-    public String getAuthorizationToken() {
-        return authorizationToken;
-    }
-
-    public Optional<URL> getBaseURLOpt() {
-        return baseUrl;
-    }
-
-    public boolean getTrustAllCertificates() {
-        return trustAllCertificates;
+        return new AiHttpClientConfiguration(scribeConfig.authorizationToken(),
+            scribeConfig.baseURLOpt(),
+            scribeConfig.trustAllCertificates());
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagConfig.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagConfig.java
@@ -56,7 +56,7 @@ public class RagConfig {
     public static RagConfig from(Configuration configuration) throws IllegalArgumentException {
         String tokenParam = Optional.ofNullable(configuration.getString(AUTHORIZATION_TOKEN_PARAMETER_NAME, null))
             .orElseThrow(() ->  new IllegalArgumentException("No value for " + AUTHORIZATION_TOKEN_PARAMETER_NAME + " parameter was provided."));
-        boolean trustAllCertificatesParam = configuration.getBoolean(TRUST_ALL_CERTIFICATES_PARAMETER_NAME, true);
+        boolean trustAllCertificatesParam = configuration.getBoolean(TRUST_ALL_CERTIFICATES_PARAMETER_NAME, false);
 
         String baseUrlParam = Optional.ofNullable(configuration.getString(BASE_URL_PARAMETER_NAME,null))
             .orElseThrow(() ->  new IllegalArgumentException("No value for " + BASE_URL_PARAMETER_NAME + " parameter was provided."));

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagDeletionListener.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagDeletionListener.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.linagora.tmail.james.jmap.settings.JmapSettings;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.mailet.rag.httpclient.DocumentId;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 
 import reactor.core.publisher.Mono;
@@ -56,19 +56,19 @@ public class RagDeletionListener implements EventListener.ReactiveGroupEventList
     private final JmapSettingsRepository jmapSettingsRepository;
     private final MailboxSessionMapperFactory mapperFactory;
     private final Partition.Factory partitionFactory;
-    private final OpenRagHttpClient openRagHttpClient;
+    private final OpenRagClient openRagClient;
 
     @Inject
     public RagDeletionListener(JmapSettingsRepository jmapSettingsRepository,
                                SessionProvider sessionProvider,
                                MailboxSessionMapperFactory mapperFactory,
                                Partition.Factory partitionFactory,
-                               OpenRagHttpClient openRagHttpClient) {
+                               OpenRagClient openRagClient) {
         this.session = sessionProvider.createSystemSession(ADMIN);
         this.jmapSettingsRepository = jmapSettingsRepository;
         this.mapperFactory = mapperFactory;
         this.partitionFactory = partitionFactory;
-        this.openRagHttpClient = openRagHttpClient;
+        this.openRagClient = openRagClient;
     }
 
     @Override
@@ -119,7 +119,7 @@ public class RagDeletionListener implements EventListener.ReactiveGroupEventList
         Partition partition = partitionFactory.forUsername(contentDeletionEvent.getUsername());
         DocumentId documentId = new DocumentId(contentDeletionEvent.messageId());
 
-        return openRagHttpClient.deleteDocument(partition, documentId)
+        return openRagClient.deleteDocument(partition, documentId)
             .doOnSuccess(any -> LOGGER.debug("Deleted RAG document {} with partition {} for user {}",
                 documentId.asString(), partition.partitionName(), contentDeletionEvent.getUsername().asString()))
             .doOnError(error -> LOGGER.error("Failed to delete RAG document {} with partition {} for user {}",

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagListener.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/RagListener.java
@@ -71,7 +71,7 @@ import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.james.jmap.settings.JmapSettings;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.mailet.rag.httpclient.DocumentId;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 
 import reactor.core.publisher.Flux;
@@ -93,13 +93,13 @@ public class RagListener implements EventListener.ReactiveGroupEventListener {
     private final ThreadIdGuessingAlgorithm threadIdGuessingAlgorithm;
     private final JmapSettingsRepository jmapSettingsRepository;
     private final Partition.Factory partitionFactory;
-    private final OpenRagHttpClient openRagHttpClient;
+    private final OpenRagClient openRagClient;
     private final ApplyWhenFilter applyWhenFilter;
 
     @Inject
     public RagListener(MailboxManager mailboxManager, MessageIdManager messageIdManager, SystemMailboxesProvider systemMailboxesProvider,
                        ThreadIdGuessingAlgorithm threadIdGuessingAlgorithm, JmapSettingsRepository jmapSettingsRepository,
-                       Partition.Factory partitionFactory, OpenRagHttpClient openRagHttpClient, GuiceLoader guiceLoader,
+                       Partition.Factory partitionFactory, OpenRagClient openRagClient, GuiceLoader guiceLoader,
                        HierarchicalConfiguration<ImmutableNode> configuration) {
         this.mailboxManager = mailboxManager;
         this.messageIdManager = messageIdManager;
@@ -107,7 +107,7 @@ public class RagListener implements EventListener.ReactiveGroupEventListener {
         this.threadIdGuessingAlgorithm = threadIdGuessingAlgorithm;
         this.jmapSettingsRepository = jmapSettingsRepository;
         this.partitionFactory = partitionFactory;
-        this.openRagHttpClient = openRagHttpClient;
+        this.openRagClient = openRagClient;
         this.applyWhenFilter = resolveApplyWhenFilter(configuration, guiceLoader);
     }
 
@@ -177,7 +177,7 @@ public class RagListener implements EventListener.ReactiveGroupEventListener {
             .doOnSuccess(text -> LOGGER.debug("RAG Listener successfully processed mailContent ***** \n{}\n *****", new DocumentId(messageResult.getMessageId())))
             .flatMap(content -> computeMetaData(messageResult, session)
                 .flatMap(metaData ->
-                    openRagHttpClient.addDocument(
+                    openRagClient.addDocument(
                     partitionFactory.forUsername(addedEvent.getUsername()),
                     new DocumentId(messageResult.getMessageId()),
                     content,
@@ -333,14 +333,14 @@ public class RagListener implements EventListener.ReactiveGroupEventListener {
     @VisibleForTesting
     public RagListener(MailboxManager mailboxManager, MessageIdManager messageIdManager, SystemMailboxesProvider systemMailboxesProvider,
                        ThreadIdGuessingAlgorithm threadIdGuessingAlgorithm, JmapSettingsRepository jmapSettingsRepository,
-                       Partition.Factory partitionFactory, OpenRagHttpClient openRagHttpClient, ApplyWhenFilter applyWhenFilter) {
+                       Partition.Factory partitionFactory, OpenRagClient openRagClient, ApplyWhenFilter applyWhenFilter) {
         this.mailboxManager = mailboxManager;
         this.messageIdManager = messageIdManager;
         this.systemMailboxesProvider = systemMailboxesProvider;
         this.threadIdGuessingAlgorithm = threadIdGuessingAlgorithm;
         this.jmapSettingsRepository = jmapSettingsRepository;
         this.partitionFactory = partitionFactory;
-        this.openRagHttpClient = openRagHttpClient;
+        this.openRagClient = openRagClient;
         this.applyWhenFilter = applyWhenFilter;
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/AiHttpClientFactory.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/AiHttpClientFactory.java
@@ -26,17 +26,16 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.netty.http.client.HttpClient;
 
-
 public final class AiHttpClientFactory {
 
     public static HttpClient create(AiHttpClientConfiguration configuration) {
         HttpClient client = HttpClient.create()
-            .baseUrl(configuration.getBaseURLOpt().orElseThrow().toString())
+            .baseUrl(configuration.baseURLOpt().orElseThrow().toString())
             .headers(headers -> headers
-                .add("Authorization", "Bearer " + configuration.getAuthorizationToken())
+                .add("Authorization", "Bearer " + configuration.authorizationToken())
                 .add("Accept", "application/json"));
 
-        return configuration.getTrustAllCertificates()
+        return configuration.trustAllCertificates()
             ? client.secure(spec -> spec.sslContext(buildInsecureSslContext()))
             : client.secure();
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/AiHttpClientFactory.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/AiHttpClientFactory.java
@@ -1,0 +1,53 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.mailet.rag.httpclient;
+
+import javax.net.ssl.SSLException;
+
+import com.linagora.tmail.mailet.conf.AiHttpClientConfiguration;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import reactor.netty.http.client.HttpClient;
+
+
+public final class AiHttpClientFactory {
+
+    public static HttpClient create(AiHttpClientConfiguration configuration) {
+        HttpClient client = HttpClient.create()
+            .baseUrl(configuration.getBaseURLOpt().orElseThrow().toString())
+            .headers(headers -> headers
+                .add("Authorization", "Bearer " + configuration.getAuthorizationToken())
+                .add("Accept", "application/json"));
+
+        return configuration.getTrustAllCertificates()
+            ? client.secure(spec -> spec.sslContext(buildInsecureSslContext()))
+            : client.secure();
+    }
+
+    public static SslContext buildInsecureSslContext() {
+        try {
+            return SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .build();
+        } catch (SSLException e) {
+            throw new RuntimeException("Failed to create insecure SSL context", e);
+        }
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/OpenRagClient.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/OpenRagClient.java
@@ -39,8 +39,8 @@ import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
-public class OpenRagHttpClient {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenRagHttpClient.class);
+public class OpenRagClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenRagClient.class);
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String RAG_DOCUMENT_ENDPOINT = "/indexer/partition/%s/file/%s";
 
@@ -48,7 +48,7 @@ public class OpenRagHttpClient {
     private final ObjectMapper objectMapper;
 
     @Inject
-    public OpenRagHttpClient(RagConfig configuration) {
+    public OpenRagClient(RagConfig configuration) {
         this.objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
         this.httpClient = AiHttpClientFactory.create(AiHttpClientConfiguration.from(configuration));
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/OpenRagHttpClient.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/mailet/rag/httpclient/OpenRagHttpClient.java
@@ -22,8 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import javax.net.ssl.SSLException;
-
 import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
@@ -31,14 +29,11 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.linagora.tmail.mailet.conf.AiHttpClientConfiguration;
 import com.linagora.tmail.mailet.rag.RagConfig;
 
-import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClient;
@@ -46,10 +41,7 @@ import reactor.netty.http.client.HttpClientResponse;
 
 public class OpenRagHttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenRagHttpClient.class);
-    private static final String API_KEY_HEADER = "Authorization";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
-    private static final String APPLICATION_JSON = "application/json";
-    private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
     private static final String RAG_DOCUMENT_ENDPOINT = "/indexer/partition/%s/file/%s";
 
     private final HttpClient httpClient;
@@ -58,7 +50,7 @@ public class OpenRagHttpClient {
     @Inject
     public OpenRagHttpClient(RagConfig configuration) {
         this.objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
-        this.httpClient = buildReactorNettyHttpClient(configuration);
+        this.httpClient = AiHttpClientFactory.create(AiHttpClientConfiguration.from(configuration));
     }
 
     public Mono<String> addDocument(Partition partition, DocumentId documentId, String textualContent, Map<String, String> metadata) {
@@ -121,34 +113,4 @@ public class OpenRagHttpClient {
             return (Mono.error(new RuntimeException("Failed to " + method.name() + " document: " + documentId.asString() + " (status: " + res.status().code() + ")")));
         }
     }
-
-    public Mono<ChatCompletionResult> proxyChatCompletions(byte[] payload) {
-        return httpClient
-            .headers(headers -> headers.add(CONTENT_TYPE_HEADER, APPLICATION_JSON))
-            .post()
-            .uri(CHAT_COMPLETIONS_ENDPOINT)
-            .send(Mono.just(Unpooled.wrappedBuffer(payload)))
-            .responseSingle((response, content) -> content
-                .asByteArray()
-                .map(body -> new ChatCompletionResult(body, response.status().code(), response.responseHeaders())));
-    }
-
-    private static SslContext buildInsecureSslContext() {
-        try {
-            return SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .build();
-        } catch (SSLException e) {
-            throw new RuntimeException("Failed to create insecure SSL context", e);
-        }
-    }
-
-    private HttpClient buildReactorNettyHttpClient(RagConfig configuration) {
-        HttpClient client = HttpClient.create()
-            .baseUrl(configuration.getBaseURLOpt().get().toString())
-            .headers(headers -> headers.add(API_KEY_HEADER, "Bearer " + configuration.getAuthorizationToken())
-                .add("Accept", APPLICATION_JSON));
-        return (configuration.getTrustAllCertificates() ? client.secure(spec -> spec.sslContext(buildInsecureSslContext())) : client.secure());
-    }
-
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ChatCompletionResult.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ChatCompletionResult.java
@@ -16,7 +16,7 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.tmail.mailet.rag.httpclient;
+package com.linagora.tmail.scribe;
 
 import io.netty.handler.codec.http.HttpHeaders;
 

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeClient.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeClient.java
@@ -1,0 +1,52 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.scribe;
+
+import jakarta.inject.Inject;
+
+import com.linagora.tmail.mailet.conf.AiHttpClientConfiguration;
+import com.linagora.tmail.mailet.rag.httpclient.AiHttpClientFactory;
+
+import io.netty.buffer.Unpooled;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+public class ScribeClient {
+
+    private static final String CONTENT_TYPE_HEADER = "Content-Type";
+    private static final String APPLICATION_JSON = "application/json";
+    private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
+
+    private final HttpClient httpClient;
+
+    @Inject
+    public ScribeClient(ScribeConfiguration configuration) {
+        this.httpClient = AiHttpClientFactory.create(AiHttpClientConfiguration.from(configuration));
+    }
+
+    public Mono<ChatCompletionResult> proxyChatCompletions(byte[] payload) {
+        return httpClient
+            .headers(headers -> headers.add(CONTENT_TYPE_HEADER, APPLICATION_JSON))
+            .post()
+            .uri(CHAT_COMPLETIONS_ENDPOINT)
+            .send(Mono.just(Unpooled.wrappedBuffer(payload)))
+            .responseSingle((response, content) -> content
+                .asByteArray()
+                .map(body -> new ChatCompletionResult(body, response.status().code(), response.responseHeaders())));
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
@@ -1,0 +1,110 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.scribe;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+public class ScribeConfiguration {
+    public static String API_KEY_PARAMETER_NAME = "scribe.token";
+    public static String BASE_URL_PARAMETER_NAME = "scribe.url";
+    public static final String TRUST_ALL_CERTIFICATES_PARAMETER_NAME = "scribe.ssl.trust.all.certs";
+
+    private final String authorizationToken;
+    private final Optional<URL> baseURLOpt;
+    private final boolean trustAllCertificates;
+
+    public ScribeConfiguration(String token, Optional<URL> baseURLOpt, boolean trustAllCertificates) {
+        Preconditions.checkNotNull(token);
+        Preconditions.checkNotNull(baseURLOpt);
+        Preconditions.checkNotNull(trustAllCertificates);
+
+        this.authorizationToken = token;
+        this.baseURLOpt = baseURLOpt;
+        this.trustAllCertificates = trustAllCertificates;
+    }
+
+    public static ScribeConfiguration from(Configuration configuration) throws IllegalArgumentException {
+        String apiKeyParam = Optional.ofNullable(configuration.getString(API_KEY_PARAMETER_NAME, null))
+            .orElseThrow(() ->  new IllegalArgumentException("No value for " + API_KEY_PARAMETER_NAME + " parameter was provided."));
+        String baseUrlParam = Optional.ofNullable(configuration.getString(BASE_URL_PARAMETER_NAME,null))
+            .orElseThrow(() ->  new IllegalArgumentException("No value for " + BASE_URL_PARAMETER_NAME + " parameter was provided."));
+
+        Optional<URL> baseURLOpt = Optional.ofNullable(baseUrlParam)
+            .filter(baseUrlString -> !Strings.isNullOrEmpty(baseUrlString))
+            .flatMap(ScribeConfiguration::baseURLStringToURL);
+
+        boolean trustAllCertificatesParam = configuration.getBoolean(TRUST_ALL_CERTIFICATES_PARAMETER_NAME, true);
+
+        try {
+            return new ScribeConfiguration(apiKeyParam, baseURLOpt, trustAllCertificatesParam);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<URL> baseURLStringToURL(String baseUrlString) {
+        try {
+            return Optional.of(URI.create(baseUrlString).toURL());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Invalid Scribe API base URL", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScribeConfiguration that = (ScribeConfiguration) o;
+        return Objects.equals(authorizationToken, that.authorizationToken) &&
+            Objects.equals(Optional.ofNullable(baseURLOpt).map(opt -> opt.map(URL::toString)),
+                Optional.ofNullable(that.baseURLOpt).map(opt -> opt.map(URL::toString))) &&
+            Objects.equals(trustAllCertificates, that.trustAllCertificates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizationToken,
+            Optional.ofNullable(baseURLOpt).map(opt -> opt.map(URL::toString)),
+            trustAllCertificates);
+    }
+
+    public String getAuthorizationToken() {
+        return authorizationToken;
+    }
+
+    public boolean getTrustAllCertificates() {
+        return trustAllCertificates;
+    }
+
+    public Optional<URL> getBaseURLOpt() {
+        return baseURLOpt;
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
@@ -60,7 +60,7 @@ public record ScribeConfiguration(String authorizationToken,
             .filter(baseUrlString -> !Strings.isNullOrEmpty(baseUrlString))
             .flatMap(ScribeConfiguration::baseURLStringToURL);
 
-        boolean trustAllCertificatesParam = configuration.getBoolean(TRUST_ALL_CERTIFICATES_PARAMETER_NAME, true);
+        boolean trustAllCertificatesParam = configuration.getBoolean(TRUST_ALL_CERTIFICATES_PARAMETER_NAME, false);
 
         try {
             return new ScribeConfiguration(apiKeyParam, baseURLOpt, trustAllCertificatesParam);

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
@@ -35,25 +35,26 @@ public record ScribeConfiguration(String authorizationToken,
     public static final String BASE_URL_PARAMETER_NAME = "scribe.url";
     public static final String TRUST_ALL_CERTIFICATES_PARAMETER_NAME = "scribe.ssl.trust.all.certs";
 
-    private final String authorizationToken;
-    private final Optional<URL> baseURLOpt;
-    private final boolean trustAllCertificates;
+    public static final String LEGACY_API_KEY_PARAMETER_NAME = "apiKey";
+    public static final String LEGACY_BASE_URL_PARAMETER_NAME = "baseURL";
 
     public ScribeConfiguration {
         Preconditions.checkNotNull(authorizationToken);
         Preconditions.checkNotNull(baseURLOpt);
-        Preconditions.checkNotNull(trustAllCertificates);
-
-        this.authorizationToken = token;
-        this.baseURLOpt = baseURLOpt;
-        this.trustAllCertificates = trustAllCertificates;
     }
 
     public static ScribeConfiguration from(Configuration configuration) throws IllegalArgumentException {
         String apiKeyParam = Optional.ofNullable(configuration.getString(API_KEY_PARAMETER_NAME, null))
-            .orElseThrow(() ->  new IllegalArgumentException("No value for " + API_KEY_PARAMETER_NAME + " parameter was provided."));
-        String baseUrlParam = Optional.ofNullable(configuration.getString(BASE_URL_PARAMETER_NAME,null))
-            .orElseThrow(() ->  new IllegalArgumentException("No value for " + BASE_URL_PARAMETER_NAME + " parameter was provided."));
+            .or(() -> Optional.ofNullable(configuration.getString(LEGACY_API_KEY_PARAMETER_NAME, null)))
+            .orElseThrow(() -> new IllegalArgumentException(
+                "No value for " + API_KEY_PARAMETER_NAME + " parameter was provided. " +
+                "(Fallback to legacy property " + LEGACY_API_KEY_PARAMETER_NAME + " also failed)."));
+
+        String baseUrlParam = Optional.ofNullable(configuration.getString(BASE_URL_PARAMETER_NAME, null))
+            .or(() -> Optional.ofNullable(configuration.getString(LEGACY_BASE_URL_PARAMETER_NAME, null)))
+            .orElseThrow(() -> new IllegalArgumentException(
+                "No value for " + BASE_URL_PARAMETER_NAME + " parameter was provided. " +
+                "(Fallback to legacy property " + LEGACY_BASE_URL_PARAMETER_NAME + " also failed)."));
 
         Optional<URL> baseURLOpt = Optional.ofNullable(baseUrlParam)
             .filter(baseUrlString -> !Strings.isNullOrEmpty(baseUrlString))

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/java/com/linagora/tmail/scribe/ScribeConfiguration.java
@@ -20,7 +20,6 @@ package com.linagora.tmail.scribe;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.configuration2.Configuration;
@@ -28,17 +27,20 @@ import org.apache.commons.configuration2.Configuration;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
-public class ScribeConfiguration {
-    public static String API_KEY_PARAMETER_NAME = "scribe.token";
-    public static String BASE_URL_PARAMETER_NAME = "scribe.url";
+public record ScribeConfiguration(String authorizationToken,
+                                  Optional<URL> baseURLOpt,
+                                  boolean trustAllCertificates) {
+
+    public static final String API_KEY_PARAMETER_NAME = "scribe.token";
+    public static final String BASE_URL_PARAMETER_NAME = "scribe.url";
     public static final String TRUST_ALL_CERTIFICATES_PARAMETER_NAME = "scribe.ssl.trust.all.certs";
 
     private final String authorizationToken;
     private final Optional<URL> baseURLOpt;
     private final boolean trustAllCertificates;
 
-    public ScribeConfiguration(String token, Optional<URL> baseURLOpt, boolean trustAllCertificates) {
-        Preconditions.checkNotNull(token);
+    public ScribeConfiguration {
+        Preconditions.checkNotNull(authorizationToken);
         Preconditions.checkNotNull(baseURLOpt);
         Preconditions.checkNotNull(trustAllCertificates);
 
@@ -69,42 +71,8 @@ public class ScribeConfiguration {
     private static Optional<URL> baseURLStringToURL(String baseUrlString) {
         try {
             return Optional.of(URI.create(baseUrlString).toURL());
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Invalid Scribe API base URL", e);
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            throw new RuntimeException("Invalid Scribe API base URL: " + baseUrlString, e);
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ScribeConfiguration that = (ScribeConfiguration) o;
-        return Objects.equals(authorizationToken, that.authorizationToken) &&
-            Objects.equals(Optional.ofNullable(baseURLOpt).map(opt -> opt.map(URL::toString)),
-                Optional.ofNullable(that.baseURLOpt).map(opt -> opt.map(URL::toString))) &&
-            Objects.equals(trustAllCertificates, that.trustAllCertificates);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(authorizationToken,
-            Optional.ofNullable(baseURLOpt).map(opt -> opt.map(URL::toString)),
-            trustAllCertificates);
-    }
-
-    public String getAuthorizationToken() {
-        return authorizationToken;
-    }
-
-    public boolean getTrustAllCertificates() {
-        return trustAllCertificates;
-    }
-
-    public Optional<URL> getBaseURLOpt() {
-        return baseURLOpt;
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AIChatCompletionRoutes.scala
+++ b/tmail-backend/tmail-third-party/ai-bot/src/main/scala/com/linagora/tmail/jmap/aibot/AIChatCompletionRoutes.scala
@@ -23,8 +23,7 @@ import java.util.stream
 import java.util.stream.Stream
 import com.linagora.tmail.james.jmap.event.ApplyWhenFilter
 import com.linagora.tmail.jmap.aibot.AIChatCompletionRoutes.LOGGER
-import com.linagora.tmail.mailet.rag.RagConfig
-import com.linagora.tmail.mailet.rag.httpclient.{ChatCompletionResult, OpenRagHttpClient}
+import com.linagora.tmail.scribe.{ChatCompletionResult, ScribeClient}
 import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_LENGTH, CONTENT_TYPE}
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpResponseStatus.{INTERNAL_SERVER_ERROR, UNAUTHORIZED}
@@ -48,10 +47,9 @@ object AIChatCompletionRoutes {
 }
 
 class AIChatCompletionRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
-                                       val ragConfig: RagConfig,
+                                       val scribeClient: ScribeClient,
                                        val metricFactory: MetricFactory,
                                        val applyWhenFilter: ApplyWhenFilter) extends JMAPRoutes {
-  private val openRagHttpClient = new OpenRagHttpClient(ragConfig)
   private val jmapAiUri = "/ai/v1/chat/completions"
 
   override def routes(): stream.Stream[JMAPRoute] = Stream.of(
@@ -91,7 +89,7 @@ class AIChatCompletionRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authen
         .aggregate()
         .asByteArray())
       .flatMap(input => SMono.fromPublisher(metricFactory.decoratePublisherWithTimerMetric("JMAP-ai-chat-completion",
-          openRagHttpClient.proxyChatCompletions(input))))
+          scribeClient.proxyChatCompletions(input))))
       .flatMap(result => sendResponse(response, result)
         .`then`())
 

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/extension/WireMockAiServerExtension.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/extension/WireMockAiServerExtension.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
+import com.linagora.tmail.scribe.ScribeConfiguration;
 import org.apache.james.GuiceModuleTestExtension;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -41,15 +42,15 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.linagora.tmail.mailet.rag.RagConfig;
 
-public class WireMockRagServerExtension extends WireMockExtension implements GuiceModuleTestExtension {
+public class WireMockAiServerExtension extends WireMockExtension implements GuiceModuleTestExtension {
     private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
     private static final String RAG_INDEXER_ENDPOINT = "/indexer/partition/.*/file/.*";
 
-    public WireMockRagServerExtension(Builder builder) {
+    public WireMockAiServerExtension(Builder builder) {
         super(builder);
     }
 
-    public WireMockRagServerExtension() {
+    public WireMockAiServerExtension() {
         this(WireMockExtension.extensionOptions()
             .options(wireMockConfig().dynamicPort()));
     }
@@ -69,6 +70,12 @@ public class WireMockRagServerExtension extends WireMockExtension implements Gui
             @Singleton
             public RagConfig ragConfig() {
                 return new RagConfig("fake-token", true, Optional.of(getBaseUrl()), "{localPart}.twake.{domainName}");
+            }
+
+            @Provides
+            @Singleton
+            public ScribeConfiguration scribeConfiguration() {
+                return new ScribeConfiguration("fake-token", Optional.of(getBaseUrl()), true);
             }
         };
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagConfigTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagConfigTest.java
@@ -70,14 +70,14 @@ public class RagConfigTest {
     }
 
     @Test
-    public void shouldConfigureTrustAllCertsTrueWhenMissingTrustAllCerts() {
+    public void shouldDefaultToCertificateValidationWhenMissingTrustAllCerts() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("openrag.url", "https://ragondin.linagora.com");
         configuration.addProperty("openrag.token", "fake-token");
         configuration.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         RagConfig actual = RagConfig.from(configuration);
 
-        assertThat(actual.getTrustAllCertificates()).isTrue();
+        assertThat(actual.getTrustAllCertificates()).isFalse();
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagDeletionListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagDeletionListenerTest.java
@@ -61,7 +61,7 @@ import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
 import com.linagora.tmail.james.jmap.settings.MemoryJmapSettingsRepository;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 
 import reactor.core.publisher.Flux;
@@ -95,7 +95,7 @@ public class RagDeletionListenerTest {
         configuration.addProperty("openrag.ssl.trust.all.certs", "true");
         configuration.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         RagConfig ragConfig = RagConfig.from(configuration);
-        OpenRagHttpClient openRagHttpClient = new OpenRagHttpClient(ragConfig);
+        OpenRagClient openRagClient = new OpenRagClient(ragConfig);
         Partition.Factory partitionFactory = Partition.Factory.fromPattern(ragConfig.getPartitionPattern());
 
         jmapSettingsRepository = new MemoryJmapSettingsRepository();
@@ -112,7 +112,7 @@ public class RagDeletionListenerTest {
         when(mapperFactory.getMailboxMapper(session)).thenReturn(mailboxMapper);
         when(messageIdMapper.findMailboxesReactive(TestMessageId.of(1))).thenReturn(reactor.core.publisher.Flux.empty());
 
-        RagDeletionListener ragDeletionListener = new RagDeletionListener(jmapSettingsRepository, sessionProvider, mapperFactory, partitionFactory, openRagHttpClient);
+        RagDeletionListener ragDeletionListener = new RagDeletionListener(jmapSettingsRepository, sessionProvider, mapperFactory, partitionFactory, openRagClient);
         eventBus.register(ragDeletionListener);
     }
 

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagDeletionListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagDeletionListenerTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableMap;
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
 import com.linagora.tmail.james.jmap.settings.MemoryJmapSettingsRepository;
@@ -70,7 +70,7 @@ import reactor.core.publisher.Mono;
 public class RagDeletionListenerTest {
 
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     private EventBus eventBus;
     private JmapSettingsRepository jmapSettingsRepository;

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerIntegrationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerIntegrationTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.common.probe.JmapSettingsProbe;
@@ -60,7 +60,7 @@ public class RagListenerIntegrationTest {
     private static final String RAG_INDEXER_ENDPOINT = "/indexer/partition/.*/file/.*";
 
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     private static final byte[] CONTENT = (
         "Subject: Test Subject\r\n" +

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
@@ -61,7 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableMap;
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
@@ -92,7 +92,7 @@ class RagListenerTest {
             "Body of the email").getBytes(StandardCharsets.UTF_8);
 
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     StoreMailboxManager mailboxManager;
     RagListener ragListener;

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/RagListenerTest.java
@@ -66,7 +66,7 @@ import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
 import com.linagora.tmail.james.jmap.settings.MemoryJmapSettingsRepository;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 
 class RagListenerTest {
@@ -117,7 +117,7 @@ class RagListenerTest {
     MailboxId bobMailBoxId;
     MailboxId aliceInboxId;
     MemoryEventDeadLetters eventDeadLetters;
-    OpenRagHttpClient openRagHttpClient;
+    OpenRagClient openRagClient;
     Partition.Factory partitionFactory;
     RagConfig ragConfig;
     JmapSettingsRepository jmapSettingsRepository;
@@ -178,13 +178,13 @@ class RagListenerTest {
         configuration.addProperty("openrag.ssl.trust.all.certs", "true");
         configuration.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         ragConfig = RagConfig.from(configuration);
-        openRagHttpClient = new OpenRagHttpClient(ragConfig);
+        openRagClient = new OpenRagClient(ragConfig);
         partitionFactory = Partition.Factory.fromPattern(ragConfig.getPartitionPattern());
         jmapSettingsRepository = new MemoryJmapSettingsRepository();
         jmapSettingsRepositoryUtils = new JmapSettingsRepositoryJavaUtils(jmapSettingsRepository);
         ApplyWhenFilter applyWhenFilter = new ApplyWhenFilter.Always();
         ragListener = new RagListener(mailboxManager, messageIdManager, systemMailboxesProvider, threadIdGuessingAlgorithm,
-            jmapSettingsRepository, partitionFactory, openRagHttpClient, applyWhenFilter);
+            jmapSettingsRepository, partitionFactory, openRagClient, applyWhenFilter);
 
         jmapSettingsRepositoryUtils.reset(BOB, ImmutableMap.of("ai.rag.enabled", "true"));
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/SaaSUserRagListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/SaaSUserRagListenerTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableMap;
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
@@ -79,7 +79,7 @@ class SaaSUserRagListenerTest {
             "Body of the email").getBytes(StandardCharsets.UTF_8);
 
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     StoreMailboxManager mailboxManager;
     RagListener ragListener;

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/SaaSUserRagListenerTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/SaaSUserRagListenerTest.java
@@ -57,7 +57,7 @@ import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepository;
 import com.linagora.tmail.james.jmap.settings.JmapSettingsRepositoryJavaUtils;
 import com.linagora.tmail.james.jmap.settings.MemoryJmapSettingsRepository;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 import com.linagora.tmail.saas.api.memory.MemorySaaSAccountRepository;
 import com.linagora.tmail.saas.filter.SaaSPayingUser;
@@ -92,7 +92,7 @@ class SaaSUserRagListenerTest {
     JmapSettingsRepository jmapSettingsRepository;
     JmapSettingsRepositoryJavaUtils jmapSettingsRepositoryUtils;
     MemorySaaSAccountRepository saasAccountRepository;
-    OpenRagHttpClient openRagHttpClient;
+    OpenRagClient openRagClient;
     Partition.Factory partitionFactory;
 
     @BeforeEach
@@ -126,7 +126,7 @@ class SaaSUserRagListenerTest {
         config.addProperty("openrag.ssl.trust.all.certs", "true");
         config.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         RagConfig ragConfig = RagConfig.from(config);
-        openRagHttpClient = new OpenRagHttpClient(ragConfig);
+        openRagClient = new OpenRagClient(ragConfig);
         partitionFactory = Partition.Factory.fromPattern(ragConfig.getPartitionPattern());
 
         jmapSettingsRepository = new MemoryJmapSettingsRepository();
@@ -137,7 +137,7 @@ class SaaSUserRagListenerTest {
         ApplyWhenFilter applyWhenFilter = new SaaSPayingUser(saasAccountRepository);
 
         ragListener = new RagListener(mailboxManager, messageIdManager, systemMailboxesProvider,
-            threadIdGuessingAlgorithm, jmapSettingsRepository, partitionFactory, openRagHttpClient, applyWhenFilter);
+            threadIdGuessingAlgorithm, jmapSettingsRepository, partitionFactory, openRagClient, applyWhenFilter);
 
         jmapSettingsRepositoryUtils.reset(BOB, ImmutableMap.of("ai.rag.enabled", "true"));
     }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagClientTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagClientTest.java
@@ -32,17 +32,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.mailet.rag.httpclient.DocumentId;
-import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
+import com.linagora.tmail.mailet.rag.httpclient.OpenRagClient;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagUnexpectedException;
 import com.linagora.tmail.mailet.rag.httpclient.Partition;
 
-public class OpenRagHttpClientTest {
+public class OpenRagClientTest {
     private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
 
     @RegisterExtension
     static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
-    private OpenRagHttpClient client;
+    private OpenRagClient client;
 
     @BeforeEach
     void setUp() {
@@ -52,7 +52,7 @@ public class OpenRagHttpClientTest {
         configuration.addProperty("openrag.ssl.trust.all.certs", "true");
         configuration.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         RagConfig ragConfig = RagConfig.from(configuration);
-        client = new OpenRagHttpClient(ragConfig);
+        client = new OpenRagClient(ragConfig);
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagHttpClientTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagHttpClientTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.mailet.rag.RagConfig;
 import com.linagora.tmail.mailet.rag.httpclient.DocumentId;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
@@ -40,7 +40,7 @@ public class OpenRagHttpClientTest {
     private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
 
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     private OpenRagHttpClient client;
 

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagHttpClientTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/mailet/rag/http/OpenRagHttpClientTest.java
@@ -18,27 +18,19 @@
 
 package com.linagora.tmail.mailet.rag.http;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.StandardCharsets;
-
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.james.mailbox.model.TestMessageId;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.tmail.extension.WireMockRagServerExtension;
 import com.linagora.tmail.mailet.rag.RagConfig;
-import com.linagora.tmail.mailet.rag.httpclient.ChatCompletionResult;
 import com.linagora.tmail.mailet.rag.httpclient.DocumentId;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagHttpClient;
 import com.linagora.tmail.mailet.rag.httpclient.OpenRagUnexpectedException;
@@ -61,76 +53,6 @@ public class OpenRagHttpClientTest {
         configuration.addProperty("openrag.partition.pattern", "{localPart}.twake.{domainName}");
         RagConfig ragConfig = RagConfig.from(configuration);
         client = new OpenRagHttpClient(ragConfig);
-    }
-
-    @Test
-    void proxyChatCompletionsShouldForwardPayloadAndHeadersAndReturnExactResponse() {
-        String resultBody = """
-            {
-              "id": "1234",
-              "choices": [
-                {
-                  "finish_reason": "stop",
-                  "index": 0,
-                  "message": {
-                    "content": "The glass green worm around Anvers"
-                  }
-                }
-              ]
-            }
-            """;
-
-        wireMockRagServerExtension.setChatCompletionResponse(200, resultBody);
-
-        String incomingPayload = """
-            {
-               "messages" : [
-                 {"role": "system", "content": "You are a translator."},
-                 {"role": "user", "content": "Translate this text:"},
-                 {"role": "user", "content": "Le ver vert en verre vers Anvers"}
-               ],
-                "metadata": {
-                 "action": "translate"
-               },
-               "stream": false
-            }""";
-
-        ChatCompletionResult result = client.proxyChatCompletions(incomingPayload.getBytes(StandardCharsets.UTF_8)).block();
-
-        verify(1, postRequestedFor(urlMatching(CHAT_COMPLETIONS_ENDPOINT)));
-
-        verify(postRequestedFor(urlMatching(CHAT_COMPLETIONS_ENDPOINT))
-            .withHeader("Authorization", equalTo("Bearer dummy-token"))
-            .withHeader("Content-Type", containing("application/json"))
-            .withRequestBody(equalToJson(incomingPayload)));
-
-        String body = new String(result.body(), StandardCharsets.UTF_8);
-        SoftAssertions.assertSoftly(solftly -> {
-            solftly.assertThat(result.status()).isEqualTo(200);
-            solftly.assertThat(result.headers().get("Content-Type")).isEqualTo("application/json");
-            solftly.assertThat(body).isEqualTo(resultBody);
-        });
-    }
-
-    @Test
-    void proxyChatCompletionsShouldReturnExactErrorResponses() {
-        String resultBody = """
-            {
-              "details": "Internal server error..."
-            }
-            """;
-
-        String incomingPayload = "{bad_payload}";
-
-        wireMockRagServerExtension.setChatCompletionResponse(500, resultBody);
-
-        ChatCompletionResult result = client.proxyChatCompletions(incomingPayload.getBytes(StandardCharsets.UTF_8)).block();
-        String body = new String(result.body(), StandardCharsets.UTF_8);
-        SoftAssertions.assertSoftly(solftly -> {
-            solftly.assertThat(result.status()).isEqualTo(500);
-            solftly.assertThat(result.headers().get("Content-Type")).isEqualTo("application/json");
-            solftly.assertThat(body).isEqualTo(resultBody);
-        });
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/AIChatCompletionRoutesTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/AIChatCompletionRoutesTest.java
@@ -16,7 +16,7 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.tmail.mailet;
+package com.linagora.tmail.scribe;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.requestSpecification;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.inject.util.Modules;
-import com.linagora.tmail.extension.WireMockRagServerExtension;
+import com.linagora.tmail.extension.WireMockAiServerExtension;
 import com.linagora.tmail.james.app.MemoryConfiguration;
 import com.linagora.tmail.james.app.MemoryServer;
 import com.linagora.tmail.james.jmap.event.ApplyWhenFilter;
@@ -66,7 +66,7 @@ class AIChatCompletionRoutesTest {
 
     private static final MemorySaaSAccountRepository SAAS_REPOSITORY = new MemorySaaSAccountRepository();
     @RegisterExtension
-    static WireMockRagServerExtension wireMockRagServerExtension = new WireMockRagServerExtension();
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
 
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeClientTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeClientTest.java
@@ -1,0 +1,120 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.scribe;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.extension.WireMockAiServerExtension;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class ScribeClientTest {
+    private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
+
+    @RegisterExtension
+    static WireMockAiServerExtension wireMockRagServerExtension = new WireMockAiServerExtension();
+
+    private ScribeClient client;
+
+    @BeforeEach
+    void setUp() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.url", wireMockRagServerExtension.getBaseUrl().toString());
+        configuration.addProperty("scribe.token", "dummy-token");
+        configuration.addProperty("scribe.ssl.trust.all.certs", "true");
+        ScribeConfiguration ragConfig = ScribeConfiguration.from(configuration);
+        client = new ScribeClient(ragConfig);
+    }
+
+    @Test
+    void proxyChatCompletionsShouldForwardPayloadAndHeadersAndReturnExactResponse() {
+        String resultBody = """
+            {
+              "id": "1234",
+              "choices": [
+                {
+                  "finish_reason": "stop",
+                  "index": 0,
+                  "message": {
+                    "content": "The glass green worm around Anvers"
+                  }
+                }
+              ]
+            }
+            """;
+
+        wireMockRagServerExtension.setChatCompletionResponse(200, resultBody);
+
+        String incomingPayload = """
+            {
+               "messages" : [
+                 {"role": "system", "content": "You are a translator."},
+                 {"role": "user", "content": "Translate this text:"},
+                 {"role": "user", "content": "Le ver vert en verre vers Anvers"}
+               ],
+                "metadata": {
+                 "action": "translate"
+               },
+               "stream": false
+            }""";
+
+        ChatCompletionResult result = client.proxyChatCompletions(incomingPayload.getBytes(StandardCharsets.UTF_8)).block();
+
+        verify(1, postRequestedFor(urlMatching(CHAT_COMPLETIONS_ENDPOINT)));
+
+        verify(postRequestedFor(urlMatching(CHAT_COMPLETIONS_ENDPOINT))
+            .withHeader("Authorization", equalTo("Bearer dummy-token"))
+            .withHeader("Content-Type", containing("application/json"))
+            .withRequestBody(equalToJson(incomingPayload)));
+
+        String body = new String(result.body(), StandardCharsets.UTF_8);
+        SoftAssertions.assertSoftly(solftly -> {
+            solftly.assertThat(result.status()).isEqualTo(200);
+            solftly.assertThat(result.headers().get("Content-Type")).isEqualTo("application/json");
+            solftly.assertThat(body).isEqualTo(resultBody);
+        });
+    }
+
+    @Test
+    void proxyChatCompletionsShouldReturnExactErrorResponses() {
+        String resultBody = """
+            {
+              "details": "Internal server error..."
+            }
+            """;
+
+        String incomingPayload = "{bad_payload}";
+
+        wireMockRagServerExtension.setChatCompletionResponse(500, resultBody);
+
+        ChatCompletionResult result = client.proxyChatCompletions(incomingPayload.getBytes(StandardCharsets.UTF_8)).block();
+        String body = new String(result.body(), StandardCharsets.UTF_8);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.status()).isEqualTo(500);
+            softly.assertThat(result.headers().get("Content-Type")).isEqualTo("application/json");
+            softly.assertThat(body).isEqualTo(resultBody);
+        });
+    }
+
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
@@ -27,9 +27,19 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-
 public class ScribeConfigurationTest {
+
+    private static void assertConfiguration(PropertiesConfiguration configuration,
+                                            String expectedToken,
+                                            String expectedUrl,
+                                            boolean expectedTrustAllCerts) throws Exception {
+        ScribeConfiguration expected = new ScribeConfiguration(
+            expectedToken,
+            Optional.of(URI.create(expectedUrl).toURL()),
+            expectedTrustAllCerts);
+        ScribeConfiguration actual = ScribeConfiguration.from(configuration);
+        assertThat(actual).isEqualTo(expected);
+    }
 
     @Test
     public void shouldThrowIllegalArgumentExceptionWhenApiKeyIsNull() {
@@ -54,6 +64,26 @@ public class ScribeConfigurationTest {
     }
 
     @Test
+    public void shouldFallbackToLegacyPropertiesWhenNewOnesAreMissing() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("apiKey", "legacy-token");
+        configuration.addProperty("baseURL", "https://legacy.example.com");
+
+        assertConfiguration(configuration, "legacy-token", "https://legacy.example.com", true);
+    }
+
+    @Test
+    public void shouldPreferNewPropertiesOverLegacyOnes() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.token", "new-token");
+        configuration.addProperty("scribe.url", "https://new.example.com");
+        configuration.addProperty("apiKey", "legacy-token");
+        configuration.addProperty("baseURL", "https://legacy.example.com");
+
+        assertConfiguration(configuration, "new-token", "https://new.example.com", true);
+    }
+
+    @Test
     public void shouldThrowRuntimeExceptionWhenUrlFormatIsWorng() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("scribe.url", "htp://test.linagora.com");
@@ -73,7 +103,7 @@ public class ScribeConfigurationTest {
         configuration.addProperty("scribe.partition.pattern", "{localPart}.twake.{domainName}");
         ScribeConfiguration actual = ScribeConfiguration.from(configuration);
 
-        assertThat(actual.getTrustAllCertificates()).isTrue();
+        assertThat(actual.trustAllCertificates()).isTrue();
     }
 
     @Test
@@ -83,14 +113,6 @@ public class ScribeConfigurationTest {
         configuration.addProperty("scribe.token", "fake-token");
         configuration.addProperty("scribe.ssl.trust.all.certs", "true");
 
-        ScribeConfiguration expected = new ScribeConfiguration("fake-token", Optional.of(URI.create("https://test.linagora.com").toURL()), true);
-        ScribeConfiguration actual = ScribeConfiguration.from(configuration);
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void shouldRespectEqualsAndHashCodeContract() {
-        EqualsVerifier.simple().forClass(ScribeConfiguration.class).verify();
+        assertConfiguration(configuration, "fake-token", "https://test.linagora.com", true);
     }
 }

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
@@ -1,0 +1,96 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.tmail.scribe;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class ScribeConfigurationTest {
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWhenApiKeyIsNull() {
+        Configuration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.url", "https://test.com");
+        configuration.addProperty("scribe.ssl.trust.all.certs", "true");
+
+        assertThatThrownBy(() -> ScribeConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No value for scribe.token parameter was provided.");
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWhenMissingURL() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.token", "fake-token");
+        configuration.addProperty("scribe.ssl.trust.all.certs", "true");
+
+        assertThatThrownBy(() -> ScribeConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No value for scribe.url parameter was provided.");
+    }
+
+    @Test
+    public void shouldThrowRuntimeExceptionWhenUrlFormatIsWorng() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.url", "htp://test.linagora.com");
+        configuration.addProperty("scribe.token", "fake-token");
+        configuration.addProperty("scribe.ssl.trust.all.certs", "true");
+
+        assertThatThrownBy(() -> ScribeConfiguration.from(configuration))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Invalid Scribe API base URL");
+    }
+
+    @Test
+    public void shouldConfigureTrustAllCertsTrueWhenMissingTrustAllCerts() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.url", "https://test.com");
+        configuration.addProperty("scribe.token", "fake-token");
+        configuration.addProperty("scribe.partition.pattern", "{localPart}.twake.{domainName}");
+        ScribeConfiguration actual = ScribeConfiguration.from(configuration);
+
+        assertThat(actual.getTrustAllCertificates()).isTrue();
+    }
+
+    @Test
+    public void shouldVerifyCorrectConfiguration() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("scribe.url", "https://test.linagora.com");
+        configuration.addProperty("scribe.token", "fake-token");
+        configuration.addProperty("scribe.ssl.trust.all.certs", "true");
+
+        ScribeConfiguration expected = new ScribeConfiguration("fake-token", Optional.of(URI.create("https://test.linagora.com").toURL()), true);
+        ScribeConfiguration actual = ScribeConfiguration.from(configuration);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRespectEqualsAndHashCodeContract() {
+        EqualsVerifier.simple().forClass(ScribeConfiguration.class).verify();
+    }
+}

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/java/com/linagora/tmail/scribe/ScribeConfigurationTest.java
@@ -69,7 +69,7 @@ public class ScribeConfigurationTest {
         configuration.addProperty("apiKey", "legacy-token");
         configuration.addProperty("baseURL", "https://legacy.example.com");
 
-        assertConfiguration(configuration, "legacy-token", "https://legacy.example.com", true);
+        assertConfiguration(configuration, "legacy-token", "https://legacy.example.com", false);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ScribeConfigurationTest {
         configuration.addProperty("apiKey", "legacy-token");
         configuration.addProperty("baseURL", "https://legacy.example.com");
 
-        assertConfiguration(configuration, "new-token", "https://new.example.com", true);
+        assertConfiguration(configuration, "new-token", "https://new.example.com", false);
     }
 
     @Test
@@ -96,14 +96,13 @@ public class ScribeConfigurationTest {
     }
 
     @Test
-    public void shouldConfigureTrustAllCertsTrueWhenMissingTrustAllCerts() {
+    public void shouldDefaultToCertificateValidationWhenTrustAllCertsIsMissing() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
         configuration.addProperty("scribe.url", "https://test.com");
         configuration.addProperty("scribe.token", "fake-token");
-        configuration.addProperty("scribe.partition.pattern", "{localPart}.twake.{domainName}");
         ScribeConfiguration actual = ScribeConfiguration.from(configuration);
 
-        assertThat(actual.trustAllCertificates()).isTrue();
+        assertThat(actual.trustAllCertificates()).isFalse();
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/ai-bot/src/test/resources/ai.properties
+++ b/tmail-backend/tmail-third-party/ai-bot/src/test/resources/ai.properties
@@ -5,3 +5,6 @@ openrag.url=http://localhost:1234
 openrag.token=fake-token
 openrag.ssl.trust.all.certs=true
 openrag.partition.pattern={localPart}.twake.{domainName}
+scribe.url=http://localhost:1234
+scribe.token=fake-token
+scribe.ssl.trust.all.certs=true


### PR DESCRIPTION
closes #2526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled AI chat completions to be proxied via a new Scribe integration.
  * Added Scribe configuration options for endpoint URL, bearer token, and SSL trust behavior (with legacy property fallbacks).
* **Documentation**
  * Documented the Scribe configuration and the AI chat completions endpoint (`/ai/v1/chat/completions`).
* **Refactor**
  * Updated AI request routing to use Scribe instead of the previous RAG HTTP path.
* **Tests**
  * Added/updated tests covering Scribe configuration, request/response handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->