### PR TITLE
ISSUE-2605 EnrichACLListener: qualify local-part-only ACL entries with the owner domain

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
@@ -200,6 +200,10 @@ Unlike the other listeners of this page, it is triggered upon ACL updates, not u
 </listeners>
 ----
 
+NOTE: By default, the mailbox manager refuses ACL entries whose domain differs from the one of the mailbox owner,
+which includes local-part-only entries (`SETACL INBOX alice lrs` is answered `NO`). For such entries to reach this
+listener, cross-domain sharing must be allowed by setting `james.rights.crossdomain.allow=true` in `jvm.properties`.
+
 == Label Provisioner Listener
 
 This listener automatically creates a predefined set of JMAP labels for every new user.

--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc
@@ -172,6 +172,34 @@ In a SaaS context, use the `applyWhen` filter to restrict signature provisioning
 </defaultText>
 ----
 
+== Enrich ACL Listener
+
+Twake Mail identifies users by their full email address. Some deployments nevertheless end up with ACL entries
+designating a user by its sole local part (e.g. `alice` instead of `alice@domain.tld`), typically set through
+IMAP `SETACL` by legacy clients or imported from another mail system.
+
+This listener reacts to ACL updates and rewrites such local-part-only user entries by appending the domain of the
+mailbox owner: `alice` becomes `alice@domain.tld` (and the `alice` entry is removed). Sharing is thereby restricted
+within the domain of the mailbox owner.
+
+Behaviour details:
+
+- Rights of the local-part-only entry are merged into the fully qualified entry when the latter already exists.
+- Negative entries (`-alice`) are rewritten as well (`-alice@domain.tld`).
+- Group (`$sales`) and special (`anyone`, `authenticated`, `owner`) entries are left untouched.
+- Mailboxes whose owner has no domain are ignored.
+
+Unlike the other listeners of this page, it is triggered upon ACL updates, not upon INBOX creation.
+
+[source,xml]
+----
+<listeners>
+  <listener>
+    <class>com.linagora.tmail.listener.EnrichACLListener</class>
+  </listener>
+</listeners>
+----
+
 == Label Provisioner Listener
 
 This listener automatically creates a predefined set of JMAP labels for every new user.

--- a/tmail-backend/integration-tests/imap/memory-imap-integration-tests/src/test/java/com/linagora/tmail/imap/IMAPEnrichACLIntegrationTest.java
+++ b/tmail-backend/integration-tests/imap/memory-imap-integration-tests/src/test/java/com/linagora/tmail/imap/IMAPEnrichACLIntegrationTest.java
@@ -1,0 +1,158 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.imap;
+
+import static org.apache.james.data.UsersRepositoryModuleChooser.Implementation.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.core.Username;
+import org.apache.james.events.EventListener;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.AllowCrossDomainAccessExtension;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.TestIMAPClient;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.tmail.james.app.MemoryConfiguration;
+import com.linagora.tmail.james.app.MemoryServer;
+import com.linagora.tmail.listener.EnrichACLListener;
+
+/**
+ * End to end validation of {@link EnrichACLListener}: IMAP SETACL designating a user by its sole local part
+ * ends up granting rights to the fully qualified user of the mailbox owner domain.
+ *
+ * Virtual hosting is enabled and users are identified by their mail address (see usersrepository.xml).
+ * Cross-domain sharing is allowed, otherwise SETACL refuses local-part-only entries upfront.
+ */
+class IMAPEnrichACLIntegrationTest {
+    private static final String DOMAIN = "domain.tld";
+    private static final Username BOB = Username.of("bob@" + DOMAIN);
+    private static final Username ALICE = Username.of("alice@" + DOMAIN);
+    private static final String PASSWORD = "secret";
+    private static final String IMAP_HOST = "127.0.0.1";
+    private static final String BOB_INBOX_SEEN_BY_ALICE = "#user.bob.INBOX";
+    private static final ConditionFactory AWAIT = Awaitility.with()
+        .pollInterval(Duration.ofMillis(100))
+        .atMost(Duration.ofSeconds(10))
+        .await();
+
+    @RegisterExtension
+    @Order(1)
+    static AllowCrossDomainAccessExtension allowCrossDomainAccessExtension = new AllowCrossDomainAccessExtension();
+
+    @RegisterExtension
+    @Order(2)
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<MemoryConfiguration>(tmpDir ->
+        MemoryConfiguration.builder()
+            .workingDirectory(tmpDir)
+            .configurationFromClasspath()
+            .usersRepository(DEFAULT)
+            .build())
+        .server(configuration -> MemoryServer.createServer(configuration)
+            .overrideWith(binder -> Multibinder.newSetBinder(binder, EventListener.ReactiveGroupEventListener.class)
+                .addBinding().to(EnrichACLListener.class)))
+        .build();
+
+    @RegisterExtension
+    TestIMAPClient bobClient = new TestIMAPClient();
+
+    @RegisterExtension
+    TestIMAPClient aliceClient = new TestIMAPClient();
+
+    private int imapPort;
+
+    @BeforeEach
+    void setUp(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(BOB.asString(), PASSWORD)
+            .addUser(ALICE.asString(), PASSWORD);
+
+        MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
+        mailboxProbe.createMailbox(MailboxPath.inbox(BOB));
+        mailboxProbe.createMailbox(MailboxPath.inbox(ALICE));
+
+        imapPort = server.getProbe(ImapGuiceProbe.class).getImapPort();
+    }
+
+    @Test
+    void setAclWithLocalPartOnlyShouldGrantRightsToTheUserOfTheOwnerDomain() throws Exception {
+        TestIMAPClient bob = bobClient.connect(IMAP_HOST, imapPort).login(BOB, PASSWORD);
+
+        assertThat(bob.sendCommand("SETACL INBOX alice lrs"))
+            .contains("OK SETACL completed");
+
+        AWAIT.untilAsserted(() -> assertThat(bob.sendCommand("GETACL INBOX"))
+            .contains("* ACL \"INBOX\" \"alice@domain.tld\" \"lrs\"")
+            .doesNotContain("\"alice\""));
+    }
+
+    @Test
+    void userOfTheOwnerDomainShouldAccessTheMailboxSharedByLocalPartOnly() throws Exception {
+        assertThat(bobClient.connect(IMAP_HOST, imapPort)
+            .login(BOB, PASSWORD)
+            .sendCommand("SETACL INBOX alice lrs"))
+            .contains("OK SETACL completed");
+
+        TestIMAPClient alice = aliceClient.connect(IMAP_HOST, imapPort).login(ALICE, PASSWORD);
+
+        AWAIT.untilAsserted(() -> assertThat(alice.sendCommand("MYRIGHTS " + BOB_INBOX_SEEN_BY_ALICE))
+            .contains("* MYRIGHTS \"" + BOB_INBOX_SEEN_BY_ALICE + "\" \"lrs\""));
+        assertThat(alice.sendCommand("LIST \"\" \"*\""))
+            .contains("\"" + BOB_INBOX_SEEN_BY_ALICE + "\"");
+    }
+
+    @Test
+    void setAclWithLocalPartOnlyShouldMergeRightsIntoTheExistingQualifiedEntry() throws Exception {
+        TestIMAPClient bob = bobClient.connect(IMAP_HOST, imapPort).login(BOB, PASSWORD);
+
+        assertThat(bob.sendCommand("SETACL INBOX alice@domain.tld w"))
+            .contains("OK SETACL completed");
+        assertThat(bob.sendCommand("SETACL INBOX alice lr"))
+            .contains("OK SETACL completed");
+
+        AWAIT.untilAsserted(() -> assertThat(bob.sendCommand("GETACL INBOX"))
+            .contains("* ACL \"INBOX\" \"alice@domain.tld\" \"lrw\"")
+            .doesNotContain("\"alice\""));
+    }
+
+    @Test
+    void setAclWithQualifiedUserShouldBeLeftUntouched() throws Exception {
+        TestIMAPClient bob = bobClient.connect(IMAP_HOST, imapPort).login(BOB, PASSWORD);
+
+        assertThat(bob.sendCommand("SETACL INBOX alice@domain.tld lrs"))
+            .contains("OK SETACL completed");
+
+        assertThat(bob.sendCommand("GETACL INBOX"))
+            .contains("* ACL \"INBOX\" \"alice@domain.tld\" \"lrs\"");
+    }
+}

--- a/tmail-backend/integration-tests/imap/memory-imap-integration-tests/src/test/java/org/apache/james/mailbox/store/AllowCrossDomainAccessExtension.java
+++ b/tmail-backend/integration-tests/imap/memory-imap-integration-tests/src/test/java/org/apache/james/mailbox/store/AllowCrossDomainAccessExtension.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Allows sharing mailboxes with entries whose domain differs from the mailbox owner one, as
+ * {@code james.rights.crossdomain.allow=true} would.
+ *
+ * Lives in the {@code org.apache.james.mailbox.store} package to reach the package-private test hook of
+ * {@link StoreRightManager} without relying on reflection.
+ */
+public class AllowCrossDomainAccessExtension implements BeforeAllCallback, AfterAllCallback {
+    private Boolean previousValue;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        previousValue = StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED;
+        StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = true;
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        StoreRightManager.IS_CROSS_DOMAIN_ACCESS_ALLOWED = previousValue;
+    }
+}

--- a/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/EnrichACLListener.java
+++ b/tmail-backend/mailbox/listeners/src/main/java/com/linagora/tmail/listener/EnrichACLListener.java
@@ -1,0 +1,161 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.listener;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.events.Event;
+import org.apache.james.events.EventListener;
+import org.apache.james.events.Group;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.events.MailboxEvents.MailboxACLUpdated;
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxACL.EntryKey;
+import org.apache.james.mailbox.model.MailboxACL.NameType;
+import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Rewrites ACL entries designating a user by its sole local part (e.g. {@code alice}) into
+ * fully qualified entries built with the domain of the mailbox owner (e.g. {@code alice@domain.tld}).
+ *
+ * Rights of a local-part-only entry are merged into the fully qualified entry when the latter already exists.
+ * Negative entries are preserved, group and special entries are left untouched.
+ *
+ * This listener is not bound by default and must be declared in {@code listeners.xml}.
+ */
+public class EnrichACLListener implements EventListener.ReactiveGroupEventListener {
+    public static class EnrichACLListenerGroup extends Group {
+
+    }
+
+    private static final Group GROUP = new EnrichACLListenerGroup();
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnrichACLListener.class);
+    private static final String DOMAIN_SEPARATOR = "@";
+
+    private final MailboxManager mailboxManager;
+
+    @Inject
+    public EnrichACLListener(MailboxManager mailboxManager) {
+        this.mailboxManager = mailboxManager;
+    }
+
+    @Override
+    public Group getDefaultGroup() {
+        return GROUP;
+    }
+
+    @Override
+    public boolean isHandling(Event event) {
+        if (event instanceof MailboxACLUpdated aclUpdated) {
+            return ownerDomain(aclUpdated.getMailboxPath()).isPresent()
+                && hasLocalPartOnlyUserEntry(aclUpdated.getAclDiff().getNewACL());
+        }
+        return false;
+    }
+
+    @Override
+    public Publisher<Void> reactiveEvent(Event event) {
+        if (event instanceof MailboxACLUpdated aclUpdated) {
+            return ownerDomain(aclUpdated.getMailboxPath())
+                .map(domain -> enrichACL(aclUpdated.getMailboxId(), aclUpdated.getMailboxPath(), domain))
+                .orElseGet(Mono::empty);
+        }
+        return Mono.empty();
+    }
+
+    private Mono<Void> enrichACL(MailboxId mailboxId, MailboxPath mailboxPath, Domain ownerDomain) {
+        MailboxSession session = mailboxManager.createSystemSession(mailboxPath.getUser());
+
+        return Mono.from(mailboxManager.listRightsReactive(mailboxId, session))
+            .filter(this::hasLocalPartOnlyUserEntry)
+            .map(acl -> enrich(acl, ownerDomain))
+            .flatMap(enrichedACL -> setRights(mailboxId, enrichedACL, session))
+            .onErrorResume(error -> {
+                LOGGER.error("Failed to enrich local-part-only ACL entries of {}", mailboxPath.asString(), error);
+                return Mono.empty();
+            });
+    }
+
+    private Mono<Void> setRights(MailboxId mailboxId, MailboxACL acl, MailboxSession session) {
+        return Mono.<Void>fromCallable(() -> {
+                mailboxManager.setRights(mailboxId, acl, session);
+                return null;
+            })
+            .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @VisibleForTesting
+    MailboxACL enrich(MailboxACL acl, Domain ownerDomain) {
+        ImmutableListMultimap<EntryKey, Rfc4314Rights> rightsByEnrichedKey = acl.getEntries().entrySet().stream()
+            .collect(ImmutableListMultimap.toImmutableListMultimap(
+                entry -> enrich(entry.getKey(), ownerDomain),
+                Map.Entry::getValue));
+
+        return new MailboxACL(rightsByEnrichedKey.asMap().entrySet().stream()
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, entry -> merge(entry.getValue()))));
+    }
+
+    private EntryKey enrich(EntryKey key, Domain ownerDomain) {
+        if (isLocalPartOnlyUser(key)) {
+            Username enrichedUser = Username.fromLocalPartWithDomain(key.getName(), ownerDomain);
+            return EntryKey.createUserEntryKey(enrichedUser, key.isNegative());
+        }
+        return key;
+    }
+
+    private Rfc4314Rights merge(Collection<Rfc4314Rights> rights) {
+        return Rfc4314Rights.of(rights.stream()
+            .flatMap(right -> right.list().stream())
+            .toList());
+    }
+
+    private boolean hasLocalPartOnlyUserEntry(MailboxACL acl) {
+        return acl.getEntries().keySet().stream()
+            .anyMatch(this::isLocalPartOnlyUser);
+    }
+
+    private boolean isLocalPartOnlyUser(EntryKey key) {
+        return key.getNameType() == NameType.user
+            && !key.getName().contains(DOMAIN_SEPARATOR);
+    }
+
+    private Optional<Domain> ownerDomain(MailboxPath mailboxPath) {
+        return Optional.ofNullable(mailboxPath.getUser())
+            .flatMap(Username::getDomainPart);
+    }
+}

--- a/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/EnrichACLListenerTest.java
+++ b/tmail-backend/mailbox/listeners/src/test/java/com/linagora/tmail/listener/EnrichACLListenerTest.java
@@ -1,0 +1,194 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.listener;
+
+import static org.apache.james.mailbox.model.MailboxACL.NEGATIVE_KEY;
+import static org.apache.james.mailbox.model.MailboxACL.Right.Lookup;
+import static org.apache.james.mailbox.model.MailboxACL.Right.Read;
+import static org.apache.james.mailbox.model.MailboxACL.Right.Write;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.james.core.Username;
+import org.apache.james.events.Event;
+import org.apache.james.events.EventBus;
+import org.apache.james.events.EventListener;
+import org.apache.james.events.Group;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.events.MailboxEvents.MailboxACLUpdated;
+import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxACL.Entry;
+import org.apache.james.mailbox.model.MailboxACL.EntryKey;
+import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.event.EventFactory;
+import org.apache.james.mailbox.store.mail.MailboxMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+
+class EnrichACLListenerTest {
+    private static class CountingACLUpdatedListener implements EventListener.ReactiveGroupEventListener {
+        private static class CountingACLUpdatedListenerGroup extends Group {
+
+        }
+
+        private final AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public Group getDefaultGroup() {
+            return new CountingACLUpdatedListenerGroup();
+        }
+
+        @Override
+        public boolean isHandling(Event event) {
+            return event instanceof MailboxACLUpdated;
+        }
+
+        @Override
+        public Publisher<Void> reactiveEvent(Event event) {
+            return Mono.fromRunnable(count::incrementAndGet);
+        }
+    }
+
+    private static final Username BOB = Username.of("bob@domain.tld");
+    private static final Username BOB_WITHOUT_DOMAIN = Username.of("bob");
+    private static final EntryKey ALICE_LOCAL_PART = EntryKey.createUserEntryKey("alice");
+    private static final EntryKey ALICE = EntryKey.createUserEntryKey("alice@domain.tld");
+    private static final EntryKey DAVID = EntryKey.createUserEntryKey("david@domain.tld");
+    private static final EntryKey SALES_GROUP = EntryKey.createGroupEntryKey("sales@domain.tld");
+
+    private InMemoryMailboxManager mailboxManager;
+    private EventBus eventBus;
+    private MailboxSession bobSession;
+    private MailboxId bobInboxId;
+    private CountingACLUpdatedListener countingListener;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        mailboxManager = resources.getMailboxManager();
+        eventBus = resources.getEventBus();
+        bobSession = mailboxManager.createSystemSession(BOB);
+        bobInboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), bobSession).orElseThrow();
+        countingListener = new CountingACLUpdatedListener();
+        eventBus.register(countingListener);
+        eventBus.register(new EnrichACLListener(mailboxManager));
+    }
+
+    @Test
+    void shouldAppendOwnerDomainToLocalPartOnlyUserEntries() throws Exception {
+        seedACL(bobInboxId, bobSession, new MailboxACL(new Entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup, Read))));
+
+        assertThat(mailboxManager.listRights(bobInboxId, bobSession).getEntries())
+            .containsOnly(Map.entry(ALICE, new Rfc4314Rights(Lookup, Read)));
+    }
+
+    @Test
+    void shouldPreserveNegativeEntries() throws Exception {
+        EntryKey negativeAliceLocalPart = EntryKey.createUserEntryKey("alice", NEGATIVE_KEY);
+        EntryKey negativeAlice = EntryKey.createUserEntryKey("alice@domain.tld", NEGATIVE_KEY);
+
+        seedACL(bobInboxId, bobSession, new MailboxACL(new Entry(negativeAliceLocalPart, new Rfc4314Rights(Write))));
+
+        assertThat(mailboxManager.listRights(bobInboxId, bobSession).getEntries())
+            .containsOnly(Map.entry(negativeAlice, new Rfc4314Rights(Write)));
+    }
+
+    @Test
+    void shouldMergeRightsWhenFullyQualifiedEntryAlreadyExists() throws Exception {
+        seedACL(bobInboxId, bobSession, new MailboxACL(
+            new Entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup, Read)),
+            new Entry(ALICE, new Rfc4314Rights(Write))));
+
+        assertThat(mailboxManager.listRights(bobInboxId, bobSession).getEntries())
+            .containsOnly(Map.entry(ALICE, new Rfc4314Rights(Lookup, Read, Write)));
+    }
+
+    @Test
+    void shouldLeaveFullyQualifiedGroupAndSpecialEntriesUntouched() throws Exception {
+        seedACL(bobInboxId, bobSession, new MailboxACL(
+            new Entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup)),
+            new Entry(DAVID, new Rfc4314Rights(Read)),
+            new Entry(SALES_GROUP, new Rfc4314Rights(Write)),
+            new Entry(MailboxACL.ANYONE_KEY, new Rfc4314Rights(Lookup))));
+
+        assertThat(mailboxManager.listRights(bobInboxId, bobSession).getEntries())
+            .containsOnly(
+                Map.entry(ALICE, new Rfc4314Rights(Lookup)),
+                Map.entry(DAVID, new Rfc4314Rights(Read)),
+                Map.entry(SALES_GROUP, new Rfc4314Rights(Write)),
+                Map.entry(MailboxACL.ANYONE_KEY, new Rfc4314Rights(Lookup)));
+    }
+
+    @Test
+    void shouldNotRewriteACLWhenNoLocalPartOnlyEntry() throws Exception {
+        seedACL(bobInboxId, bobSession, new MailboxACL(new Entry(ALICE, new Rfc4314Rights(Lookup, Read))));
+
+        assertThat(mailboxManager.listRights(bobInboxId, bobSession).getEntries())
+            .containsOnly(Map.entry(ALICE, new Rfc4314Rights(Lookup, Read)));
+        assertThat(countingListener.count.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRewriteACLOnlyOnce() throws Exception {
+        seedACL(bobInboxId, bobSession, new MailboxACL(new Entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup, Read))));
+
+        assertThat(countingListener.count.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldIgnoreMailboxesWhoseOwnerHasNoDomain() throws Exception {
+        MailboxSession session = mailboxManager.createSystemSession(BOB_WITHOUT_DOMAIN);
+        MailboxId inboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB_WITHOUT_DOMAIN), session).orElseThrow();
+
+        seedACL(inboxId, session, new MailboxACL(new Entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup, Read))));
+
+        assertThat(mailboxManager.listRights(inboxId, session).getEntries())
+            .containsOnly(Map.entry(ALICE_LOCAL_PART, new Rfc4314Rights(Lookup, Read)));
+    }
+
+    /**
+     * Local-part-only ACL entries are refused by the mailbox manager when cross-domain sharing is disabled:
+     * such legacy entries are seeded straight into the storage and the corresponding event is dispatched by hand.
+     */
+    private void seedACL(MailboxId mailboxId, MailboxSession session, MailboxACL acl) {
+        MailboxMapper mapper = mailboxManager.getMapperFactory().getMailboxMapper(session);
+        Mailbox mailbox = mapper.findMailboxById(mailboxId).block();
+
+        mapper.setACL(mailbox, acl)
+            .flatMap(aclDiff -> eventBus.dispatch(EventFactory.aclUpdated()
+                    .randomEventId()
+                    .mailboxSession(session)
+                    .mailbox(mailbox)
+                    .aclDiff(aclDiff)
+                    .build(),
+                new MailboxIdRegistrationKey(mailboxId)))
+            .block();
+    }
+}


### PR DESCRIPTION
Closes #2605

## What

Adds `com.linagora.tmail.listener.EnrichACLListener`, an opt-in mailbox listener (declared in `listeners.xml`, **not** bound by Guice by default) that rewrites ACL entries designating a user by its sole local part into fully qualified entries built with the domain of the mailbox owner: `alice` becomes `alice@domain.tld`, and the `alice` entry is removed.

## How

- Reacts to `MailboxACLUpdated` events whose new ACL contains at least one local-part-only user entry (cheap `isHandling` pre-filter, which also prevents the listener from re-triggering itself on the ACL it just rewrote).
- Re-reads the current ACL from storage (rather than trusting the event payload, which may be stale in a distributed setup) and rewrites it in a single `setRights` call.
  - `setRights` is used instead of remove/add `applyRightsCommand`s because `StoreRightManager` rejects any command whose key has no domain (`DifferentDomainException`) when cross-domain sharing is disabled — a full ACL reset only validates the new, fully qualified entries.
- Rights of the local-part-only entry are merged into an already existing fully qualified entry; negative entries are preserved (`-alice` → `-alice@domain.tld`); group and special entries (`anyone`, `authenticated`, `owner`) are untouched; mailboxes whose owner has no domain are ignored.
- Lives in the `tmail-listeners` module, already on the classpath of every app through `guice/common`.

Documented in `docs/modules/ROOT/pages/tmail-backend/configure/extra-listener.adoc`.

## Tests

`EnrichACLListenerTest` (7 tests, all green) seeds legacy local-part ACLs straight through the mailbox mapper and dispatches the resulting event, since the public API refuses such entries when cross-domain sharing is disabled. Covers enrichment, negative entries, merge with an existing qualified entry, untouched group/special entries, no-op on already qualified ACLs, single rewrite (no event loop) and owner without domain.

## Known limitation

When cross-domain sharing is disabled and the ACL also holds an entry from a foreign domain (e.g. `carol@other.tld`), the rewrite is rejected by James (`DifferentDomainException`) and logged; James would not have accepted such an entry in the first place.

---
*Generated automatically*
