### PR TITLE
Reduce deployment test CI time through container reuse

### DIFF
--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapCliTest.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapCliTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedLdapCliTest implements CliContract {
     @RegisterExtension
-    TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
+    static final TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
 
     @Override
     public GenericContainer<?> jamesContainer() {

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapImapAndSmtpTest.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapImapAndSmtpTest.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedLdapImapAndSmtpTest extends ImapAndSmtpContract {
     @RegisterExtension
-    TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
+    static final TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
 
     @Override
     protected ExternalJamesConfiguration configuration() {

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapJmapTest.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/DistributedLdapJmapTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedLdapJmapTest implements JmapContract {
     @RegisterExtension
-    TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
+    static final TmailDistributedLdapExtension extension = new TmailDistributedLdapExtension();
 
     @Override
     public GenericContainer<?> jmapContainer() {

--- a/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
+++ b/tmail-backend/deployment-tests/distributed-ldap/src/test/java/com/linagora/tmail/deployment/TmailDistributedLdapExtension.java
@@ -36,8 +36,8 @@ import java.util.UUID;
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
 import org.apache.james.util.Port;
 import org.apache.james.util.Runnables;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -46,7 +46,7 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
 
-public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterEachCallback {
+public class TmailDistributedLdapExtension implements BeforeAllCallback, AfterAllCallback {
 
     private final Network network;
     private final GenericContainer<?> cassandra;
@@ -104,7 +104,7 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+    public void beforeAll(ExtensionContext extensionContext) throws IOException {
         String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed-ldap").toString(),
             Paths.get("tmail-backend", "apps", "distributed", "target", "jib-image.tar").toString());
         james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
@@ -112,7 +112,7 @@ public class TmailDistributedLdapExtension implements BeforeEachCallback, AfterE
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) {
+    public void afterAll(ExtensionContext extensionContext) {
         james.stop();
         Runnables.runParallel(
             cassandra::stop,

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedCliTest.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedCliTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedCliTest implements CliContract {
     @RegisterExtension
-    TmailDistributedExtension extension = new TmailDistributedExtension();
+    static final TmailDistributedExtension extension = new TmailDistributedExtension();
 
     @Override
     public GenericContainer<?> jamesContainer() {

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedImapAndSmtpTest.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedImapAndSmtpTest.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedImapAndSmtpTest extends ImapAndSmtpContract {
     @RegisterExtension
-    TmailDistributedExtension extension = new TmailDistributedExtension();
+    static final TmailDistributedExtension extension = new TmailDistributedExtension();
 
     @Override
     protected ExternalJamesConfiguration configuration() {

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedJmapTest.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/DistributedJmapTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class DistributedJmapTest implements JmapContract {
     @RegisterExtension
-    TmailDistributedExtension extension = new TmailDistributedExtension();
+    static final TmailDistributedExtension extension = new TmailDistributedExtension();
 
     @Override
     public GenericContainer<?> jmapContainer() {

--- a/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
+++ b/tmail-backend/deployment-tests/distributed/src/test/java/com/linagora/tmail/deployment/TmailDistributedExtension.java
@@ -35,14 +35,14 @@ import java.util.UUID;
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
 import org.apache.james.util.Port;
 import org.apache.james.util.Runnables;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.MountableFile;
 
-public class TmailDistributedExtension implements BeforeEachCallback, AfterEachCallback {
+public class TmailDistributedExtension implements BeforeAllCallback, AfterAllCallback {
     private final Network network;
     private final GenericContainer<?> cassandra;
     private final GenericContainer<?> opensearch;
@@ -79,7 +79,7 @@ public class TmailDistributedExtension implements BeforeEachCallback, AfterEachC
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+    public void beforeAll(ExtensionContext extensionContext) throws IOException {
         String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "distributed").toString(),
             Paths.get("tmail-backend", "apps", "distributed", "target", "jib-image.tar").toString());
         james.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
@@ -87,7 +87,7 @@ public class TmailDistributedExtension implements BeforeEachCallback, AfterEachC
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) {
+    public void afterAll(ExtensionContext extensionContext) {
         james.stop();
         Runnables.runParallel(
             cassandra::stop,

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryCliTest.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryCliTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 class MemoryCliTest implements CliContract {
     @RegisterExtension
-    TmailMemoryExtension extension = new TmailMemoryExtension();
+    static final TmailMemoryExtension extension = new TmailMemoryExtension();
 
     @Override
     public GenericContainer<?> jamesContainer() {

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryImapAndSmtpTest.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryImapAndSmtpTest.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class MemoryImapAndSmtpTest extends ImapAndSmtpContract {
     @RegisterExtension
-    static TmailMemoryExtension extension = new TmailMemoryExtension();
+    static final TmailMemoryExtension extension = new TmailMemoryExtension();
 
     @Override
     protected ExternalJamesConfiguration configuration() {

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryJmapTest.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/MemoryJmapTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
 
 public class MemoryJmapTest implements JmapContract {
     @RegisterExtension
-    static TmailMemoryExtension extension = new TmailMemoryExtension();
+    static final TmailMemoryExtension extension = new TmailMemoryExtension();
 
     @Override
     public GenericContainer<?> jmapContainer() {

--- a/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
+++ b/tmail-backend/deployment-tests/memory/src/test/java/com/linagora/tmail/deployment/TmailMemoryExtension.java
@@ -26,13 +26,13 @@ import java.util.UUID;
 
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
 import org.apache.james.util.Port;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
-public class TmailMemoryExtension implements BeforeEachCallback, AfterEachCallback {
+public class TmailMemoryExtension implements BeforeAllCallback, AfterAllCallback {
 
     private final GenericContainer<?> container = new GenericContainer<>("linagora/tmail-backend-memory:latest")
         .withCopyFileToContainer(MountableFile.forClasspathResource("james-conf/imapserver.xml"), "/root/conf/")
@@ -44,7 +44,7 @@ public class TmailMemoryExtension implements BeforeEachCallback, AfterEachCallba
         .withExposedPorts(25, 143, 80, 8000);
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+    public void beforeAll(ExtensionContext extensionContext) throws IOException {
         String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "memory").toString(),
             Paths.get("tmail-backend", "apps", "memory", "target", "jib-image.tar").toString());
         container.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
@@ -52,7 +52,7 @@ public class TmailMemoryExtension implements BeforeEachCallback, AfterEachCallba
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) {
+    public void afterAll(ExtensionContext extensionContext) {
         container.stop();
     }
 

--- a/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/PostgresImapAndSmtpTest.java
+++ b/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/PostgresImapAndSmtpTest.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.GenericContainer;
 public class PostgresImapAndSmtpTest extends ImapAndSmtpContract {
 
     @RegisterExtension
-    TmailPostgresExtension extension = new TmailPostgresExtension();
+    static final TmailPostgresExtension extension = new TmailPostgresExtension();
 
     @Override
     protected ExternalJamesConfiguration configuration() {

--- a/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/PostgresLdapImapAndSmtpTest.java
+++ b/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/PostgresLdapImapAndSmtpTest.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.GenericContainer;
 public class PostgresLdapImapAndSmtpTest extends ImapAndSmtpContract {
 
     @RegisterExtension
-    TmailLdapPostgresExtension extension = new TmailLdapPostgresExtension();
+    static final TmailLdapPostgresExtension extension = new TmailLdapPostgresExtension();
 
     @Override
     protected ExternalJamesConfiguration configuration() {

--- a/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/TmailLdapPostgresExtension.java
+++ b/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/TmailLdapPostgresExtension.java
@@ -78,8 +78,8 @@ public class TmailLdapPostgresExtension extends TmailPostgresExtension {
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception {
-        super.afterEach(extensionContext);
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        super.afterAll(extensionContext);
         ldap.stop();
     }
 }

--- a/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/TmailPostgresExtension.java
+++ b/tmail-backend/deployment-tests/postgres/src/test/java/com/linagora/tmail/deployment/TmailPostgresExtension.java
@@ -34,15 +34,15 @@ import java.util.UUID;
 import org.apache.james.mpt.imapmailbox.external.james.host.external.ExternalJamesConfiguration;
 import org.apache.james.util.Port;
 import org.apache.james.util.Runnables;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
-public class TmailPostgresExtension implements BeforeEachCallback, AfterEachCallback {
+public class TmailPostgresExtension implements BeforeAllCallback, AfterAllCallback {
     protected final Network network;
     protected final GenericContainer<?> postgres;
     protected final GenericContainer<?> opensearch;
@@ -92,7 +92,7 @@ public class TmailPostgresExtension implements BeforeEachCallback, AfterEachCall
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
         String dockerSaveFileUrl = new File("").getAbsolutePath().replace(Paths.get("tmail-backend", "deployment-tests", "postgres").toString(),
             Paths.get("tmail-backend", "apps", "postgres", "target", "jib-image.tar").toString());
         tmailBackend.getDockerClient().loadImageCmd(Files.newInputStream(Paths.get(dockerSaveFileUrl))).exec();
@@ -100,7 +100,7 @@ public class TmailPostgresExtension implements BeforeEachCallback, AfterEachCall
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception {
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
         tmailBackend.stop();
         Runnables.runParallel(
             postgres::stop,


### PR DESCRIPTION
Use a class-scoped lifecycle for Testcontainers-based deployment tests.

JUnit extensions are changed from per-test callbacks to class-level callbacks, and registered extensions are made static. As a result, the deployment environment is initialized once per test class instead of once per test method.

This reduces repeated container startup, image loading, and teardown operations, helping shorten deployment test execution in CI.

Before
<img width="794" height="230" alt="Screenshot 2026-09-03 at 9 52 45 AM" src="https://github.com/user-attachments/assets/d088ab00-0a27-447a-b035-1c4c23cdbcfc" />

After
<img width="695" height="254" alt="Screenshot 2026-09-03 at 9 36 01 AM" src="https://github.com/user-attachments/assets/10f3dcd1-82a8-41b5-b9b2-9d9002db683a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Deployment test environments now start required containers once per test suite instead of before every test, then shut them down after the suite completes.
  - Test environment setup is shared consistently across distributed, LDAP, memory, and PostgreSQL deployment scenarios.
  - Test fixtures are initialized once and kept immutable, improving consistency and reducing repeated setup overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->