### PR TITLE
ISSUE-2556 JMAP specs for the upload from URL extension

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -43,6 +43,7 @@
 *** xref:tmail-backend/jmap-extensions/teamMailboxRevokeAccess.adoc[]
 *** xref:tmail-backend/jmap-extensions/ticketAuthentication.adoc[]
 *** xref:tmail-backend/jmap-extensions/unauthenticatedBlobAccess.adoc[]
+*** xref:tmail-backend/jmap-extensions/uploadFromUrl.adoc[]
 ** xref:tmail-backend/smtp-extensions/index.adoc[]
 *** xref:tmail-backend/smtp-extensions/smtpAuthDelegationExtension.adoc[]
 ** xref:tmail-backend/webadmin.adoc[]

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/index.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/index.adoc
@@ -49,6 +49,7 @@ from the blob id of the calendar file (.ics).
  - link:jmapSettings.adoc[com:linagora:params:jmap:settings] allows clients to store per-user settings on the backend side.
  - link:publicAssets.adoc[com:linagora:params:public:assets] allows clients to store images as public assets to use on their TMail signature.
  - link:downloadAll.adoc[com:linagora:params:downloadAll] allows clients to download all attachments of a mail at once compressed in a zip file.
+ - link:uploadFromUrl.adoc[com:linagora:params:jmap:upload:from-url] allows clients to import a remote file as a normal JMAP upload.
  - link:unauthenticatedBlobAccess.adoc[com:linagora:params:jmap:unauthenticated:blob:access] allows clients to generate short-lived tokens for unauthenticated blob download.
  - link:mailboxClear.adoc[com:linagora:params:jmap:mailbox:clear] allows clients to clear a user mailbox thus avoiding round trips, outdated projection and network issues.
  - link:saas.adoc[com:linagora:params:saas] allows to return the Twake Workplace SaaS capability for users.

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
@@ -2,24 +2,34 @@
 :navtitle: JMAP Upload From URL
 
 This extension lets an authenticated JMAP client import one remote file as a
-normal JMAP upload without transferring the file through the client.
+normal JMAP upload without transferring the file through the client. It enables
+backend-to-backend uploads, for example to attach a file selected from a remote
+Drive service to an email.
 
 == Capability
 
 Servers supporting this extension advertise
 `com:linagora:params:jmap:upload:from-url` in the JMAP session capabilities.
 
-The capability object contains one property:
+The capability object contains these properties:
 
 - `uploadUrl`: an absolute URL template for the upload-from-URL endpoint. The
   template contains the `{accountId}` variable.
+- `allowedOrigins`: optional. An array of origin patterns explicitly
+  accepted by the server. An origin contains no path, query, fragment, or
+  credentials. The `%` token matches a non-empty fragment within one DNS label.
+
+When `allowedOrigins` is absent, the server applies a dynamic URL security
+policy that cannot be advertised as a fixed list. Its absence does not mean
+that arbitrary remote URLs are accepted.
 
 Example:
 
 ....
 {
   "com:linagora:params:jmap:upload:from-url": {
-    "uploadUrl": "https://jmap.example.com/upload-from-url/{accountId}"
+    "uploadUrl": "https://jmap.example.com/upload-from-url/{accountId}",
+    "allowedOrigins": ["https://%-mail.twake.example.com"]
   }
 }
 ....
@@ -78,8 +88,6 @@ Content-Type: application/json
 
 The returned blob has the same ownership, expiry, quota, download, and
 `Email/set` attachment behavior as a traditional JMAP upload.
-
-Server could return the upload progress through Server-Sent Events, for example `{"progress":432743}` prior termination at a fixed rate (2 seconds).
 
 === Errors
 

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
@@ -15,11 +15,11 @@ The capability object contains these properties:
 
 - `uploadUrl`: an absolute URL template for the upload-from-URL endpoint. The
   template contains the `{accountId}` variable.
-- `allowedOrigins`: optional. An array of origin patterns explicitly
-  accepted by the server. An origin contains no path, query, fragment, or
+- `allowedSources`: optional. An array of remote source patterns explicitly
+  accepted by the server. A source contains no path, query, fragment, or
   credentials. The `%` token matches a non-empty fragment within one DNS label.
 
-When `allowedOrigins` is absent, the server applies a dynamic URL security
+When `allowedSources` is absent, the server applies a dynamic URL security
 policy that cannot be advertised as a fixed list. Its absence does not mean
 that arbitrary remote URLs are accepted.
 
@@ -29,7 +29,7 @@ Example:
 {
   "com:linagora:params:jmap:upload:from-url": {
     "uploadUrl": "https://jmap.example.com/upload-from-url/{accountId}",
-    "allowedOrigins": ["https://%-mail.twake.example.com"]
+    "allowedSources": ["https://%-drive.twake.example.com"]
   }
 }
 ....

--- a/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc
@@ -1,0 +1,119 @@
+= JMAP Upload From URL
+:navtitle: JMAP Upload From URL
+
+This extension lets an authenticated JMAP client import one remote file as a
+normal JMAP upload without transferring the file through the client.
+
+== Capability
+
+Servers supporting this extension advertise
+`com:linagora:params:jmap:upload:from-url` in the JMAP session capabilities.
+
+The capability object contains one property:
+
+- `uploadUrl`: an absolute URL template for the upload-from-URL endpoint. The
+  template contains the `{accountId}` variable.
+
+Example:
+
+....
+{
+  "com:linagora:params:jmap:upload:from-url": {
+    "uploadUrl": "https://jmap.example.com/upload-from-url/{accountId}"
+  }
+}
+....
+
+When this capability is absent, clients must treat upload from URL as
+unavailable.
+
+== Upload route
+
+The extension defines the following authenticated route:
+
+....
+POST /upload-from-url/{accountId}
+....
+
+The request has an empty body and uses these headers:
+
+- `Content-Location`: required. An absolute URL identifying the remote file.
+- `Content-Type`: optional. The media type to associate with the resulting JMAP
+  upload.
+
+One request imports exactly one file. The server applies its configured remote
+URL policy; advertising the capability does not imply that every HTTPS URL is
+accepted.
+
+Example request:
+
+....
+POST /upload-from-url/ACCOUNT_ID HTTP/1.1
+Authorization: Bearer TOKEN
+Content-Location: https://drive.example.com/files/downloads/token/report.pdf
+Content-Type: application/pdf
+....
+
+The optional request `Content-Type` hints the media type. When it is absent or
+invalid, the server should attempt to obtain the media type from the remote response.
+
+The imported file is subject to the normal JMAP upload size limit.
+
+=== Success response
+
+Success uses the response defined by RFC 8620 for binary upload and returns
+`201 Created`:
+
+....
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "accountId": "ACCOUNT_ID",
+  "blobId": "uploads-...",
+  "type": "application/pdf",
+  "size": 123456
+}
+....
+
+The returned blob has the same ownership, expiry, quota, download, and
+`Email/set` attachment behavior as a traditional JMAP upload.
+
+Server could return the upload progress through Server-Sent Events, for example `{"progress":432743}` prior termination at a fixed rate (2 seconds).
+
+=== Errors
+
+Errors use Problem Details with matching HTTP and `status` values:
+
+|===
+| Status | Meaning
+
+| `400`
+| Missing or malformed request metadata, non-empty request body, or rejected URL.
+
+| `401`
+| Authentication failed.
+
+| `403`
+| The target account is not accessible.
+
+| `413`
+| The decoded remote file exceeds the configured JMAP upload size.
+
+| `429`
+| Remote file transfer capacity is unavailable.
+
+| `500`
+| Upload persistence failed unexpectedly.
+
+| `502`
+| The remote server could not be reached, returned an unsupported response, or
+  supplied content that could not be decoded.
+
+| `504`
+| The remote connection or transfer timed out.
+|===
+
+If the client disconnects while an import is in progress, the server cancels the
+remote transfer and upload consumption. This does not guarantee rollback when
+the existing JMAP upload service has already committed the upload.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the JMAP Upload From URL extension.
  - Described capability advertisement, endpoint usage, request requirements, upload limits, successful responses, progress reporting, error handling, and cancellation behavior.
  - Added the new extension documentation to the navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->