### PR TITLE
[TMail] WebAdmin: default auto-generate password to false

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/webadmin.adoc
@@ -6,6 +6,15 @@ The following document discusses additional webAdmin routes exposed by TMail.
 It follows the conventions of xref:3.7.0@james-distributed-app:operate/webadmin.adoc[existing routes for the Apache James
 Distributed Server].
 
+[WARNING]
+====
+Unlike Apache James, TMail defaults WebAdmin password generation to disabled when `password.generate` is not configured.
+Set `password.generate=true` in `webadmin.properties` to enable it.
+
+Without JWT or any configured password, WebAdmin requests are unauthenticated. Do not expose the WebAdmin endpoint outside
+of a trusted environment in that configuration.
+====
+
 == Team Mailboxes
 
 === Listing Team Mailboxes for a domain

--- a/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
+++ b/tmail-backend/apps/distributed/src/main/java/com/linagora/tmail/james/app/DistributedServer.java
@@ -397,7 +397,8 @@ public class DistributedServer {
             new MailetProcessingModule(),
             REQUIRE_TASK_MANAGER_MODULE,
             new DistributedTaskManagerModule()))
-        .with(new CassandraLabelRepositoryModule(),
+        .with(WebAdminServerModule.defaultPasswordGenerationModule(false),
+            new CassandraLabelRepositoryModule(),
             new CassandraDomainSignatureTemplateRepositoryModule(),
             new CassandraRateLimitingModule(),
             new CassandraUserQuotaReporterModule(),

--- a/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
+++ b/tmail-backend/apps/memory/src/main/java/com/linagora/tmail/james/app/MemoryServer.java
@@ -60,6 +60,7 @@ import org.apache.james.modules.server.DKIMMailetModule;
 import org.apache.james.modules.server.DropListsRoutesModule;
 import org.apache.james.modules.server.JMXServerModule;
 import org.apache.james.modules.server.TaskManagerModule;
+import org.apache.james.modules.server.WebAdminServerModule;
 import org.apache.james.oidc.memory.CaffeineOidcTokenCacheModule;
 import org.apache.james.rate.limiter.memory.MemoryRateLimiterModule;
 import org.apache.james.util.Host;
@@ -209,7 +210,8 @@ public class MemoryServer {
           new JmapSettingsReportRoutesModule(),
           new JmapSettingsRoutesModule(),
           new DKIMMailetModule())
-        .with(new TeamMailboxModule(),
+        .with(WebAdminServerModule.defaultPasswordGenerationModule(false),
+            new TeamMailboxModule(),
             new TMailScanningQuotaSearcherModule(),
             new MemoryRateLimiterModule(),
             new MemoryRateLimitingModule(),

--- a/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
+++ b/tmail-backend/apps/migration-proxy/src/main/java/com/linagora/tmail/migration/MigrationProxyServer.java
@@ -160,7 +160,7 @@ public class MigrationProxyServer {
 
         return GuiceJamesServer.forConfiguration(configuration)
             .combineWith(Modules.override(PROTOCOLS, DATA, chooseSslModule(), eventBusModuleChoice.module())
-                .with(MIGRATION_PROXY))
+                .with(MIGRATION_PROXY, WebAdminServerModule.defaultPasswordGenerationModule(false)))
             .combineWith(new UsersRepositoryModuleChooser(new PostgresUsersRepositoryModule())
                 .chooseModules(usersRepositoryImplementation));
     }

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -404,7 +404,8 @@ public class PostgresTmailServer {
             POSTGRES_SERVER_MODULE,
             PROTOCOLS,
             PLUGINS))
-        .with(new TeamMailboxModule(),
+        .with(WebAdminServerModule.defaultPasswordGenerationModule(false),
+            new TeamMailboxModule(),
             new TMailMailboxSortOrderProviderModule(),
             new PostgresRateLimitingModule(),
             new PostgresUserQuotaReporterModule(),


### PR DESCRIPTION
adaptation for https://github.com/apache/james-project/pull/3104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * WebAdmin password generation is now disabled by default across supported server configurations (including distributed, memory, migration proxy, and Postgres).
  * WebAdmin requests remain unauthenticated unless JWT authentication or an explicitly configured password is available; keep it confined to trusted environments.

* **Documentation**
  * Added a WebAdmin note explaining how to enable password generation via `webadmin.properties` and the related security implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->