### PR TITLE
[DOCUMENTATION] Release 1.0.20 Changelog and upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,116 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.0.20] - 2026-08-23
+
+### James
+
+#### Added
+
+- JAMES-4210 Protocol-neutral SASL SPI: pluggable, per-server SASL mechanisms for IMAP, SMTP, POP3 and ManageSieve
+- JAMES-4215 Optional SASL GSSAPI (Kerberos) mechanism
+- JAMES-4215 Make the SMTP maximum line length configurable
+- JAMES-4195 JMAP OIDC authentication, with a Redis backed token cache and a backchannel logout route
+- JAMES-4216 Allow HTML templating for overquota emails
+- JAMES-4209 Distributed app content recovery runner
+- [ENHANCEMENT] Optional stricter RRT checks in `ValidRcptHandler` upon email reception
+- [ENHANCEMENT] WebAdmin: default to auto-generated credentials, backed by a Guice bean for the default password generation value
+- [ENHANCEMENT] Add an `autoMerge` mode (defaults to false) to `SolveMailboxInconsistencies`
+
+#### Fixes
+
+- [FIX] S3: the fallback bucket should not apply the bucket prefix
+- [FIX] ManageSieve: adhere to the filename syntax and better validate script names in `SieveFileRepository`
+- JAMES-4210 ManageSieve commands after STARTTLS should work
+- JAMES-4218 IMAP: selection should reset applicable flags, APPEND should trigger flag unsolicited notifications
+- [FIX] IMAP: EXAMINE should honor its read-only promises
+- [FIX] IMAP: rare NPE within processor error handling
+- [FIX] Handle partial rows in `attachmentV2`
+- [FIX] Task manager: tolerate failures for additional information, allow canceling tasks with a truncated history, purge stalled tasks upon cleanup, and handle a missing Cassandra history like Postgres does
+- [FIX] Cassandra event store: read snapshots with a single row and include the snapshot in the event batch
+- [FIX] `CassandraMailRepository` should be more resilient to extra large mail repositories
+- [FIX] `ClearMailRepository` should count only once
+- [FIX] Avoid a 500 upon mail repository download
+- [FIX] Include more IP ranges in WebPush target validation
+- [FIX] Prevent potentially blocking calls upon uploads
+- [FIX] JMAP `DownloadRoutes`: avoid a noisy benign `IllegalStateException` upon mid-stream errors
+- [FIX] `ICALAttributeDTO` should sanitize an invalid dtstamp
+- [FIX] `MessageManager::setFlags` should support overlapping ranges
+- JAMES-4214 Pass the message rather than an `InputStream` so that several body parts can be read
+- [FIX] RabbitMQ: allow disabling the notification queue auto-delete in favor of `x-expires`
+- [FIX] Cassandra folder rename: base decisions on a truth table, use SERIAL for the initial picture, and upfront read the mailbox and its children
+- [FIX] User rename: handle submailbox edge cases, simplify the rename dance when the destination exists, and return the correct quota when the target address is not empty
+- [FIX] `SolveMailboxInconsistencies`: run several times until convergence, address all possible failures, leverage strong consistency, and recover from duplicated or failed `mailboxPathV3` registrations
+- [FIX] Account for consistency choices within `SolveMessageInconsistenciesService` and `RecomputeMailboxCountersService`
+- [FIX] Cross domain RRT was listing non existing addresses
+- [FIX] Prevent PostgreSQL pool poisoning
+- [FIX] `findNonPersonalMailboxes`: handle null rights
+- [FIX] `StoreMailboxManager::renameSubMailboxes` should change the namespace
+- [FIX] Quote usernames correctly
+
+#### Enhancements
+
+- [ENHANCEMENT] Prevent FETCH fragmentation
+- [METRICS] Measure LWT time for UID and ModSeq
+- [AUDIT TRAIL] Log the allocated messageId
+- [DOCUMENTATION] Provide backup guidance
+
+#### Upgrades
+
+- [UPGRADE] ActiveMQ 6.2.6 → 6.2.7 and Artemis 2.53.0 → 2.55.0 (fixes several CVEs)
+- [UPGRADE] RabbitMQ amqp-client 5.25.0 → 5.33.1
+- [UPGRADE] jsoup 1.20.1 → 1.23.1. Note that null characters (`\0`) in HTML are now replaced or removed during tokenization rather than preserved.
+- Bump `org.postgresql:postgresql` to latest
+
+### TMail
+
+#### Added
+
+- ISSUE-2556 JMAP upload from URL extension: specification, implementation, Guice bindings for all TMail applications, contract tests and documentation. Opt-in through `upload.from.url.enabled`.
+- New **migration proxy** application: an IMAP front proxy routing each user to the legacy or to the new backend during a migration, closing IMAP sessions upon migration. Docker images are published, and it is documented.
+- ISSUE-2570 Allow not deduplicating in transit blobs, so that mails in transit do not outlive their processing (`mailprocessing.deduplication.enabled=false`)
+- ISSUE-2405 Team mailbox migration via scoped IMAP login
+- ISSUE-2515 WebAdmin routes to manage mailing lists (read and write)
+- ISSUE-2488 Ease the configuration of the mailing list DN
+- ISSUE-2464 OBM mailing list: handle the `externalContactEmail` attribute
+- [ENHANCEMENT] Support subaddressing for LDAP mailing lists
+- ISSUE-2536 WebAdmin: expose the sum of quota, globally and per domain
+- ISSUE-2479 WebAdmin: `POST /users?action=reindex` to reindex all users
+- ISSUE-2375 WebAdmin tasks to provision the email templates of a reference account into the `Templates` mailbox of a user or of every user of a domain
+- ISSUE-2436 New `IsDmarcReportWithIssues` and `IsDmarcReportWithoutIssues` mailet matchers
+- Scribe: a dedicated AI chat completion client and its own configuration (`scribe.url`, `scribe.token`), decoupled from the RAG configuration
+- ISSUE-2514 Restrict Scribe and the AI label classifier to paying SaaS users through the `applyWhen` filter (`com.linagora.tmail.saas.filter.SaaSPayingUser`)
+- ISSUE-2574 Set a distinct `User-Agent` header for DAV clients
+- JAMES-4210 Adopt the shared James SASL SPI for TMail IMAP and SMTP, with TMail PLAIN SASL defaults
+- Allow sending from, and accepting emails for, aliases of team mailboxes
+
+#### Fixes
+
+- ISSUE-2407 Naming strategy isolation for the event bus notification path: a notification is now only published onto the channels of the event bus that dispatched it
+- ISSUE-2508 Downgrade `CalDavCollect` parse failures to WARN
+- ISSUE-2456 Close TMail AMQP consumers upon shutdown
+- ISSUE-2556 Redact sensitive tokens from remote URLs upon logs
+- [FIX] `IllegalStateException` when a download stream fails after commit
+- [FIX] `IndexOutOfBoundsException` in `DownloadRoutes` for multi-mailbox messages
+- [FIX] `UnsupportedOperationException` when copying calendars with custom `X-` properties
+- [FIX] Calendar copy should preserve the timezone binding
+- [FIX] NPE in `FirebasePushListener` when the messaging error code is null
+- [FIX] `AmqpUri`: `setUri(URI)` no longer throws `URISyntaxException`
+- [FIX] Harden Sent contact indexing
+- JAMES-4210 Fix a startup race between the Redis binding and the pub/sub subscription
+
+#### Enhancements
+
+- ISSUE-2462 Reuse the James JMAP OIDC authentication implementation. The TMail configuration keys, challenge realm, Redis key prefixes and backchannel logout route are preserved.
+- [ENHANCEMENT] `CalDavCollect`: take RRT into account to check the user
+- [ENHANCEMENT] WebAdmin: `password.generate` defaults to `false`, preserving the historical TMail behaviour despite the James default change
+- [ENHANCEMENT] AI: `openrag.ssl.trust.all.certs` and `scribe.ssl.trust.all.certs` now default to `false` (secure by default)
+- [ENHANCEMENT] AI: reorganize the AI packages while keeping the historical fully qualified class names for `AIBaseModule`, `RagDeletionModule`, `LlmClassifierListener`, `RagListener`, `AIBotMailet` and `RecipientsContain`
+- [ENHANCEMENT] Allow configuring the SaaS subscription queue names
+- ISSUE-2556 Bound the remote decompressor allocation
+- ISSUE-2437 Better document the JMAP ecosystem endpoint
+- [REFACTOR] Introduce `ManagedRabbitMQConsumer`
+
 ## [1.0.19] - 2026-06-08
 
 ### James

--- a/tmail-backend/apps/distributed/src/doc/release-instructions/1.0.20/index.md
+++ b/tmail-backend/apps/distributed/src/doc/release-instructions/1.0.20/index.md
@@ -1,0 +1,172 @@
+# Distributed Twake Mail backend 1.0.20 release instructions
+
+## Schema migration
+
+This release requires no mandatory schema migration.
+
+## Behaviour changes
+
+### AI: certificate validation is now enabled by default
+
+`openrag.ssl.trust.all.certs` and `scribe.ssl.trust.all.certs` in `ai.properties` now default to `false`
+instead of `true`. Deployments relying on the previous default - typically those pointing to an OpenRAG or
+Scribe endpoint served with a self-signed certificate - must now set the property explicitly:
+
+```
+openrag.ssl.trust.all.certs=true
+scribe.ssl.trust.all.certs=true
+```
+
+Prefer trusting the private PKI over disabling the validation.
+
+### WebAdmin credentials
+
+Apache James now generates a random WebAdmin password upon startup when `password.generate` is not
+configured, which makes WebAdmin authenticated out of the box. **TMail pins that default back to `false`**,
+so existing TMail deployments are unaffected and WebAdmin keeps its previous behaviour.
+
+Set `password.generate=true` in `webadmin.properties` to opt into the generated password. Note that, without
+JWT nor a configured password, the WebAdmin endpoint remains unauthenticated and must not be exposed outside
+of a trusted network. See the [WebAdmin documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc).
+
+### IMAP / SMTP SASL
+
+TMail adopted the new protocol-neutral SASL SPI of Apache James. No configuration change is required: when
+`TMailImapPackage` or `TMailImapAuthPackage` is declared, the TMail delegation-aware PLAIN mechanism is
+enabled automatically while the other default mechanisms are preserved.
+
+If you explicitly configure `auth.saslMechanisms` in `imapserver.xml`, include the TMail factory in order to
+keep IMAP delegation support:
+
+```xml
+<auth>
+    <saslMechanisms>com.linagora.tmail.sasl.TMailPlainSaslMechanismFactory,OauthBearerSaslMechanismFactory,XOauth2SaslMechanismFactory</saslMechanisms>
+</auth>
+```
+
+See the [IMAP auth delegation extension documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/imap-extensions/imapAuthDelegationExtension.adoc).
+
+### JMAP OIDC authentication
+
+The TMail-specific JMAP OIDC implementation was dropped in favour of the Apache James one. The
+`oidc.*` keys in `jmap.properties`, the `OidcAuthenticationStrategy` class name, the challenge realm, the
+Redis key prefixes and the backchannel logout route are all preserved: no configuration change is required.
+They are now documented in the
+[JMAP OIDC extension page](../../../../../../../docs/modules/ROOT/pages/tmail-backend/jmap-extensions/oidcAuthentication.adoc).
+
+## New features configuration
+
+### JMAP upload from URL (Optional)
+
+TMail can now import an attachment directly from a remote URL, instead of having the client upload its bytes.
+The feature is disabled by default. To enable it, set in `jmap.properties`:
+
+```
+upload.from.url.enabled=true
+upload.from.url.allowed.sources=https://drive.example.com,https://%-drive.twake.linagora.com
+# upload.from.url.source.response.timeout=1m
+# upload.from.url.source.trust.all.ssl.certs=false
+```
+
+Only HTTPS sources are accepted, and the imported content is bounded by the existing `upload.max.size`
+setting. Enabling the feature without `upload.from.url.allowed.sources` starts the server with a warning and
+accepts any HTTPS source on port `443` that passes SSRF validation; pinning the allowed sources is strongly
+advised.
+
+See [JMAP configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/jmap.adoc) and the
+[upload from URL specification](../../../../../../../docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc).
+
+### Mail processing deduplication (Optional)
+
+Mails in transit - the ones held by the mail queue and the mail repositories - are, by default, deduplicated
+with the copies eventually stored within the mailboxes, which means their blobs can only be reclaimed by the
+deduplication garbage collector, several generations later.
+
+Setting the following key in `blob.properties` stores each mail in transit as a standalone RFC822 object,
+deleted as soon as the mail leaves the mail queue or the mail repository:
+
+```
+mailprocessing.deduplication.enabled=false
+# mailprocessing.bucket=mail-processing
+```
+
+This trades storage volume for a bounded, self-managed transit storage, and allows replaying the mail queue
+content out of the `mail-processing` bucket. See
+[blob store configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc).
+
+### RabbitMQ notification queue expiry (Optional)
+
+The per-node notification (key registration) queue can now be declared with a TTL rather than as auto-delete,
+which makes it survive short consumer outages. In `rabbitmq.properties`:
+
+```
+notification.queue.autoDelete=false
+notification.queue.ttl=3600000
+```
+
+Both keys are optional and the previous auto-delete behaviour remains the default.
+
+### Scribe AI endpoint (Optional)
+
+Scribe - the JMAP AI chat completion endpoint `/ai/v1/chat/completions` - now has its own configuration,
+decoupled from the RAG one. In `ai.properties`:
+
+```
+scribe.url=https://chat.example.com
+scribe.token=my-token
+scribe.ssl.trust.all.certs=false
+```
+
+For backward compatibility, Scribe falls back to the legacy `baseURL` and `apiKey` properties when
+`scribe.url` and `scribe.token` are absent.
+
+AI features can be restricted to paying SaaS users through the `applyWhen` filter:
+
+```
+ai.jmap.capability.applyWhen=com.linagora.tmail.saas.filter.SaaSPayingUser
+```
+
+The same filter can be declared on the `LlmMailClassifierListener` in `listeners.xml`. See the
+[AI bot documentation](../../../../../../../tmail-backend/tmail-third-party/ai-bot/README.md).
+
+### Mailing lists (Optional)
+
+WebAdmin routes to read and manage LDAP mailing lists are now available, the mailing list DN configuration
+was eased, subaddressing is supported, and the OBM `externalContactEmail` attribute is handled. See the
+[WebAdmin documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc).
+
+### New WebAdmin routes
+
+- Sum of the quota, globally and per domain.
+- `POST /users?action=reindex` to reindex all users.
+- Tasks to provision the email templates of a reference account into the `Templates` mailbox of a user or
+  of every user of a domain.
+
+### DMARC report matchers (Optional)
+
+New `IsDmarcReportWithIssues` and `IsDmarcReportWithoutIssues` mailet matchers are available for use in the
+mailet container.
+
+### Team mailbox aliases and migration (Optional)
+
+Team mailboxes now accept emails sent to their aliases, and members can send from those aliases. A team
+mailbox can also be migrated through a scoped IMAP login: an administrator authenticating with a team mailbox
+scope is routed to the team mailbox owner rather than to himself.
+
+### Migration proxy (Optional, new application)
+
+A new `migration-proxy` application is shipped: an IMAP front proxy routing each user to the legacy or to the
+new backend during a migration, closing the IMAP sessions of a user upon migration. It is published as a
+dedicated Docker image and is not required by an existing distributed deployment. See the
+[migration proxy documentation](../../../../../../../docs/modules/ROOT/pages/migration-proxy/objective.adoc).
+
+## Tmail deployment
+
+Please update your tmail-backend docker image to the following version: `linagora/tmail-backend:distributed-1.0.20`
+
+Deployments using the AI features should use `linagora/tmail-backend:distributed-ai-1.0.20` instead, and
+deployments running the migration proxy should use `linagora/tmail-migration-proxy:1.0.20`.
+
+## References
+
+* Official Twake Mail release notes: https://github.com/linagora/tmail-backend/releases/tag/1.0.20

--- a/tmail-backend/apps/postgres/src/doc/release-instructions/1.0.20/index.md
+++ b/tmail-backend/apps/postgres/src/doc/release-instructions/1.0.20/index.md
@@ -1,0 +1,122 @@
+# Postgres Twake Mail backend 1.0.20 release instructions
+
+## Schema migration
+
+This release requires no mandatory schema migration.
+
+## Behaviour changes
+
+### WebAdmin credentials
+
+Apache James now generates a random WebAdmin password upon startup when `password.generate` is not
+configured, which makes WebAdmin authenticated out of the box. **TMail pins that default back to `false`**,
+so existing TMail deployments are unaffected and WebAdmin keeps its previous behaviour.
+
+Set `password.generate=true` in `webadmin.properties` to opt into the generated password. Note that, without
+JWT nor a configured password, the WebAdmin endpoint remains unauthenticated and must not be exposed outside
+of a trusted network. See the [WebAdmin documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc).
+
+### IMAP / SMTP SASL
+
+TMail adopted the new protocol-neutral SASL SPI of Apache James. No configuration change is required: when
+`TMailImapPackage` or `TMailImapAuthPackage` is declared, the TMail delegation-aware PLAIN mechanism is
+enabled automatically while the other default mechanisms are preserved.
+
+If you explicitly configure `auth.saslMechanisms` in `imapserver.xml`, include the TMail factory in order to
+keep IMAP delegation support:
+
+```xml
+<auth>
+    <saslMechanisms>com.linagora.tmail.sasl.TMailPlainSaslMechanismFactory,OauthBearerSaslMechanismFactory,XOauth2SaslMechanismFactory</saslMechanisms>
+</auth>
+```
+
+See the [IMAP auth delegation extension documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/imap-extensions/imapAuthDelegationExtension.adoc).
+
+### JMAP OIDC authentication
+
+The TMail-specific JMAP OIDC implementation was dropped in favour of the Apache James one. The
+`oidc.*` keys in `jmap.properties`, the `OidcAuthenticationStrategy` class name, the challenge realm, the
+Redis key prefixes and the backchannel logout route are all preserved: no configuration change is required.
+They are now documented in the
+[JMAP OIDC extension page](../../../../../../../docs/modules/ROOT/pages/tmail-backend/jmap-extensions/oidcAuthentication.adoc).
+
+## New features
+
+### JMAP upload from URL (Optional)
+
+TMail can now import an attachment directly from a remote URL, instead of having the client upload its bytes.
+The feature is disabled by default. To enable it, set in `jmap.properties`:
+
+```
+upload.from.url.enabled=true
+upload.from.url.allowed.sources=https://drive.example.com,https://%-drive.twake.linagora.com
+# upload.from.url.source.response.timeout=1m
+# upload.from.url.source.trust.all.ssl.certs=false
+```
+
+Only HTTPS sources are accepted, and the imported content is bounded by the existing `upload.max.size`
+setting. Enabling the feature without `upload.from.url.allowed.sources` starts the server with a warning and
+accepts any HTTPS source on port `443` that passes SSRF validation; pinning the allowed sources is strongly
+advised.
+
+See [JMAP configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/jmap.adoc) and the
+[upload from URL specification](../../../../../../../docs/modules/ROOT/pages/tmail-backend/jmap-extensions/uploadFromUrl.adoc).
+
+### Mail processing deduplication (Optional)
+
+Mails in transit - the ones held by the mail queue and the mail repositories - are, by default, deduplicated
+with the copies eventually stored within the mailboxes, which means their blobs can only be reclaimed by the
+deduplication garbage collector, several generations later.
+
+Setting the following key in `blob.properties` stores each mail in transit as a standalone RFC822 object,
+deleted as soon as the mail leaves the mail queue or the mail repository:
+
+```
+mailprocessing.deduplication.enabled=false
+# mailprocessing.bucket=mail-processing
+```
+
+This trades storage volume for a bounded, self-managed transit storage. See
+[blob store configuration](../../../../../../../docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc).
+
+### Mailing lists (Optional)
+
+WebAdmin routes to read and manage LDAP mailing lists are now available, the mailing list DN configuration
+was eased, subaddressing is supported, and the OBM `externalContactEmail` attribute is handled. See the
+[WebAdmin documentation](../../../../../../../docs/modules/ROOT/pages/tmail-backend/webadmin.adoc).
+
+### New WebAdmin routes
+
+- Sum of the quota, globally and per domain.
+- `POST /users?action=reindex` to reindex all users.
+- Tasks to provision the email templates of a reference account into the `Templates` mailbox of a user or
+  of every user of a domain.
+
+### DMARC report matchers (Optional)
+
+New `IsDmarcReportWithIssues` and `IsDmarcReportWithoutIssues` mailet matchers are available for use in the
+mailet container.
+
+### Team mailbox aliases and migration (Optional)
+
+Team mailboxes now accept emails sent to their aliases, and members can send from those aliases. A team
+mailbox can also be migrated through a scoped IMAP login: an administrator authenticating with a team mailbox
+scope is routed to the team mailbox owner rather than to himself.
+
+### Migration proxy (Optional, new application)
+
+A new `migration-proxy` application is shipped: an IMAP front proxy routing each user to the legacy or to the
+new backend during a migration, closing the IMAP sessions of a user upon migration. It is published as a
+dedicated Docker image and is not required by an existing Postgres deployment. See the
+[migration proxy documentation](../../../../../../../docs/modules/ROOT/pages/migration-proxy/objective.adoc).
+
+## Tmail deployment
+
+Please update your tmail-backend docker image to the following version: `linagora/tmail-backend:postgresql-1.0.20`
+
+Deployments running the migration proxy should use `linagora/tmail-migration-proxy:1.0.20`.
+
+## References
+
+* Official Twake Mail release notes: https://github.com/linagora/tmail-backend/releases/tag/1.0.20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Twake Mail 1.0.20, covering new features, fixes, enhancements, and dependency updates.
  * Added deployment guidance for Distributed and Postgres editions, including migration requirements, configuration updates, authentication, mail processing, mailing lists, aliases, and migration proxy setup.
  * Documented updated WebAdmin routes, credential behavior, deployment image versions, and release references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->