### PR TITLE
ISSUE-2509 Avoid version conflicts when migrating contacts upon username change

### DIFF
--- a/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStep.scala
+++ b/tmail-backend/jmap/extensions-api/src/main/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStep.scala
@@ -34,7 +34,11 @@ class ContactUsernameChangeTaskStep @Inject()(contactSearchEngine: EmailAddressC
     val oldAccountId: AccountId = AccountId.fromUsername(oldUsername)
     val newAccountId: AccountId = AccountId.fromUsername(newUsername)
 
+    // An address stored in several address books is listed once per address book while
+    // delete(accountId, address) removes all of them at once: deduplicate to avoid concurrent
+    // delete-by-query racing each other on the same documents (409 version conflicts).
     SFlux.fromPublisher(contactSearchEngine.list(oldAccountId))
+      .distinct(_.fields.address)
       .flatMap(contact => SMono.fromPublisher(contactSearchEngine.index(newAccountId, contact.fields))
         .`then`(SMono.fromPublisher(contactSearchEngine.delete(oldAccountId, contact.fields.address))))
       .`then`()

--- a/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OSEmailAddressContactSearchEngine.java
+++ b/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OSEmailAddressContactSearchEngine.java
@@ -26,6 +26,7 @@ import static com.linagora.tmail.james.jmap.ContactMappingFactory.EMAIL;
 import static com.linagora.tmail.james.jmap.ContactMappingFactory.FIRSTNAME;
 import static com.linagora.tmail.james.jmap.ContactMappingFactory.SURNAME;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -45,6 +46,7 @@ import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.util.FunctionalUtils;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -72,10 +74,15 @@ import com.linagora.tmail.james.jmap.dto.DomainContactDocument;
 import com.linagora.tmail.james.jmap.dto.UserContactDocument;
 
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 public class OSEmailAddressContactSearchEngine implements EmailAddressContactSearchEngine {
     private static final String DELIMITER = ":";
     private static final Time TIMEOUT = new Time.Builder().time("1m").build();
+    private static final int HTTP_CONFLICT = 409;
+    private static final int DELETE_BY_QUERY_MAX_RETRIES = 3;
+    // Above the default 1s refresh interval so a retry searches a refreshed view of the index
+    private static final Duration DELETE_BY_QUERY_RETRY_BACKOFF = Duration.ofMillis(500);
 
     private static final List<String> ALL_SEARCH_FIELDS = List.of(EMAIL, FIRSTNAME, SURNAME);
     private final OpenSearchIndexer userContactIndexer;
@@ -165,9 +172,19 @@ public class OSEmailAddressContactSearchEngine implements EmailAddressContactSea
                 .field(ACCOUNT_ID)
                 .value(new FieldValue.Builder().stringValue(accountId.getIdentifier()).build())).toQuery())).toQuery();
 
-        return userContactIndexer.deleteAllMatchingQuery(combinedQuery,
-                RoutingKey.fromString(address.asString()))
+        // defer: the underlying request is sent eagerly, each retry must issue a fresh one
+        return Mono.defer(() -> userContactIndexer.deleteAllMatchingQuery(combinedQuery,
+                RoutingKey.fromString(address.asString())))
+            .retryWhen(Retry.backoff(DELETE_BY_QUERY_MAX_RETRIES, DELETE_BY_QUERY_RETRY_BACKOFF)
+                .filter(OSEmailAddressContactSearchEngine::isVersionConflict))
             .then();
+    }
+
+    // A concurrent delete removed documents between the delete-by-query search and delete phases:
+    // replaying the query then sees a refreshed snapshot and completes.
+    private static boolean isVersionConflict(Throwable throwable) {
+        return throwable instanceof ResponseException responseException
+            && responseException.getResponse().getStatusLine().getStatusCode() == HTTP_CONFLICT;
     }
 
     @Override

--- a/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OSEmailAddressContactSearchEngine.java
+++ b/tmail-backend/jmap/extensions-opensearch/src/main/java/com/linagora/tmail/james/jmap/OSEmailAddressContactSearchEngine.java
@@ -81,8 +81,8 @@ public class OSEmailAddressContactSearchEngine implements EmailAddressContactSea
     private static final Time TIMEOUT = new Time.Builder().time("1m").build();
     private static final int HTTP_CONFLICT = 409;
     private static final int DELETE_BY_QUERY_MAX_RETRIES = 3;
-    // Above the default 1s refresh interval so a retry searches a refreshed view of the index
-    private static final Duration DELETE_BY_QUERY_RETRY_BACKOFF = Duration.ofMillis(500);
+    // Fixed delay (no jitter) above the default 1s refresh interval so each retry searches a refreshed view of the index
+    private static final Duration DELETE_BY_QUERY_RETRY_DELAY = Duration.ofMillis(1500);
 
     private static final List<String> ALL_SEARCH_FIELDS = List.of(EMAIL, FIRSTNAME, SURNAME);
     private final OpenSearchIndexer userContactIndexer;
@@ -175,7 +175,7 @@ public class OSEmailAddressContactSearchEngine implements EmailAddressContactSea
         // defer: the underlying request is sent eagerly, each retry must issue a fresh one
         return Mono.defer(() -> userContactIndexer.deleteAllMatchingQuery(combinedQuery,
                 RoutingKey.fromString(address.asString())))
-            .retryWhen(Retry.backoff(DELETE_BY_QUERY_MAX_RETRIES, DELETE_BY_QUERY_RETRY_BACKOFF)
+            .retryWhen(Retry.fixedDelay(DELETE_BY_QUERY_MAX_RETRIES, DELETE_BY_QUERY_RETRY_DELAY)
                 .filter(OSEmailAddressContactSearchEngine::isVersionConflict))
             .then();
     }

--- a/tmail-backend/jmap/extensions-opensearch/src/test/java/com/linagora.tmail.james.jmap.model/OSEmailAddressContactSearchTest.java
+++ b/tmail-backend/jmap/extensions-opensearch/src/test/java/com/linagora.tmail.james.jmap.model/OSEmailAddressContactSearchTest.java
@@ -20,18 +20,24 @@ package com.linagora.tmail.james.jmap.model;
 
 import static com.linagora.tmail.james.jmap.OpenSearchContactConfiguration.DEFAULT_CONFIGURATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.apache.james.backends.opensearch.DockerOpenSearchExtension;
 import org.apache.james.backends.opensearch.IndexCreationFactory;
 import org.apache.james.backends.opensearch.OpenSearchConfiguration;
 import org.apache.james.backends.opensearch.ReactorOpenSearchClient;
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.api.model.AccountId;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -40,12 +46,20 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 
 import com.linagora.tmail.james.jmap.ContactMappingFactory;
 import com.linagora.tmail.james.jmap.OSEmailAddressContactSearchEngine;
+import com.linagora.tmail.james.jmap.contact.ContactFields;
 import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngine;
 import com.linagora.tmail.james.jmap.contact.EmailAddressContactSearchEngineContract;
+import com.linagora.tmail.james.jmap.contact.MatchAllQuery;
 import com.linagora.tmail.james.jmap.contact.MatchQuery;
 import com.linagora.tmail.james.jmap.contact.QueryType;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 public class OSEmailAddressContactSearchTest implements EmailAddressContactSearchEngineContract {
+    private static final AccountId ACCOUNT_ID = AccountId.fromUsername(Username.of("bob@linagora.com"));
+    private static final int ADDRESS_BOOK_COUNT = 5;
+    private static final int CONCURRENT_DELETES = 10;
     private static final ConditionFactory CALMLY_AWAIT = Awaitility
         .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
         .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
@@ -83,6 +97,25 @@ public class OSEmailAddressContactSearchTest implements EmailAddressContactSearc
                         .build())
                 .block()
                 .hits().total().value()).isEqualTo(documentCount));
+    }
+
+    @Test
+    void concurrentDeletesOfTheSameAddressShouldNotFail() throws Exception {
+        MailAddress mailAddress = new MailAddress("multi@linagora.com");
+        ContactFields fields = ContactFields.of(mailAddress, "Multi", "Contact");
+        Flux.range(0, ADDRESS_BOOK_COUNT)
+            .flatMap(any -> searchEngine.index(ACCOUNT_ID, fields, UUID.randomUUID().toString()))
+            .then()
+            .block();
+        awaitDocumentsIndexed(new MatchAllQuery(), ADDRESS_BOOK_COUNT);
+
+        assertThatCode(() -> Flux.range(0, CONCURRENT_DELETES)
+            .flatMap(any -> Mono.from(searchEngine.delete(ACCOUNT_ID, mailAddress)))
+            .then()
+            .block())
+            .doesNotThrowAnyException();
+
+        awaitDocumentsIndexed(new MatchAllQuery(), 0);
     }
 
     private Query extractOpenSearchQuery(QueryType queryType) {

--- a/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStepTest.scala
+++ b/tmail-backend/jmap/extensions/src/test/scala/com/linagora/tmail/james/jmap/contact/ContactUsernameChangeTaskStepTest.scala
@@ -18,11 +18,14 @@
 
 package com.linagora.tmail.james.jmap.contact
 
-import ContactUsernameChangeTaskStepTest.{ALICE, ALICE_ACCOUNT_ID, ANDRE_CONTACT, BOB, BOB_ACCOUNT_ID, MARIE_CONTACT}
+import java.util.concurrent.atomic.AtomicInteger
+
+import ContactUsernameChangeTaskStepTest.{ADDRESS_BOOK_1, ADDRESS_BOOK_2, ALICE, ALICE_ACCOUNT_ID, ANDRE_CONTACT, BOB, BOB_ACCOUNT_ID, MARIE_CONTACT}
 import org.apache.james.core.{MailAddress, Username}
 import org.apache.james.jmap.api.model.AccountId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, Test}
+import org.reactivestreams.Publisher
 import reactor.core.scala.publisher.{SFlux, SMono}
 
 import scala.jdk.CollectionConverters._
@@ -39,6 +42,8 @@ object ContactUsernameChangeTaskStepTest {
   val MARIE_CONTACT: ContactFields = ContactFields(MARIE_MAIL_ADDRESS, "Marie", "Bourdier")
   val ALICE_MAIL_ADDRESS: MailAddress = new MailAddress("alice@linagora.com")
   val ALICE_CONTACT: ContactFields = ContactFields(ALICE_MAIL_ADDRESS, "Alice", "Gwen")
+  val ADDRESS_BOOK_1: String = "addressBook1"
+  val ADDRESS_BOOK_2: String = "addressBook2"
 }
 
 class ContactUsernameChangeTaskStepTest {
@@ -99,5 +104,41 @@ class ContactUsernameChangeTaskStepTest {
       .map(_.fields)
       .collectSeq().block().asJava)
       .containsExactlyInAnyOrder(ANDRE_CONTACT, MARIE_CONTACT)
+  }
+
+  @Test
+  def shouldMigrateContactPresentInSeveralAddressBooks(): Unit = {
+    SMono.fromPublisher(searchEngine.index(ALICE_ACCOUNT_ID, ANDRE_CONTACT, ADDRESS_BOOK_1)).block()
+    SMono.fromPublisher(searchEngine.index(ALICE_ACCOUNT_ID, ANDRE_CONTACT, ADDRESS_BOOK_2)).block()
+
+    SMono.fromPublisher(testee.changeUsername(ALICE, BOB)).block()
+
+    assertThat(SFlux.fromPublisher(searchEngine.list(BOB_ACCOUNT_ID))
+      .map(_.fields)
+      .collectSeq().block().asJava)
+      .containsExactly(ANDRE_CONTACT)
+    assertThat(SFlux.fromPublisher(searchEngine.list(ALICE_ACCOUNT_ID))
+      .map(_.fields)
+      .collectSeq().block().asJava)
+      .isEmpty()
+  }
+
+  @Test
+  def shouldDeleteEachAddressOnlyOnce(): Unit = {
+    val deleteCount: AtomicInteger = new AtomicInteger(0)
+    val countingSearchEngine: EmailAddressContactSearchEngine = new InMemoryEmailAddressContactSearchEngine {
+      override def delete(accountId: AccountId, mailAddress: MailAddress): Publisher[Void] = {
+        deleteCount.incrementAndGet()
+        super.delete(accountId, mailAddress)
+      }
+    }
+    testee = new ContactUsernameChangeTaskStep(countingSearchEngine)
+    SMono.fromPublisher(countingSearchEngine.index(ALICE_ACCOUNT_ID, ANDRE_CONTACT, ADDRESS_BOOK_1)).block()
+    SMono.fromPublisher(countingSearchEngine.index(ALICE_ACCOUNT_ID, ANDRE_CONTACT, ADDRESS_BOOK_2)).block()
+    SMono.fromPublisher(countingSearchEngine.index(ALICE_ACCOUNT_ID, MARIE_CONTACT, ADDRESS_BOOK_1)).block()
+
+    SMono.fromPublisher(testee.changeUsername(ALICE, BOB)).block()
+
+    assertThat(deleteCount.get()).isEqualTo(2)
   }
 }


### PR DESCRIPTION
Closes #2509

## Root cause

`ContactUsernameChangeTaskStep` drives the migration off `list(oldAccountId)`, which returns one entry per (address, address book). `delete(oldAccountId, address)` however is a `_delete_by_query` that removes **all** address-book variants of that address at once. An address present in N address books therefore fired N concurrent `_delete_by_query` on the same documents (same routing shard): the first one wins, the others find the documents already gone and fail with a `409 version_conflict_engine_exception` — which failed the whole `UsernameChangeTask` even though the data ended up consistent.

## Fix

1. **`ContactUsernameChangeTaskStep`**: `.distinct(_.fields.address)` before migrating, so each address is indexed and deleted exactly once. This removes the self-inflicted race.
2. **`OSEmailAddressContactSearchEngine.delete(accountId, address)`**: retry (3 attempts, 500ms exponential backoff) upon `ResponseException` with status 409, as suggested in the issue. The backoff exceeds the default 1s refresh interval so a retry runs against a refreshed snapshot, where the already-deleted documents are no longer matched. The request is wrapped in `Mono.defer` because `ReactorOpenSearchClient` sends the request eagerly: without it, retries just replayed the same failed future (observed while writing the test).

## Tests

- `ContactUsernameChangeTaskStepTest`: `shouldMigrateContactPresentInSeveralAddressBooks` and `shouldDeleteEachAddressOnlyOnce` (counts `delete` invocations on a decorated in-memory engine).
- `OSEmailAddressContactSearchTest.concurrentDeletesOfTheSameAddressShouldNotFail`: 10 concurrent broad deletes of an address indexed in 5 address books. Without the retry this test reproduces the exact production 409 (`version_conflicts: 5, deleted: 0`); with it, it passes and the documents are gone.

Full `OSEmailAddressContactSearchTest` class (90 tests) and checkstyle pass locally.

Note: `jmap-extensions` currently does not compile against the James snapshot in my local `~/.m2` (unrelated `SSRFValidator` missing), so the Scala test was validated by running it from `extensions-api` where the step and in-memory engine live; CI will run it in place.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contact migration when the same contact appears in multiple address books, preventing duplicate processing.
  - Prevented conflicts during concurrent contact deletions by retrying eligible operations automatically.
  - Ensured contacts are migrated once and removed cleanly from the original account.

- **Tests**
  - Added coverage for duplicate contacts across address books and concurrent deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->