### PR TITLE
ISSUE-2603 Expose Dav server response as sabreResponse MDC field on CalDav/CardDav errors

### DIFF
--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavAddContactProcessor.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavAddContactProcessor.java
@@ -26,6 +26,7 @@ import jakarta.inject.Singleton;
 
 import org.apache.james.core.Username;
 import org.apache.james.util.FunctionalUtils;
+import org.apache.james.util.MDCBuilder;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,10 +74,8 @@ public class CardDavAddContactProcessor implements ContactAddIndexingProcessor {
                 return cardDavClient.existsCollectedContact(openPassUserId, cardDavCreationObjectRequest.uid())
                     .filter(FunctionalUtils.identityPredicate().negate())
                     .flatMap(exists -> cardDavClient.createCollectedContact(openPassUserId, cardDavCreationObjectRequest))
-                    .onErrorResume(error -> {
-                        LOGGER.error("Error while creating collected contact if not exists.", error);
-                        return Mono.empty();
-                    });
+                    .onErrorResume(error -> Mono.fromRunnable(() -> MDCBuilder.withMdc(DavClientException.mdcOf(error),
+                        () -> LOGGER.error("Error while creating collected contact if not exists.", error))));
             });
     }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavClient.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/CardDavClient.java
@@ -28,6 +28,7 @@ import com.linagora.tmail.dav.request.CardDavCreationObjectRequest;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
@@ -45,16 +46,15 @@ public class CardDavClient {
     public Mono<Boolean> existsCollectedContact(OpenPaaSUserId userId, DavUid collectedId) {
         return client.get()
             .uri(String.format(COLLECTED_ADDRESS_BOOK_PATH, userId.value(), collectedId.value()))
-            .responseSingle((response, byteBufMono) -> handleContactExistsResponse(response, userId, collectedId));
+            .responseSingle((response, byteBufMono) -> handleContactExistsResponse(response, byteBufMono, userId, collectedId));
     }
 
-    private Mono<Boolean> handleContactExistsResponse(HttpClientResponse response, OpenPaaSUserId userId, DavUid collectedId) {
+    private Mono<Boolean> handleContactExistsResponse(HttpClientResponse response, ByteBufMono responseContent, OpenPaaSUserId userId, DavUid collectedId) {
         return switch (response.status().code()) {
             case 200 -> Mono.just(true);
             case 404 -> Mono.just(false);
-            default -> Mono.error(new DavClientException(
-                String.format("Unexpected status code: %d when checking contact exists for userId: %s and collectedId: %s",
-                    response.status().code(), userId.value(), collectedId.value())));
+            default -> DavClientHelper.unexpectedStatus(response, responseContent,
+                "checking contact exists for userId: %s and collectedId: %s".formatted(userId.value(), collectedId.value()));
         };
     }
 
@@ -67,18 +67,18 @@ public class CardDavClient {
             .put()
             .uri(String.format(COLLECTED_ADDRESS_BOOK_PATH, userId.value(), vcardUid.value()))
             .send(Mono.just(Unpooled.wrappedBuffer(vcardPayload)))
-            .responseSingle((response, byteBufMono) -> handleContactCreationResponse(response, userId, vcardUid));
+            .responseSingle((response, byteBufMono) -> handleContactCreationResponse(response, byteBufMono, userId, vcardUid));
     }
 
-    private Mono<Void> handleContactCreationResponse(HttpClientResponse response, OpenPaaSUserId userId, DavUid vcardUid) {
+    private Mono<Void> handleContactCreationResponse(HttpClientResponse response, ByteBufMono responseContent, OpenPaaSUserId userId, DavUid vcardUid) {
         return switch (response.status().code()) {
             case 201 -> Mono.empty();
             case 204 -> {
                 LOGGER.info("Contact for user {} and collected id {} already exists", userId.value(), vcardUid.value());
                 yield Mono.empty();
             }
-            default -> Mono.error(new DavClientException(
-                String.format("Unexpected status code: %d when creating contact for user: %s and collected id: %s", response.status().code(), userId.value(), vcardUid.value())));
+            default -> DavClientHelper.unexpectedStatus(response, responseContent,
+                "creating contact for user: %s and collected id: %s".formatted(userId.value(), vcardUid.value()));
         };
     }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientException.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientException.java
@@ -18,13 +18,60 @@
 
 package com.linagora.tmail.dav;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.apache.james.util.MDCBuilder;
+
 public class DavClientException extends RuntimeException {
+    public static final String SABRE_RESPONSE_MDC_KEY = "sabreResponse";
+    public static final int SABRE_RESPONSE_MAX_BYTES = 1024;
+
+    /**
+     * Builds the MDC context to be used when logging the given error: when it is a {@link DavClientException}
+     * carrying the Dav server response, that response is exposed under the {@value #SABRE_RESPONSE_MDC_KEY} key.
+     */
+    public static MDCBuilder mdcOf(Throwable throwable) {
+        if (throwable instanceof DavClientException davClientException) {
+            return davClientException.mdc();
+        }
+        return MDCBuilder.create();
+    }
+
+    public static String truncateSabreResponse(byte[] responseBody) {
+        byte[] truncated = Arrays.copyOf(responseBody, Math.min(responseBody.length, SABRE_RESPONSE_MAX_BYTES));
+        return new String(truncated, StandardCharsets.UTF_8);
+    }
+
+    private final Optional<String> sabreResponse;
+
     public DavClientException(String message) {
         super(message);
+        this.sabreResponse = Optional.empty();
     }
 
     public DavClientException(String message, Throwable cause) {
         super(message, cause);
+        this.sabreResponse = Optional.empty();
+    }
+
+    public DavClientException(String message, String sabreResponse) {
+        super(message);
+        this.sabreResponse = Optional.of(sabreResponse);
+    }
+
+    /**
+     * Body of the Dav server response that caused this exception, truncated to the first
+     * {@value #SABRE_RESPONSE_MAX_BYTES} bytes, when available.
+     */
+    public Optional<String> sabreResponse() {
+        return sabreResponse;
+    }
+
+    public MDCBuilder mdc() {
+        return MDCBuilder.create()
+            .addToContextIfPresent(SABRE_RESPONSE_MDC_KEY, sabreResponse);
     }
 
     public static class PermissionDenied extends DavClientException {

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientException.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientException.java
@@ -18,15 +18,13 @@
 
 package com.linagora.tmail.dav;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Optional;
 
 import org.apache.james.util.MDCBuilder;
 
 public class DavClientException extends RuntimeException {
     public static final String SABRE_RESPONSE_MDC_KEY = "sabreResponse";
-    public static final int SABRE_RESPONSE_MAX_BYTES = 1024;
+    public static final int SABRE_RESPONSE_MAX_CHARS = 1024;
 
     /**
      * Builds the MDC context to be used when logging the given error: when it is a {@link DavClientException}
@@ -39,9 +37,15 @@ public class DavClientException extends RuntimeException {
         return MDCBuilder.create();
     }
 
-    public static String truncateSabreResponse(byte[] responseBody) {
-        byte[] truncated = Arrays.copyOf(responseBody, Math.min(responseBody.length, SABRE_RESPONSE_MAX_BYTES));
-        return new String(truncated, StandardCharsets.UTF_8);
+    /**
+     * Truncates by Unicode code points rather than by bytes so that no multi-byte UTF-8 sequence
+     * nor UTF-16 surrogate pair gets split, which would yield an invalid string.
+     */
+    public static String truncateSabreResponse(String responseBody) {
+        return responseBody.codePoints()
+            .limit(SABRE_RESPONSE_MAX_CHARS)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
     }
 
     private final Optional<String> sabreResponse;
@@ -63,7 +67,7 @@ public class DavClientException extends RuntimeException {
 
     /**
      * Body of the Dav server response that caused this exception, truncated to the first
-     * {@value #SABRE_RESPONSE_MAX_BYTES} bytes, when available.
+     * {@value #SABRE_RESPONSE_MAX_CHARS} characters, when available.
      */
     public Optional<String> sabreResponse() {
         return sabreResponse;

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
@@ -20,19 +20,18 @@ package com.linagora.tmail.dav;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.lang3.StringUtils;
-
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClientResponse;
 
 class DavClientHelper {
-
+    private static final byte[] EMPTY_BODY = new byte[0];
 
     static <T> Mono<T> unexpectedStatus(HttpClientResponse response, ByteBufMono content, String context) {
-        return content.asString(StandardCharsets.UTF_8)
-            .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+        return content.asByteArray()
+            .switchIfEmpty(Mono.just(EMPTY_BODY))
             .flatMap(body -> Mono.error(new DavClientException(
-                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, body))));
+                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, new String(body, StandardCharsets.UTF_8)),
+                DavClientException.truncateSabreResponse(body))));
     }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
@@ -30,8 +30,9 @@ class DavClientHelper {
     static <T> Mono<T> unexpectedStatus(HttpClientResponse response, ByteBufMono content, String context) {
         return content.asByteArray()
             .switchIfEmpty(Mono.just(EMPTY_BODY))
+            .map(body -> new String(body, StandardCharsets.UTF_8))
             .flatMap(body -> Mono.error(new DavClientException(
-                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, new String(body, StandardCharsets.UTF_8)),
+                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, body),
                 DavClientException.truncateSabreResponse(body))));
     }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/dav/DavClientHelper.java
@@ -31,8 +31,9 @@ class DavClientHelper {
         return content.asByteArray()
             .switchIfEmpty(Mono.just(EMPTY_BODY))
             .map(body -> new String(body, StandardCharsets.UTF_8))
-            .flatMap(body -> Mono.error(new DavClientException(
-                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, body),
-                DavClientException.truncateSabreResponse(body))));
+            .map(DavClientException::truncateSabreResponse)
+            .flatMap(truncatedBody -> Mono.error(new DavClientException(
+                "Unexpected status code: %d when %s: %s".formatted(response.status().code(), context, truncatedBody),
+                truncatedBody)));
     }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/main/java/com/linagora/tmail/mailet/CalDavCollect.java
@@ -31,6 +31,7 @@ import jakarta.mail.MessagingException;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
+import org.apache.james.util.MDCBuilder;
 import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
 import org.apache.mailet.AttributeValue;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linagora.tmail.dav.DavClient;
+import com.linagora.tmail.dav.DavClientException;
 import com.linagora.tmail.dav.DavUser;
 import com.linagora.tmail.dav.DavUserProvider;
 
@@ -123,7 +125,8 @@ public class CalDavCollect extends GenericMailet {
             } catch (ParserException e) {
                 LOGGER.warn("Failed to parse calendar in mail {} with recipient {}: malformed iCalendar payload", mail.getName(), recipient, e);
             } catch (Exception e) {
-                LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e);
+                MDCBuilder.withMdc(DavClientException.mdcOf(e),
+                    () -> LOGGER.error("Error while handling calendar in mail {} with recipient {}", mail.getName(), recipient, e));
             }
         }
     }

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
@@ -423,8 +423,10 @@ class DavClientTest {
                 .willReturn(badRequest().withBody(longBody)));
 
         assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
-            .isInstanceOfSatisfying(DavClientException.class,
-                exception -> assertThat(exception.sabreResponse()).contains("a".repeat(DavClientException.SABRE_RESPONSE_MAX_CHARS)));
+            .isInstanceOfSatisfying(DavClientException.class, exception -> {
+                assertThat(exception.sabreResponse()).contains("a".repeat(DavClientException.SABRE_RESPONSE_MAX_CHARS));
+                assertThat(exception.getMessage()).doesNotContain("a".repeat(DavClientException.SABRE_RESPONSE_MAX_CHARS + 1));
+            });
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
@@ -19,11 +19,13 @@
 package com.linagora.tmail.dav;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -41,6 +43,7 @@ import static com.linagora.tmail.dav.DavServerExtension.ALICE_DAV_USER;
 import static com.linagora.tmail.dav.DavServerExtension.ALICE_ID;
 import static com.linagora.tmail.dav.DavServerExtension.ALICE_VEVENT_1;
 import static com.linagora.tmail.dav.DavServerExtension.createDelegatedBasicAuthenticationToken;
+import static com.linagora.tmail.dav.DavServerExtension.itip;
 import static com.linagora.tmail.dav.DavServerExtension.propfind;
 import static com.linagora.tmail.dav.DavServerExtension.report;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +51,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -79,6 +83,13 @@ class DavClientTest {
     private static final OpenPaaSUserId OPENPAAS_USER_ID = new OpenPaaSUserId("openpaasUserId1");
     private static final DavUser OPEN_PAAS_DAV_USER = new DavUser(OPENPAAS_USER_ID, OPENPAAS_USER_NAME);
     private static final UnaryOperator<DavCalendarObject> DUMMY_CALENDAR_OBJECT_UPDATER = calendarObject -> calendarObject;
+    private static final byte[] ITIP_PAYLOAD = "{\"ical\": \"BEGIN:VCALENDAR\\nEND:VCALENDAR\"}".getBytes(StandardCharsets.UTF_8);
+    private static final String SABRE_ERROR_BODY = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+          <s:exception>Sabre\\VObject\\ITip\\ITipException</s:exception>
+          <s:message>The supplied message must have a valid METHOD property</s:message>
+        </d:error>""";
 
     @RegisterExtension
     static DavServerExtension davServerExtension = new DavServerExtension();
@@ -153,6 +164,41 @@ class DavClientTest {
 
         assertThatCode(() -> client.carddav(OPENPAAS_USER_NAME).createCollectedContact(OPENPAAS_USER_ID, request).block())
             .doesNotThrowAnyException();
+    }
+
+    @Test
+    void existsCollectedContactShouldExposeSabreResponseWhenHTTPResponseIs500() {
+        DavUid collectedContactUid = new DavUid(UUID.randomUUID().toString());
+        davServerExtension.stubFor(
+            get("/addressbooks/%s/collected/%s.vcf".formatted(OPENPAAS_USER_ID.value(), collectedContactUid.value()))
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(OPENPAAS_USER_NAME.asString())))
+                .willReturn(serverError().withBody(SABRE_ERROR_BODY)));
+
+        assertThatThrownBy(() -> client.carddav(OPENPAAS_USER_NAME).existsCollectedContact(OPENPAAS_USER_ID, collectedContactUid).block())
+            .isInstanceOfSatisfying(DavClientException.class,
+                exception -> assertThat(exception.sabreResponse()).contains(SABRE_ERROR_BODY));
+    }
+
+    @Test
+    void createCollectedContactShouldExposeSabreResponseWhenHTTPResponseIs400() throws Exception {
+        DavUid collectedContactUid = new DavUid(UUID.randomUUID().toString());
+        davServerExtension.stubFor(
+            put("/addressbooks/%s/collected/%s.vcf".formatted(OPENPAAS_USER_ID.value(), collectedContactUid.value()))
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(OPENPAAS_USER_NAME.asString())))
+                .willReturn(badRequest().withBody(SABRE_ERROR_BODY)));
+
+        CardDavCreationObjectRequest request = new CardDavCreationObjectRequest(
+            "4.0",
+            collectedContactUid,
+            Optional.of("An Bach4"),
+            Optional.of(List.of("An", "Bach4")),
+            new CardDavCreationObjectRequest.Email(
+                List.of(EmailType.HOME),
+                new MailAddress("anbach4@lina.com")));
+
+        assertThatThrownBy(() -> client.carddav(OPENPAAS_USER_NAME).createCollectedContact(OPENPAAS_USER_ID, request).block())
+            .isInstanceOfSatisfying(DavClientException.class,
+                exception -> assertThat(exception.sabreResponse()).contains(SABRE_ERROR_BODY));
     }
 
     @Test
@@ -329,6 +375,56 @@ class DavClientTest {
                 urlEqualTo(ALICE_CALENDAR_OBJECT_1))
                 .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
                 .withHeader("Accept", equalTo("application/xml")));
+    }
+
+    @Test
+    void sendITIPRequestShouldSucceedWhenHTTPResponseIs204() {
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(noContent()));
+
+        assertThatCode(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void sendITIPRequestShouldExposeSabreResponseWhenHTTPResponseIs400() {
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest().withBody(SABRE_ERROR_BODY)));
+
+        assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
+            .isInstanceOfSatisfying(DavClientException.class, exception -> {
+                assertThat(exception.sabreResponse()).contains(SABRE_ERROR_BODY);
+                assertThat(exception.getMessage()).contains("Unexpected status code: 400 when sending itip request for '/calendars/ALICE_ID'");
+            });
+    }
+
+    @Test
+    void sendITIPRequestShouldExposeEmptySabreResponseWhenHTTPResponseHasNoBody() {
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest()));
+
+        assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
+            .isInstanceOfSatisfying(DavClientException.class,
+                exception -> assertThat(exception.sabreResponse()).contains(""));
+    }
+
+    @Test
+    void sendITIPRequestShouldTruncateSabreResponseToFirstKilobyte() {
+        String longBody = "a".repeat(2 * DavClientException.SABRE_RESPONSE_MAX_BYTES);
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest().withBody(longBody)));
+
+        assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
+            .isInstanceOfSatisfying(DavClientException.class,
+                exception -> assertThat(exception.sabreResponse()).contains("a".repeat(DavClientException.SABRE_RESPONSE_MAX_BYTES)));
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavClientTest.java
@@ -415,8 +415,8 @@ class DavClientTest {
     }
 
     @Test
-    void sendITIPRequestShouldTruncateSabreResponseToFirstKilobyte() {
-        String longBody = "a".repeat(2 * DavClientException.SABRE_RESPONSE_MAX_BYTES);
+    void sendITIPRequestShouldTruncateSabreResponseToMaxChars() {
+        String longBody = "a".repeat(2 * DavClientException.SABRE_RESPONSE_MAX_CHARS);
         davServerExtension.stubFor(
             itip("/calendars/" + ALICE_ID)
                 .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
@@ -424,7 +424,22 @@ class DavClientTest {
 
         assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
             .isInstanceOfSatisfying(DavClientException.class,
-                exception -> assertThat(exception.sabreResponse()).contains("a".repeat(DavClientException.SABRE_RESPONSE_MAX_BYTES)));
+                exception -> assertThat(exception.sabreResponse()).contains("a".repeat(DavClientException.SABRE_RESPONSE_MAX_CHARS)));
+    }
+
+    @Test
+    void sendITIPRequestShouldTruncateSabreResponseByCharacterRatherThanByte() {
+        // Each emoji is 4 UTF-8 bytes and a UTF-16 surrogate pair; the leading ASCII char shifts the emojis so that
+        // a byte-based cut at 1024 would land in the middle of one, yielding an invalid code point
+        String multiByteBody = "a" + "😀".repeat(2 * DavClientException.SABRE_RESPONSE_MAX_CHARS);
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest().withBody(multiByteBody)));
+
+        assertThatThrownBy(() -> client.caldav(Username.of(ALICE)).sendITIPRequest(URI.create("/calendars/" + ALICE_ID), ITIP_PAYLOAD).block())
+            .isInstanceOfSatisfying(DavClientException.class,
+                exception -> assertThat(exception.sabreResponse()).contains("a" + "😀".repeat(DavClientException.SABRE_RESPONSE_MAX_CHARS - 1)));
     }
 
     @Test

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavServerExtension.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/dav/DavServerExtension.java
@@ -261,4 +261,8 @@ public class DavServerExtension extends WireMockExtension {
     public static MappingBuilder report(String url) {
         return request("REPORT", new UrlPattern(equalTo(url), !USE_REGEX));
     }
+
+    public static MappingBuilder itip(String url) {
+        return request("ITIP", new UrlPattern(equalTo(url), !USE_REGEX));
+    }
 }

--- a/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/mailet/CalDavCollectTest.java
+++ b/tmail-backend/tmail-third-party/openpaas/src/test/java/com/linagora/tmail/mailet/CalDavCollectTest.java
@@ -1,0 +1,156 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.mailet;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.linagora.tmail.dav.DavServerExtension.ALICE;
+import static com.linagora.tmail.dav.DavServerExtension.ALICE_DAV_USER;
+import static com.linagora.tmail.dav.DavServerExtension.ALICE_ID;
+import static com.linagora.tmail.dav.DavServerExtension.createDelegatedBasicAuthenticationToken;
+import static com.linagora.tmail.dav.DavServerExtension.itip;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.AttributeValue;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMailetConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.linagora.tmail.dav.DavClient;
+import com.linagora.tmail.dav.DavClientException;
+import com.linagora.tmail.dav.DavServerExtension;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import reactor.core.publisher.Mono;
+
+class CalDavCollectTest {
+    private static final String ORGANIZER = "bob@james.org";
+    private static final String ICS = """
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//Twake Mail//EN
+        METHOD:REQUEST
+        BEGIN:VEVENT
+        UID:ab3db856-a866-4a91-99a3-c84372eaee87
+        DTSTAMP:20250101T100000Z
+        DTSTART:20250101T110000Z
+        DTEND:20250101T120000Z
+        SUMMARY:Sprint planning
+        ORGANIZER:mailto:%s
+        ATTENDEE:mailto:%s
+        END:VEVENT
+        END:VCALENDAR
+        """.formatted(ORGANIZER, ALICE);
+    private static final String SABRE_ERROR_BODY = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+          <s:exception>Sabre\\VObject\\ITip\\ITipException</s:exception>
+          <s:message>The supplied message must have a valid METHOD property</s:message>
+        </d:error>""";
+
+    @RegisterExtension
+    static DavServerExtension davServerExtension = new DavServerExtension();
+
+    private CalDavCollect mailet;
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger logger;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mailet = new CalDavCollect(new DavClient(davServerExtension.getDavConfiguration()), username -> Mono.just(ALICE_DAV_USER));
+        mailet.init(FakeMailetConfig.builder().mailetName("CalDavCollect").build());
+
+        logger = (Logger) LoggerFactory.getLogger(CalDavCollect.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        logger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(logAppender);
+    }
+
+    @Test
+    void serviceShouldLogSabreResponseAsMdcFieldWhenDavServerRejectsItipRequest() throws Exception {
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest().withBody(SABRE_ERROR_BODY)));
+
+        mailet.service(mailWithCalendar());
+
+        assertThat(errorLogs())
+            .hasSize(1)
+            .first()
+            .satisfies(event -> {
+                assertThat(event.getFormattedMessage()).isEqualTo("Error while handling calendar in mail mail1 with recipient " + ALICE);
+                assertThat(event.getMDCPropertyMap()).containsEntry(DavClientException.SABRE_RESPONSE_MDC_KEY, SABRE_ERROR_BODY);
+            });
+    }
+
+    @Test
+    void serviceShouldNotLeakSabreResponseMdcFieldAfterLogging() throws Exception {
+        davServerExtension.stubFor(
+            itip("/calendars/" + ALICE_ID)
+                .withHeader("Authorization", equalTo(createDelegatedBasicAuthenticationToken(ALICE)))
+                .willReturn(badRequest().withBody(SABRE_ERROR_BODY)));
+
+        mailet.service(mailWithCalendar());
+
+        assertThat(org.slf4j.MDC.get(DavClientException.SABRE_RESPONSE_MDC_KEY)).isNull();
+    }
+
+    private List<ILoggingEvent> errorLogs() {
+        return logAppender.list.stream()
+            .filter(event -> event.getLevel() == Level.ERROR)
+            .toList();
+    }
+
+    private Mail mailWithCalendar() throws Exception {
+        ObjectNode json = new ObjectMapper().createObjectNode();
+        json.put("ical", ICS);
+        json.put("recipient", ALICE);
+        json.put("sender", ORGANIZER);
+        byte[] jsonBytes = json.toString().getBytes(StandardCharsets.UTF_8);
+
+        return FakeMail.builder()
+            .name("mail1")
+            .attribute(new Attribute(
+                AttributeName.of(CalDavCollect.DEFAULT_SOURCE_ATTRIBUTE_NAME),
+                AttributeValue.of(ImmutableMap.<String, AttributeValue<?>>of("ics1", AttributeValue.of(jsonBytes)))))
+            .build();
+    }
+}


### PR DESCRIPTION
Closes #2603

## Problem

When the Dav server (Sabre) rejects an ITIP request or a collected contact, `CalDavCollect` / `CardDavAddContactProcessor` log a `DavClientException` but we have no structured access to *why* the server refused the payload, which makes the diagnostic of rejected events / contacts hard.

## Changes

- `DavClientException` now carries the Dav server response body (truncated to its first 1024 bytes) and exposes it through `sabreResponse()` and a ready-to-use `MDCBuilder` (`mdcOf(Throwable)`).
- `DavClientHelper.unexpectedStatus` fills that response body (the full body is still part of the exception message, as before).
- `CardDavClient` now goes through `DavClientHelper.unexpectedStatus` for `existsCollectedContact` / `createCollectedContact`, so the Sabre response is captured for contact collection too.
- `CalDavCollect` and `CardDavAddContactProcessor` log Dav failures within an MDC context holding the `sabreResponse` field.

## Tests

- `DavClientTest`: new ITIP / CardDav tests asserting the exposed Sabre response (including empty body and 1024-byte truncation).
- `CalDavCollectTest` (new, WireMock based): asserts the error log carries the `sabreResponse` MDC field and that the MDC does not leak after logging.

`mvn -f tmail-backend/tmail-third-party/openpaas/pom.xml test -Dtest='DavClientTest,CalDavCollectTest'` and `checkstyle:check` pass locally.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DAV server errors during contact, calendar, and iTIP operations.
  * Error details are now captured in diagnostics, including empty responses, with lengthy messages safely truncated.
  * Failed collection operations complete gracefully instead of unexpectedly propagating errors.
  * Enhanced logging context makes DAV integration issues easier to troubleshoot.

* **Tests**
  * Added coverage for rejected requests, response handling, truncation, and diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->