### PR TITLE
ISSUE-2570 Allow to not deduplicate in transit blobs

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -5,6 +5,7 @@ Twake mail ships some slight blob store enhancements:
  - BlobId list allows limiting the could of save request for similar objects onto the blob store,
 thus improving overall efficiency.
  - Secondary blob store reads and write to several S3 sites providing higher resiliency.
+ - Mail processing deduplication can be turned off, so that mails in transit do not outlive their processing.
 
 == Object Storage: BlobId list
 
@@ -32,6 +33,37 @@ Example `blob.properties`:
 # This prevents isolation issues for Swift backed S3 deployments, also adds a performance boost.
 # Mandatory, Allowed values are: true, false
 single.save.enable=false
+[...]
+....
+
+== Mail processing deduplication
+
+Mails in transit - the ones stored by the mail queue and by the mail repositories - are, by default, deduplicated with
+the copies eventually stored within the mailboxes: they share the very same blobs.
+
+This means their blobs can not be deleted when the mail leaves the mail queue - the mailboxes might reference them -
+and can only be reclaimed by the deduplication garbage collector, several generations later. For deployments handling
+a high volume of transactional traffic, the object storage thus holds mails long after they have been delivered, and
+the mail queue content can not be rebuilt out of the object storage alone, as it is split and shared.
+
+Setting `mailprocessing.deduplication.enabled=false` stores each mail in transit as a single, standalone RFC822 object
+within the `mail-processing` bucket. That object is deleted as soon as the mail leaves the mail queue or the mail
+repository holding it. This trades storage volume - a mail delivered locally is stored twice: once for the transit,
+once for the mailbox - for a bounded, self-managed transit storage, and allows replaying the mail queue content out of
+the `mail-processing` bucket.
+
+Example `blob.properties`:
+
+....
+[...]
+# Whether mails in transit are deduplicated with the copies eventually stored within the mailboxes.
+# Optional, Allowed values are: true, false, defaults to true
+# `mailprocessing.deduplication.enable` is accepted as an alias.
+mailprocessing.deduplication.enabled=false
+
+# Bucket storing mails in transit when mailprocessing.deduplication.enabled is false.
+# Optional, defaults to mail-processing
+# mailprocessing.bucket=mail-processing
 [...]
 ....
 

--- a/tmail-backend/apps/distributed/src/main/conf/blob.properties
+++ b/tmail-backend/apps/distributed/src/main/conf/blob.properties
@@ -28,6 +28,23 @@ deduplication.enable=false
 # Mandatory, Allowed values are: true, false
 single.save.enable=false
 
+# ==================================== Mail processing deduplication =====================================
+# Whether mails in transit - stored by the mail queue and by the mail repositories - are deduplicated with
+# the copies eventually stored in the mailboxes.
+# When true (default) mails in transit share their blobs with the mailboxes, and can thus only be reclaimed
+# by the deduplication garbage collector, several generations after their deletion.
+# When false, each mail in transit is stored as a single, standalone blob within the mail-processing bucket,
+# and is deleted as soon as it leaves the mail queue / the mail repository. This trades storage volume -
+# mails are stored twice: once for the transit, once for the mailbox - for a bounded, self-managed transit
+# storage. It further allows rebuilding the mail queue content out of the mail-processing bucket.
+# Optional, Allowed values are: true, false, defaults to true
+# `mailprocessing.deduplication.enable` is accepted as an alias.
+mailprocessing.deduplication.enabled=true
+
+# Bucket storing mails in transit when mailprocessing.deduplication.enabled is false.
+# Optional, defaults to mail-processing
+# mailprocessing.bucket=mail-processing
+
 # ========================================= Cassandra BlobStore Cache ======================================
 # A cassandra cache can be enabled to reduce latency when reading small blobs frequently
 # A dedicated keyspace with a replication factor of one is then used

--- a/tmail-backend/apps/postgres/sample-configuration/blob.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/blob.properties
@@ -24,6 +24,23 @@ deduplication.enable=true
 # Duration. Default unit: days. Defaults to 30 days.
 # deduplication.gc.generation.duration=30days
 
+# ==================================== Mail processing deduplication =====================================
+# Whether mails in transit - stored by the mail queue and by the mail repositories - are deduplicated with
+# the copies eventually stored in the mailboxes.
+# When true (default) mails in transit share their blobs with the mailboxes, and can thus only be reclaimed
+# by the deduplication garbage collector, several generations after their deletion.
+# When false, each mail in transit is stored as a single, standalone blob within the mail-processing bucket,
+# and is deleted as soon as it leaves the mail queue / the mail repository. This trades storage volume -
+# mails are stored twice: once for the transit, once for the mailbox - for a bounded, self-managed transit
+# storage. It further allows rebuilding the mail queue content out of the mail-processing bucket.
+# Optional, Allowed values are: true, false, defaults to true
+# `mailprocessing.deduplication.enable` is accepted as an alias.
+mailprocessing.deduplication.enabled=true
+
+# Bucket storing mails in transit when mailprocessing.deduplication.enabled is false.
+# Optional, defaults to mail-processing
+# mailprocessing.bucket=mail-processing
+
 # ========================================= Encryption ========================================
 # If you choose to enable encryption, the blob content will be encrypted before storing them in the BlobStore.
 # Warning: Once this feature is enabled, there is no turning back as turning it off will lead to all content being

--- a/tmail-backend/apps/postgres/sample-configuration/distributed/blob.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/distributed/blob.properties
@@ -24,6 +24,23 @@ deduplication.enable=true
 # Duration. Default unit: days. Defaults to 30 days.
 # deduplication.gc.generation.duration=30days
 
+# ==================================== Mail processing deduplication =====================================
+# Whether mails in transit - stored by the mail queue and by the mail repositories - are deduplicated with
+# the copies eventually stored in the mailboxes.
+# When true (default) mails in transit share their blobs with the mailboxes, and can thus only be reclaimed
+# by the deduplication garbage collector, several generations after their deletion.
+# When false, each mail in transit is stored as a single, standalone blob within the mail-processing bucket,
+# and is deleted as soon as it leaves the mail queue / the mail repository. This trades storage volume -
+# mails are stored twice: once for the transit, once for the mailbox - for a bounded, self-managed transit
+# storage. It further allows rebuilding the mail queue content out of the mail-processing bucket.
+# Optional, Allowed values are: true, false, defaults to true
+# `mailprocessing.deduplication.enable` is accepted as an alias.
+mailprocessing.deduplication.enabled=true
+
+# Bucket storing mails in transit when mailprocessing.deduplication.enabled is false.
+# Optional, defaults to mail-processing
+# mailprocessing.bucket=mail-processing
+
 # ========================================= Encryption ========================================
 # If you choose to enable encryption, the blob content will be encrypted before storing them in the BlobStore.
 # Warning: Once this feature is enabled, there is no turning back as turning it off will lead to all content being

--- a/tmail-backend/guice/blob-guice/pom.xml
+++ b/tmail-backend/guice/blob-guice/pom.xml
@@ -46,6 +46,37 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mail-store</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>blob-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-cassandra</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
@@ -372,6 +372,7 @@ public class BlobStoreModulesChooser {
             .add(new BaseObjectStorageModule())
             .addAll(chooseStoragePolicyModule(blobStoreConfiguration.storageStrategy()))
             .add(new StoragePolicyConfigurationSanityEnforcementModule(blobStoreConfiguration))
+            .add(new MailProcessingModule())
             .build();
     }
 

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/MailProcessingModule.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/MailProcessingModule.java
@@ -1,0 +1,64 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.blob.mail.MimeMessageStore;
+import org.apache.james.modules.mailbox.ConfigurationComponent;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.linagora.tmail.blob.mail.DuplicatingMimeMessageStore;
+import com.linagora.tmail.blob.mail.MailProcessingConfiguration;
+
+/**
+ * Substitutes James' {@link MimeMessageStore.Factory} - injected by the mail queue and by the mail
+ * repositories - with the Twake Mail one, allowing mails in transit not to be deduplicated.
+ *
+ * @see MailProcessingConfiguration
+ */
+public class MailProcessingModule extends AbstractModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailProcessingModule.class);
+
+    @Override
+    protected void configure() {
+        bind(DuplicatingMimeMessageStore.Factory.class).in(Scopes.SINGLETON);
+        bind(MimeMessageStore.Factory.class).to(DuplicatingMimeMessageStore.Factory.class);
+    }
+
+    @Provides
+    @Singleton
+    MailProcessingConfiguration mailProcessingConfiguration(PropertiesProvider propertiesProvider) {
+        try {
+            return MailProcessingConfiguration.from(propertiesProvider.getConfigurations(ConfigurationComponent.NAMES));
+        } catch (FileNotFoundException e) {
+            LOGGER.warn("Could not find {} configuration file, deduplicating mails in transit", ConfigurationComponent.NAME);
+            return MailProcessingConfiguration.DEDUPLICATED;
+        } catch (ConfigurationException e) {
+            throw new RuntimeException("Failed reading " + ConfigurationComponent.NAME + " configuration file", e);
+        }
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/mail/DuplicatingMimeMessageStore.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/mail/DuplicatingMimeMessageStore.java
@@ -1,0 +1,325 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.mail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import jakarta.inject.Inject;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BlobStoreDAO.ByteSourceBlob;
+import org.apache.james.blob.api.BlobStoreDAO.InputStreamBlob;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.blob.api.Store;
+import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.james.blob.mail.MimeMessageStore;
+import org.apache.james.lifecycle.api.Disposable;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.server.core.MimeMessageInputStream;
+import org.apache.james.server.core.MimeMessageSource;
+import org.apache.james.server.core.MimeMessageWrapper;
+import org.apache.james.util.ReactorUtils;
+import org.reactivestreams.Publisher;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteSource;
+import com.google.common.io.FileBackedOutputStream;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * A {@link Store} storing each mail in transit as a standalone blob, thus never deduplicating it with the
+ * copies eventually stored within the mailboxes.
+ *
+ * <p>Mails are written as a single, complete RFC822 object in a dedicated bucket, through the
+ * {@link BlobStoreDAO} - bypassing the deduplicating {@link BlobStore} whose <code>delete</code> is a no-op.
+ * Blobs are thus effectively deleted upon dequeue / mail repository removal instead of being left over to
+ * the deduplication garbage collector. Note that the {@link BlobStoreDAO} is to be the encryption and
+ * compression aware one, not the raw one.</p>
+ *
+ * <p>Given {@link MimeMessagePartsId} carries two blob ids, and given no schema change is desired, the header
+ * blob id is used as a discriminator: it is set to {@link #NO_HEADER_BLOB} while the body blob id holds the
+ * id of the full message. Parts ids written while deduplication was enabled keep pointing to regular,
+ * deduplicated header and body blobs: they are transparently read from - and, upon deletion, left over to
+ * the deduplication garbage collector - by the deduplicating store.</p>
+ */
+public class DuplicatingMimeMessageStore implements Store<MimeMessage, MimeMessagePartsId> {
+    /**
+     * Marker used as a header blob id, denoting a mail stored as a single, non deduplicated blob.
+     *
+     * Note: this value needs to survive the serialization round trips of the mail queue and of the mail
+     * repositories, hence the comparison upon {@link BlobId#asString()} rather than upon {@link BlobId}
+     * equality: reading it back yields whichever {@link BlobId} implementation the deployment relies on.
+     */
+    public static final String NO_HEADER_BLOB = "EMPTY";
+    private static final BlobId HEADER_MARKER = new PlainBlobId(NO_HEADER_BLOB);
+
+    static final String METRIC_PREFIX = "mailProcessing:";
+    static final String SAVE_TIMER_NAME = METRIC_PREFIX + "save";
+    static final String READ_TIMER_NAME = METRIC_PREFIX + "read";
+    static final String DELETE_TIMER_NAME = METRIC_PREFIX + "delete";
+    /** Mails written back when deduplication was enabled: their drain is what an operator watches after a switch. */
+    static final String DEDUPLICATED_READ_TIMER_NAME = METRIC_PREFIX + "deduplicatedRead";
+    static final String DEDUPLICATED_DELETE_TIMER_NAME = METRIC_PREFIX + "deduplicatedDelete";
+
+    public static boolean isFullMessageBlob(MimeMessagePartsId partsId) {
+        return NO_HEADER_BLOB.equals(partsId.getHeaderBlobId().asString());
+    }
+
+    /**
+     * Substitutes James' {@link MimeMessageStore.Factory} - which the mail queue and the mail repositories
+     * inject - so that mails in transit are, or are not, deduplicated depending on the configuration.
+     */
+    public static class Factory extends MimeMessageStore.Factory {
+        private final BlobStore blobStore;
+        private final BlobStoreDAO blobStoreDAO;
+        private final BlobId.Factory blobIdFactory;
+        private final MailProcessingConfiguration configuration;
+        private final MetricFactory metricFactory;
+
+        @Inject
+        public Factory(BlobStore blobStore, BlobStoreDAO blobStoreDAO, BlobId.Factory blobIdFactory,
+                       MailProcessingConfiguration configuration, MetricFactory metricFactory) {
+            super(blobStore);
+            this.blobStore = blobStore;
+            this.blobStoreDAO = blobStoreDAO;
+            this.blobIdFactory = blobIdFactory;
+            this.configuration = configuration;
+            this.metricFactory = metricFactory;
+        }
+
+        @Override
+        public Store<MimeMessage, MimeMessagePartsId> mimeMessageStore() {
+            return mimeMessageStore(blobStore.getDefaultBucketName());
+        }
+
+        @Override
+        public Store<MimeMessage, MimeMessagePartsId> mimeMessageStore(BucketName bucketName) {
+            Store<MimeMessage, MimeMessagePartsId> deduplicatingStore = super.mimeMessageStore(bucketName);
+
+            if (configuration.deduplicationEnabled()) {
+                return deduplicatingStore;
+            }
+            return new DuplicatingMimeMessageStore(blobStoreDAO, blobIdFactory,
+                configuration.mailProcessingBucket(), deduplicatingStore, metricFactory);
+        }
+    }
+
+    private final BlobStoreDAO blobStoreDAO;
+    private final BlobId.Factory blobIdFactory;
+    private final BucketName bucketName;
+    private final Store<MimeMessage, MimeMessagePartsId> deduplicatingStore;
+    private final MetricFactory metricFactory;
+
+    public DuplicatingMimeMessageStore(BlobStoreDAO blobStoreDAO, BlobId.Factory blobIdFactory, BucketName bucketName,
+                                       Store<MimeMessage, MimeMessagePartsId> deduplicatingStore,
+                                       MetricFactory metricFactory) {
+        this.blobStoreDAO = blobStoreDAO;
+        this.blobIdFactory = blobIdFactory;
+        this.bucketName = bucketName;
+        this.deduplicatingStore = deduplicatingStore;
+        this.metricFactory = metricFactory;
+    }
+
+    @Override
+    public Mono<MimeMessagePartsId> save(MimeMessage message) {
+        Preconditions.checkNotNull(message);
+
+        BlobId blobId = blobIdFactory.of(UUID.randomUUID().toString());
+
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric(SAVE_TIMER_NAME,
+            Mono.from(blobStoreDAO.save(bucketName, blobId, ByteSourceBlob.of(asByteSource(message))))
+                .thenReturn(MimeMessagePartsId.builder()
+                    .headerBlobId(HEADER_MARKER)
+                    .bodyBlobId(blobId)
+                    .build())));
+    }
+
+    @Override
+    public Mono<MimeMessage> read(MimeMessagePartsId blobIds) {
+        Preconditions.checkNotNull(blobIds);
+
+        if (!isFullMessageBlob(blobIds)) {
+            return Mono.from(metricFactory.decoratePublisherWithTimerMetric(DEDUPLICATED_READ_TIMER_NAME,
+                deduplicatingStore.read(blobIds)));
+        }
+
+        return Mono.from(metricFactory.decoratePublisherWithTimerMetric(READ_TIMER_NAME,
+            Mono.from(blobStoreDAO.readReactive(bucketName, blobIds.getBodyBlobId()))
+                .flatMap(blob -> Mono.fromCallable(() -> materialize(blob))
+                    .subscribeOn(ReactorUtils.BLOCKING_CALL_WRAPPER))
+                .map(content -> (MimeMessage) new MimeMessageWrapper(new FullMessageSource(content)))));
+    }
+
+    @Override
+    public Publisher<Void> delete(MimeMessagePartsId blobIds) {
+        Preconditions.checkNotNull(blobIds);
+
+        if (!isFullMessageBlob(blobIds)) {
+            return metricFactory.decoratePublisherWithTimerMetric(DEDUPLICATED_DELETE_TIMER_NAME,
+                deduplicatingStore.delete(blobIds));
+        }
+
+        return metricFactory.decoratePublisherWithTimerMetric(DELETE_TIMER_NAME,
+            blobStoreDAO.delete(bucketName, blobIds.getBodyBlobId()));
+    }
+
+    private CloseableByteSource materialize(InputStreamBlob blob) throws IOException {
+        FileBackedOutputStream out = new FileBackedOutputStream(FILE_THRESHOLD);
+        try (InputStream in = blob.payload()) {
+            long size = in.transferTo(out);
+            out.flush();
+            return new FileBackedByteSource(out, size);
+        } catch (IOException | RuntimeException e) {
+            out.reset();
+            out.close();
+            throw e;
+        }
+    }
+
+    private static ByteSource asByteSource(MimeMessage message) {
+        return new ByteSource() {
+            private final AtomicLong size = new AtomicLong(-1);
+
+            @Override
+            public InputStream openStream() throws IOException {
+                return fullMessageStream(message);
+            }
+
+            @Override
+            public long size() throws IOException {
+                long knownSize = size.get();
+                if (knownSize >= 0) {
+                    return knownSize;
+                }
+                long computedSize = messageSize(message);
+                size.set(computedSize);
+                return computedSize;
+            }
+        };
+    }
+
+    private static InputStream fullMessageStream(MimeMessage message) throws IOException {
+        try {
+            return new MimeMessageInputStream(message);
+        } catch (MessagingException e) {
+            throw new IOException("Failed to generate message stream", e);
+        }
+    }
+
+    /**
+     * Size of the full message, headers included.
+     *
+     * <p>Beware: this size is relied upon as the content length of the underlying object storage upload, thus
+     * needs to be exact. {@link MimeMessage#getSize()} - which only accounts for the body, and which the
+     * JavaMail specification documents as an estimate - can not be used here. {@link MimeMessageWrapper}
+     * exposes an exact message size, otherwise we count the very bytes we are about to upload.</p>
+     */
+    @VisibleForTesting
+    static long messageSize(MimeMessage message) throws IOException {
+        if (message instanceof MimeMessageWrapper) {
+            try {
+                long size = ((MimeMessageWrapper) message).getMessageSize();
+                if (size >= 0) {
+                    return size;
+                }
+            } catch (MessagingException e) {
+                throw new IOException("Failed accessing message size", e);
+            }
+        }
+
+        CountingOutputStream countingOutputStream = new CountingOutputStream(OutputStream.nullOutputStream());
+        try (InputStream in = fullMessageStream(message)) {
+            in.transferTo(countingOutputStream);
+        }
+        return countingOutputStream.getCount();
+    }
+
+    private static class FileBackedByteSource extends CloseableByteSource {
+        private final FileBackedOutputStream out;
+        private final long size;
+
+        private FileBackedByteSource(FileBackedOutputStream out, long size) {
+            this.out = out;
+            this.size = size;
+        }
+
+        @Override
+        public InputStream openStream() throws IOException {
+            return out.asByteSource().openStream();
+        }
+
+        @Override
+        public long size() {
+            return size;
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.reset();
+            out.close();
+        }
+    }
+
+    private static class FullMessageSource implements MimeMessageSource, Disposable {
+        private final CloseableByteSource content;
+        private final String sourceId;
+
+        private FullMessageSource(CloseableByteSource content) {
+            this.content = content;
+            this.sourceId = UUID.randomUUID().toString();
+        }
+
+        @Override
+        public String getSourceId() {
+            return sourceId;
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return content.openStream();
+        }
+
+        @Override
+        public long getMessageSize() throws IOException {
+            return content.size();
+        }
+
+        @Override
+        public void dispose() {
+            try {
+                content.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/mail/MailProcessingConfiguration.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/mail/MailProcessingConfiguration.java
@@ -1,0 +1,63 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.mail;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.james.blob.api.BucketName;
+
+/**
+ * Whether mails in transit - stored by the mail queue and by the mail repositories - are deduplicated with
+ * the copies eventually stored within the mailboxes, and if not, in which bucket they are to be stored.
+ *
+ * Read from <code>blob.properties</code>:
+ *
+ * <pre>
+ * mailprocessing.deduplication.enabled=true
+ * mailprocessing.bucket=mail-processing
+ * </pre>
+ *
+ * @see DuplicatingMimeMessageStore
+ */
+public record MailProcessingConfiguration(boolean deduplicationEnabled, BucketName mailProcessingBucket) {
+    public static final BucketName MAIL_PROCESSING_BUCKET = BucketName.of("mail-processing");
+    public static final MailProcessingConfiguration DEDUPLICATED = new MailProcessingConfiguration(true, MAIL_PROCESSING_BUCKET);
+
+    static final String DEDUPLICATION_ENABLED_PROPERTY = "mailprocessing.deduplication.enabled";
+    // Accepted alias, consistent with the `deduplication.enable` spelling of the blob store deduplication
+    static final String DEDUPLICATION_ENABLE_PROPERTY = "mailprocessing.deduplication.enable";
+    static final String BUCKET_PROPERTY = "mailprocessing.bucket";
+
+    public static MailProcessingConfiguration duplicated() {
+        return duplicated(MAIL_PROCESSING_BUCKET);
+    }
+
+    public static MailProcessingConfiguration duplicated(BucketName mailProcessingBucket) {
+        return new MailProcessingConfiguration(false, mailProcessingBucket);
+    }
+
+    public static MailProcessingConfiguration from(Configuration configuration) {
+        boolean deduplicationEnabled = configuration.getBoolean(DEDUPLICATION_ENABLED_PROPERTY,
+            configuration.getBoolean(DEDUPLICATION_ENABLE_PROPERTY, true));
+
+        if (deduplicationEnabled) {
+            return DEDUPLICATED;
+        }
+        return duplicated(BucketName.of(configuration.getString(BUCKET_PROPERTY, MAIL_PROCESSING_BUCKET.asString())));
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/guice/MailProcessingModuleTest.java
+++ b/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/guice/MailProcessingModuleTest.java
@@ -1,0 +1,84 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.blob.mail.MimeMessageStore;
+import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.server.blob.deduplication.BlobStoreFactory;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.linagora.tmail.blob.mail.DuplicatingMimeMessageStore;
+import com.linagora.tmail.blob.mail.MailProcessingConfiguration;
+
+class MailProcessingModuleTest {
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
+
+    private static Injector injector(MailProcessingConfiguration configuration) {
+        BlobStoreDAO blobStoreDAO = new MemoryBlobStoreDAO();
+        BlobStore blobStore = BlobStoreFactory.builder()
+            .blobStoreDAO(blobStoreDAO)
+            .blobIdFactory(BLOB_ID_FACTORY)
+            .defaultBucketName()
+            .deduplication();
+
+        Module dependencies = binder -> {
+            binder.bind(BlobStore.class).toInstance(blobStore);
+            binder.bind(BlobStoreDAO.class).toInstance(blobStoreDAO);
+            binder.bind(BlobId.Factory.class).toInstance(BLOB_ID_FACTORY);
+            binder.bind(MailProcessingConfiguration.class).toInstance(configuration);
+            binder.bind(MetricFactory.class).toInstance(new RecordingMetricFactory());
+        };
+
+        return Guice.createInjector(Modules.override(new MailProcessingModule()).with(dependencies));
+    }
+
+    @Test
+    void shouldSubstituteJamesMimeMessageStoreFactory() {
+        assertThat(injector(MailProcessingConfiguration.DEDUPLICATED).getInstance(MimeMessageStore.Factory.class))
+            .isInstanceOf(DuplicatingMimeMessageStore.Factory.class);
+    }
+
+    @Test
+    void shouldDeduplicateByDefault() {
+        MimeMessageStore.Factory factory = injector(MailProcessingConfiguration.DEDUPLICATED)
+            .getInstance(MimeMessageStore.Factory.class);
+
+        assertThat(factory.mimeMessageStore()).isNotInstanceOf(DuplicatingMimeMessageStore.class);
+    }
+
+    @Test
+    void shouldDuplicateWhenDeduplicationIsDisabled() {
+        MimeMessageStore.Factory factory = injector(MailProcessingConfiguration.duplicated())
+            .getInstance(MimeMessageStore.Factory.class);
+
+        assertThat(factory.mimeMessageStore()).isInstanceOf(DuplicatingMimeMessageStore.class);
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/mail/DuplicatingMimeMessageStoreTest.java
+++ b/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/mail/DuplicatingMimeMessageStoreTest.java
@@ -1,0 +1,313 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Clock;
+
+import jakarta.mail.internet.MimeMessage;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.blob.api.Store;
+import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.james.blob.mail.MimeMessageStore;
+import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.server.blob.deduplication.BlobStoreFactory;
+import org.apache.james.server.blob.deduplication.GenerationAwareBlobId;
+import org.apache.james.server.core.MimeMessageInputStream;
+import org.apache.james.server.core.MimeMessageWrapper;
+import org.apache.james.util.MimeMessageUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Strings;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class DuplicatingMimeMessageStoreTest {
+    private static final PlainBlobId.Factory BLOB_ID_FACTORY = new PlainBlobId.Factory();
+    private static final BucketName MAIL_PROCESSING = MailProcessingConfiguration.MAIL_PROCESSING_BUCKET;
+
+    private MemoryBlobStoreDAO blobStoreDAO;
+    private RecordingMetricFactory metricFactory;
+    private Store<MimeMessage, MimeMessagePartsId> testee;
+    private Store<MimeMessage, MimeMessagePartsId> deduplicatingStore;
+
+    @BeforeEach
+    void setUp() {
+        blobStoreDAO = new MemoryBlobStoreDAO();
+        metricFactory = new RecordingMetricFactory();
+        BlobStore deduplicatingBlobStore = BlobStoreFactory.builder()
+            .blobStoreDAO(blobStoreDAO)
+            .blobIdFactory(BLOB_ID_FACTORY)
+            .defaultBucketName()
+            .deduplication();
+
+        testee = new DuplicatingMimeMessageStore.Factory(deduplicatingBlobStore, blobStoreDAO, BLOB_ID_FACTORY,
+            MailProcessingConfiguration.duplicated(), metricFactory)
+            .mimeMessageStore();
+        deduplicatingStore = MimeMessageStore.factory(deduplicatingBlobStore).mimeMessageStore();
+    }
+
+    private MimeMessage message() throws Exception {
+        return MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom("any@any.com")
+            .addToRecipient("toddy@any.com")
+            .setSubject("Important Mail")
+            .setText("Important mail content")
+            .build();
+    }
+
+    @Test
+    void factoryShouldReturnTheDeduplicatingStoreWhenDeduplicationIsEnabled() {
+        BlobStore deduplicatingBlobStore = BlobStoreFactory.builder()
+            .blobStoreDAO(blobStoreDAO)
+            .blobIdFactory(BLOB_ID_FACTORY)
+            .defaultBucketName()
+            .deduplication();
+
+        assertThat(new DuplicatingMimeMessageStore.Factory(deduplicatingBlobStore, blobStoreDAO, BLOB_ID_FACTORY,
+            MailProcessingConfiguration.DEDUPLICATED, metricFactory)
+            .mimeMessageStore())
+            .isNotInstanceOf(DuplicatingMimeMessageStore.class);
+    }
+
+    @Test
+    void mailStoreShouldPreserveContent() throws Exception {
+        MimeMessage message = message();
+
+        MimeMessagePartsId parts = testee.save(message).block();
+
+        assertThat(MimeMessageUtil.asString(testee.read(parts).block()))
+            .isEqualTo(MimeMessageUtil.asString(message));
+    }
+
+    @Test
+    void mailStoreShouldPreserveBigContent() throws Exception {
+        MimeMessage message = MimeMessageBuilder.mimeMessageBuilder()
+            .addFrom("any@any.com")
+            .addToRecipient("toddy@any.com")
+            .setSubject("Important Mail")
+            .setText(Strings.repeat("Important mail content\r\n", 20000))
+            .build();
+
+        MimeMessagePartsId parts = testee.save(message).block();
+
+        assertThat(MimeMessageUtil.asString(testee.read(parts).block()))
+            .isEqualTo(MimeMessageUtil.asString(message));
+    }
+
+    @Test
+    void saveShouldWriteASingleBlobInTheMailProcessingBucket() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        assertThat(Flux.from(blobStoreDAO.listBlobs(MAIL_PROCESSING)).collectList().block())
+            .containsExactly(parts.getBodyBlobId());
+    }
+
+    @Test
+    void saveShouldNotWriteInTheDeduplicatingBucket() throws Exception {
+        testee.save(message()).block();
+
+        assertThat(Flux.from(blobStoreDAO.listBlobs(BucketName.DEFAULT)).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void saveShouldFlagTheHeaderBlobId() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        assertThat(parts.getHeaderBlobId().asString()).isEqualTo(DuplicatingMimeMessageStore.NO_HEADER_BLOB);
+    }
+
+    @Test
+    void saveShouldNotDeduplicate() throws Exception {
+        MimeMessagePartsId parts1 = testee.save(message()).block();
+        MimeMessagePartsId parts2 = testee.save(message()).block();
+
+        assertThat(parts1.getBodyBlobId()).isNotEqualTo(parts2.getBodyBlobId());
+        assertThat(Flux.from(blobStoreDAO.listBlobs(MAIL_PROCESSING)).collectList().block())
+            .hasSize(2);
+    }
+
+    @Test
+    void deleteShouldRemoveTheUnderlyingBlob() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        Mono.from(testee.delete(parts)).block();
+
+        assertThat(Flux.from(blobStoreDAO.listBlobs(MAIL_PROCESSING)).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void readShouldThrowUponDeletedMail() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        Mono.from(testee.delete(parts)).block();
+
+        assertThatThrownBy(() -> testee.read(parts).block())
+            .isInstanceOf(ObjectNotFoundException.class);
+    }
+
+    @Test
+    void deleteShouldNotDeleteOtherMails() throws Exception {
+        MimeMessage message = message();
+        MimeMessagePartsId parts1 = testee.save(message()).block();
+        MimeMessagePartsId parts2 = testee.save(message).block();
+
+        Mono.from(testee.delete(parts1)).block();
+
+        assertThat(MimeMessageUtil.asString(testee.read(parts2).block()))
+            .isEqualTo(MimeMessageUtil.asString(message));
+    }
+
+    @Test
+    void theHeaderMarkerShouldSurviveABlobIdSerializationRoundTrip() throws Exception {
+        BlobId.Factory generationAwareBlobIdFactory = new GenerationAwareBlobId.Factory(Clock.systemUTC(), BLOB_ID_FACTORY,
+            GenerationAwareBlobId.Configuration.DEFAULT);
+
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        MimeMessagePartsId deserialized = MimeMessagePartsId.builder()
+            .headerBlobId(generationAwareBlobIdFactory.parse(parts.getHeaderBlobId().asString()))
+            .bodyBlobId(generationAwareBlobIdFactory.parse(parts.getBodyBlobId().asString()))
+            .build();
+
+        assertThat(DuplicatingMimeMessageStore.isFullMessageBlob(deserialized)).isTrue();
+    }
+
+    @Test
+    void readShouldSupportPartsWrittenByTheDeduplicatingStore() throws Exception {
+        MimeMessage message = message();
+        MimeMessagePartsId legacyParts = deduplicatingStore.save(message).block();
+
+        assertThat(MimeMessageUtil.asString(testee.read(legacyParts).block()))
+            .isEqualTo(MimeMessageUtil.asString(message));
+    }
+
+    @Test
+    void deleteShouldNotRemoveBlobsWrittenByTheDeduplicatingStore() throws Exception {
+        MimeMessagePartsId legacyParts = deduplicatingStore.save(message()).block();
+
+        Mono.from(testee.delete(legacyParts)).block();
+
+        assertThat(Flux.from(blobStoreDAO.listBlobs(BucketName.DEFAULT)).collectList().block())
+            .containsExactlyInAnyOrder(legacyParts.getHeaderBlobId(), legacyParts.getBodyBlobId());
+    }
+
+    @Test
+    void deduplicatedMailsShouldRemainReadableAfterTheirDeletionAttempt() throws Exception {
+        MimeMessage message = message();
+        MimeMessagePartsId legacyParts = deduplicatingStore.save(message).block();
+
+        Mono.from(testee.delete(legacyParts)).block();
+
+        assertThat(MimeMessageUtil.asString(testee.read(legacyParts).block()))
+            .isEqualTo(MimeMessageUtil.asString(message));
+    }
+
+    @Test
+    void messageSizeShouldMatchTheUploadedBytes() throws Exception {
+        MimeMessage message = message();
+
+        assertThat(DuplicatingMimeMessageStore.messageSize(message))
+            .isEqualTo(streamSize(message));
+    }
+
+    @Test
+    void messageSizeShouldMatchTheUploadedBytesForWrappedMessages() throws Exception {
+        MimeMessage message = new MimeMessageWrapper(message());
+
+        assertThat(DuplicatingMimeMessageStore.messageSize(message))
+            .isEqualTo(streamSize(message));
+    }
+
+    @Test
+    void messageSizeShouldMatchTheUploadedBytesForModifiedMessages() throws Exception {
+        MimeMessageWrapper message = new MimeMessageWrapper(message());
+        message.addHeader("X-Added-By-A-Mailet", "a value added while the mail was in transit");
+        message.saveChanges();
+
+        assertThat(DuplicatingMimeMessageStore.messageSize(message))
+            .isEqualTo(streamSize(message));
+    }
+
+    @Test
+    void saveShouldPublishATimerMetric() throws Exception {
+        testee.save(message()).block();
+
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.SAVE_TIMER_NAME)).hasSize(1);
+    }
+
+    @Test
+    void readShouldPublishATimerMetric() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        testee.read(parts).block();
+
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.READ_TIMER_NAME)).hasSize(1);
+    }
+
+    @Test
+    void deleteShouldPublishATimerMetric() throws Exception {
+        MimeMessagePartsId parts = testee.save(message()).block();
+
+        Mono.from(testee.delete(parts)).block();
+
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.DELETE_TIMER_NAME)).hasSize(1);
+    }
+
+    @Test
+    void readShouldPublishADedicatedTimerMetricForDeduplicatedMails() throws Exception {
+        MimeMessagePartsId legacyParts = deduplicatingStore.save(message()).block();
+
+        testee.read(legacyParts).block();
+
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.DEDUPLICATED_READ_TIMER_NAME)).hasSize(1);
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.READ_TIMER_NAME)).isEmpty();
+    }
+
+    @Test
+    void deleteShouldPublishADedicatedTimerMetricForDeduplicatedMails() throws Exception {
+        MimeMessagePartsId legacyParts = deduplicatingStore.save(message()).block();
+
+        Mono.from(testee.delete(legacyParts)).block();
+
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.DEDUPLICATED_DELETE_TIMER_NAME)).hasSize(1);
+        assertThat(metricFactory.executionTimesFor(DuplicatingMimeMessageStore.DELETE_TIMER_NAME)).isEmpty();
+    }
+
+    private long streamSize(MimeMessage message) throws Exception {
+        try (InputStream in = new MimeMessageInputStream(message)) {
+            return in.transferTo(OutputStream.nullOutputStream());
+        }
+    }
+}

--- a/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/mail/MailProcessingConfigurationTest.java
+++ b/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/mail/MailProcessingConfigurationTest.java
@@ -1,0 +1,83 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.james.blob.api.BucketName;
+import org.junit.jupiter.api.Test;
+
+class MailProcessingConfigurationTest {
+    private static MailProcessingConfiguration parse(String... lines) {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        for (String line : lines) {
+            int separator = line.indexOf('=');
+            configuration.addProperty(line.substring(0, separator), line.substring(separator + 1));
+        }
+        return MailProcessingConfiguration.from(configuration);
+    }
+
+    @Test
+    void shouldDeduplicateByDefault() {
+        assertThat(parse()).isEqualTo(MailProcessingConfiguration.DEDUPLICATED);
+    }
+
+    @Test
+    void shouldDeduplicateWhenExplicitlyEnabled() {
+        assertThat(parse("mailprocessing.deduplication.enabled=true"))
+            .isEqualTo(MailProcessingConfiguration.DEDUPLICATED);
+    }
+
+    @Test
+    void shouldNotDeduplicateWhenDisabled() {
+        assertThat(parse("mailprocessing.deduplication.enabled=false"))
+            .isEqualTo(MailProcessingConfiguration.duplicated());
+    }
+
+    @Test
+    void shouldSupportTheEnableSpelling() {
+        assertThat(parse("mailprocessing.deduplication.enable=false"))
+            .isEqualTo(MailProcessingConfiguration.duplicated());
+    }
+
+    @Test
+    void shouldSupportTheEnableSpellingWhenEnabled() {
+        assertThat(parse("mailprocessing.deduplication.enable=true"))
+            .isEqualTo(MailProcessingConfiguration.DEDUPLICATED);
+    }
+
+    @Test
+    void enabledShouldTakePrecedenceOverItsAlias() {
+        assertThat(parse("mailprocessing.deduplication.enabled=false", "mailprocessing.deduplication.enable=true"))
+            .isEqualTo(MailProcessingConfiguration.duplicated());
+    }
+
+    @Test
+    void shouldSupportBucketOverriding() {
+        assertThat(parse("mailprocessing.deduplication.enabled=false", "mailprocessing.bucket=in-transit"))
+            .isEqualTo(MailProcessingConfiguration.duplicated(BucketName.of("in-transit")));
+    }
+
+    @Test
+    void bucketOverridingShouldBeIgnoredWhenDeduplicating() {
+        assertThat(parse("mailprocessing.bucket=in-transit"))
+            .isEqualTo(MailProcessingConfiguration.DEDUPLICATED);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable deduplication for mail-processing data.
  * Mail-processing messages can now be stored as standalone objects in a configurable bucket.
  * Standalone in-transit messages are automatically removed after leaving processing and can be replayed from the bucket.
  * Added support for both `enabled` and `enable` configuration keys, with deduplication enabled by default.

* **Documentation**
  * Added configuration guidance and documented storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->