### PR TITLE
ISSUE-2591 update document for macros user build tmail-backend image

### DIFF
--- a/tmail-backend/apps/distributed/README.md
+++ b/tmail-backend/apps/distributed/README.md
@@ -26,7 +26,14 @@ To build the distributed server:
 
 ```
 mvn clean install
+
+#You can add the -DskipTests flag as well if you don't want to run the tests.
+mvn clean install -DskipTests
+
 mvn compile com.google.cloud.tools:jib-maven-plugin:3.4.3:dockerBuild
+
+# For Apple Silicon users, you can build the image for ARM64 architecture with:
+mvn compile com.google.cloud.tools:jib-maven-plugin:3.4.3:dockerBuild -Djib.from.platforms=linux/arm64
 ```
 
 ## Run

--- a/tmail-backend/apps/memory/README.md
+++ b/tmail-backend/apps/memory/README.md
@@ -21,6 +21,9 @@ Then to build your server:
 ```
 mvn clean install
 mvn compile com.google.cloud.tools:jib-maven-plugin:3.4.3:dockerBuild
+
+# For Apple Silicon users, you can build the image for ARM64 architecture with:
+mvn compile com.google.cloud.tools:jib-maven-plugin:3.4.3:dockerBuild -Djib.from.platforms=linux/arm64
 ```
 
 You can add the -DskipTests flag as well if you don't want to run the tests.


### PR DESCRIPTION
Update document for macros user build tmail-backend image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for building Docker images on Apple Silicon using the ARM64 platform.
  * Documented a Maven build option that skips tests for faster builds.
  * Retained existing standard build and Docker build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->