### PR TITLE
ISSUE-2608 ShardingBlobStoreDAO

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -6,6 +6,7 @@ Twake mail ships some slight blob store enhancements:
 thus improving overall efficiency.
  - Secondary blob store reads and write to several S3 sites providing higher resiliency.
  - Mail processing deduplication can be turned off, so that mails in transit do not outlive their processing.
+ - Buckets can be sharded applicatively, keeping Ceph / Rados gateway bucket indexes listable.
 
 == Object Storage: BlobId list
 
@@ -86,3 +87,40 @@ Specified to TMail backend, we can configure the following configurations in the
 | objectstorage.s3.secondary.secretKey
 | https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[S3 access key secret]
 |===
+
+== Object storage bucket sharding (Ceph / Rados gateway)
+
+S3 compatibility is an API contract, not a behaviour contract: the same verb with the same signature is backed by an
+omap index in RocksDB on one side, and by something else entirely on the other.
+
+A Ceph / Rados gateway bucket index is split into shards, each shard being an omap that should ideally not hold more
+than 100K entries. Holding 10 billion objects within a single bucket would thus require ~100.000 index shards, and
+because S3 listings are *ordered*, serving a 1000 key page then means actively merging 100.000 index shards. This does
+not hold, and listing is required by the deduplication garbage collector.
+
+Twake Mail thus offers *applicative sharding* of the buckets: the blobId decides which one of N physical buckets holds
+the blob. Given 10 billion objects and 256 shards, each bucket holds ~39 million objects, thus ~500 index shards of
+~78K entries: each bucket stays comfortably listable.
+
+....
+-Dtmail.blobstore.shards=256
+....
+
+Physical buckets are named after the logical bucket followed by the zero padded shard number, eg. `blobs-000` up to
+`blobs-255`. Listings (including the ones driven by the deduplication garbage collector) transparently merge every
+shard, with a concurrency of 2.
+
+Sharding sits at the very bottom of the blob store layers, and thus also applies to the secondary blob store when one
+is configured.
+
+[WARNING]
+====
+The shard count is *written in stone*. Changing it on a non-empty deployment relocates every blobId onto another
+bucket, making the already written blobs unreachable. Pick it once, at install time, out of the volume the deployment
+is expected to reach.
+
+Omitting `tmail.blobstore.shards` disables sharding entirely, which is the behaviour of deployments predating this
+option. The option is only honoured by S3 backed deployments.
+====
+
+Note that Ceph auto-resharding should be turned off, and the bucket index sharded at the right size, for this to hold.

--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -104,33 +104,20 @@ the blob. Given 10 billion objects and 256 shards, each bucket holds ~39 million
 
 === Turning it on
 
-The shard count is a JVM system property, not a `blob.properties` entry, as it must be settled before anything is
-written and never move afterwards:
-
-....
--Dtmail.blobstore.shards=256
-....
-
-Omitting it disables sharding entirely, which is the behaviour of deployments predating this option. It is only
-honoured by S3 backed deployments (`implementation=s3`).
-
-Buckets that stay small enough to be listed as they are can be left out of the layout, and are then stored under
-their plain name. Slicing the JMAP uploads - bounded by their expiration - or the mails in transit - bounded by the
-time they spend in the queue - into 256 buckets buys nothing:
-
-....
--Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing
-....
-
-Comma separated list of *logical* bucket names, empty by default. Like the shard count, it is written in stone for
-the buckets it names: moving a bucket in or out of the list makes what it already holds unreachable.
-
-The bucket names it produces are then resolved by the S3 connector as usual, out of `blob.properties`
-(`blobstore.properties` is accepted as a legacy name):
+Sharding is configured in `blob.properties` (`blobstore.properties` is accepted as a legacy name), alongside the
+object storage settings the bucket names are then resolved with:
 
 .blob.properties
 ....
 implementation=s3
+
+# How many physical buckets a logical bucket is spread over.
+# Optional, defaults to 0, which disables sharding altogether.
+tmail.blobstore.shards=256
+
+# Logical buckets left out of the layout, stored under their plain name. Comma separated.
+# Optional, defaults to none.
+tmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing
 
 # The default bucket, holding mailbox content. Left unprefixed by the S3 connector.
 objectstorage.namespace=blobs
@@ -139,12 +126,18 @@ objectstorage.namespace=blobs
 objectstorage.bucketPrefix=tmail-
 ....
 
+Leaving `tmail.blobstore.shards` out disables sharding entirely, which is the behaviour of deployments predating this
+option. It is only honoured by S3 backed deployments (`implementation=s3`).
+
+Slicing a bucket that stays small enough to be listed as it is buys nothing: the JMAP uploads are bounded by their
+expiration, and the mails in transit by the time they spend in the queue. Those go in
+`tmail.blobstore.shards.ommited.buckets`, which takes *logical* bucket names.
+
 === Resulting layout
 
 A physical bucket is named after the logical bucket followed by the zero padded shard number, and the S3 connector
-then prepends `objectstorage.bucketPrefix` to it. With the configuration above, `-Dtmail.blobstore.shards=4` and
-`-Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing`, the four logical buckets a distributed
-deployment writes to map as follows:
+then prepends `objectstorage.bucketPrefix` to it. With the configuration above, `tmail.blobstore.shards` lowered to
+`4` for readability, the four logical buckets a distributed deployment writes to map as follows:
 
 |===
 | Logical bucket | Holds | Physical S3 buckets
@@ -170,7 +163,8 @@ Dropping `tmail.blobstore.shards.ommited.buckets` would instead split all four, 
 `tmail-jmap-uploads-0` … `tmail-jmap-uploads-3` and `mail-processing` becoming `tmail-mail-processing-0` …
 `tmail-mail-processing-3`.
 
-Without `tmail.blobstore.shards`, the very same configuration yields the layout deployments already have, unchanged:
+Without `tmail.blobstore.shards`, the very same `blob.properties` yields the layout deployments already have,
+unchanged:
 
 |===
 | Logical bucket | Physical S3 bucket
@@ -191,9 +185,10 @@ blob store when one is configured.
 
 [WARNING]
 ====
-The shard count is *written in stone*. Changing it on a non-empty deployment relocates every blobId onto another
-bucket, making the already written blobs unreachable. Pick it once, at install time, out of the volume the deployment
-is expected to reach.
+Both `tmail.blobstore.shards` and `tmail.blobstore.shards.ommited.buckets` are *written in stone*. Changing the
+shard count on a non-empty deployment relocates every blobId onto another bucket, and moving a bucket in or out of
+the omitted list does the same for that bucket: the already written blobs become unreachable. Pick them once, at
+install time, out of the volume the deployment is expected to reach.
 
 Mind also the total bucket count: every sharded logical bucket is multiplied by the shard count, so at 256 shards
 the two sharded buckets above become 512, and all four would become 1024 were none omitted. Ceph caps the number of

--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -181,7 +181,8 @@ consequence is that `objectstorage.namespace.read.fallback` no longer matches an
 
 Listings - including the ones driven by the deduplication garbage collector - transparently merge every shard, with a
 concurrency of 2. Sharding sits at the very bottom of the blob store layers, and thus also applies to the secondary
-blob store when one is configured.
+blob store when one is configured. Omitted buckets are configured without the secondary bucket suffix; Twake Mail
+applies that suffix automatically before matching them on the secondary store.
 
 [WARNING]
 ====

--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -114,6 +114,17 @@ written and never move afterwards:
 Omitting it disables sharding entirely, which is the behaviour of deployments predating this option. It is only
 honoured by S3 backed deployments (`implementation=s3`).
 
+Buckets that stay small enough to be listed as they are can be left out of the layout, and are then stored under
+their plain name. Slicing the JMAP uploads - bounded by their expiration - or the mails in transit - bounded by the
+time they spend in the queue - into 256 buckets buys nothing:
+
+....
+-Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing
+....
+
+Comma separated list of *logical* bucket names, empty by default. Like the shard count, it is written in stone for
+the buckets it names: moving a bucket in or out of the list makes what it already holds unreachable.
+
 The bucket names it produces are then resolved by the S3 connector as usual, out of `blob.properties`
 (`blobstore.properties` is accepted as a legacy name):
 
@@ -131,8 +142,9 @@ objectstorage.bucketPrefix=tmail-
 === Resulting layout
 
 A physical bucket is named after the logical bucket followed by the zero padded shard number, and the S3 connector
-then prepends `objectstorage.bucketPrefix` to it. With the configuration above and `-Dtmail.blobstore.shards=4`, the
-four logical buckets a distributed deployment writes to map as follows:
+then prepends `objectstorage.bucketPrefix` to it. With the configuration above, `-Dtmail.blobstore.shards=4` and
+`-Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing`, the four logical buckets a distributed
+deployment writes to map as follows:
 
 |===
 | Logical bucket | Holds | Physical S3 buckets
@@ -141,18 +153,22 @@ four logical buckets a distributed deployment writes to map as follows:
 | Mailbox content. This is `objectstorage.namespace`.
 | `tmail-blobs-0`, `tmail-blobs-1`, `tmail-blobs-2`, `tmail-blobs-3`
 
-| `jmap-uploads`
-| JMAP uploads.
-| `tmail-jmap-uploads-0` … `tmail-jmap-uploads-3`
-
 | `tmail-deleted-message-vault`
 | Deleted message vault.
 | `tmail-tmail-deleted-message-vault-0` … `tmail-tmail-deleted-message-vault-3`
 
+| `jmap-uploads`
+| JMAP uploads. Omitted, thus not sharded.
+| `tmail-jmap-uploads`
+
 | `mail-processing`
-| Mails in transit, when `mailprocessing.deduplication.enabled=false`.
-| `tmail-mail-processing-0` … `tmail-mail-processing-3`
+| Mails in transit, when `mailprocessing.deduplication.enabled=false`. Omitted, thus not sharded.
+| `tmail-mail-processing`
 |===
+
+Dropping `tmail.blobstore.shards.ommited.buckets` would instead split all four, `jmap-uploads` becoming
+`tmail-jmap-uploads-0` … `tmail-jmap-uploads-3` and `mail-processing` becoming `tmail-mail-processing-0` …
+`tmail-mail-processing-3`.
 
 Without `tmail.blobstore.shards`, the very same configuration yields the layout deployments already have, unchanged:
 
@@ -179,9 +195,9 @@ The shard count is *written in stone*. Changing it on a non-empty deployment rel
 bucket, making the already written blobs unreachable. Pick it once, at install time, out of the volume the deployment
 is expected to reach.
 
-Mind also the total bucket count: every logical bucket is multiplied by the shard count, so those four become 1024
-buckets at 256 shards. Ceph caps the number of buckets a user owns with `rgw_max_buckets` (1000 by default), which
-needs raising accordingly.
+Mind also the total bucket count: every sharded logical bucket is multiplied by the shard count, so at 256 shards
+the two sharded buckets above become 512, and all four would become 1024 were none omitted. Ceph caps the number of
+buckets a user owns with `rgw_max_buckets` (1000 by default), which needs raising accordingly.
 ====
 
 Note that Ceph auto-resharding should be turned off, and the bucket index sharded at the right size, for this to hold.

--- a/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/blob-store.adoc
@@ -102,16 +102,76 @@ Twake Mail thus offers *applicative sharding* of the buckets: the blobId decides
 the blob. Given 10 billion objects and 256 shards, each bucket holds ~39 million objects, thus ~500 index shards of
 ~78K entries: each bucket stays comfortably listable.
 
+=== Turning it on
+
+The shard count is a JVM system property, not a `blob.properties` entry, as it must be settled before anything is
+written and never move afterwards:
+
 ....
 -Dtmail.blobstore.shards=256
 ....
 
-Physical buckets are named after the logical bucket followed by the zero padded shard number, eg. `blobs-000` up to
-`blobs-255`. Listings (including the ones driven by the deduplication garbage collector) transparently merge every
-shard, with a concurrency of 2.
+Omitting it disables sharding entirely, which is the behaviour of deployments predating this option. It is only
+honoured by S3 backed deployments (`implementation=s3`).
 
-Sharding sits at the very bottom of the blob store layers, and thus also applies to the secondary blob store when one
-is configured.
+The bucket names it produces are then resolved by the S3 connector as usual, out of `blob.properties`
+(`blobstore.properties` is accepted as a legacy name):
+
+.blob.properties
+....
+implementation=s3
+
+# The default bucket, holding mailbox content. Left unprefixed by the S3 connector.
+objectstorage.namespace=blobs
+
+# Prepended to every other bucket name.
+objectstorage.bucketPrefix=tmail-
+....
+
+=== Resulting layout
+
+A physical bucket is named after the logical bucket followed by the zero padded shard number, and the S3 connector
+then prepends `objectstorage.bucketPrefix` to it. With the configuration above and `-Dtmail.blobstore.shards=4`, the
+four logical buckets a distributed deployment writes to map as follows:
+
+|===
+| Logical bucket | Holds | Physical S3 buckets
+
+| `blobs`
+| Mailbox content. This is `objectstorage.namespace`.
+| `tmail-blobs-0`, `tmail-blobs-1`, `tmail-blobs-2`, `tmail-blobs-3`
+
+| `jmap-uploads`
+| JMAP uploads.
+| `tmail-jmap-uploads-0` … `tmail-jmap-uploads-3`
+
+| `tmail-deleted-message-vault`
+| Deleted message vault.
+| `tmail-tmail-deleted-message-vault-0` … `tmail-tmail-deleted-message-vault-3`
+
+| `mail-processing`
+| Mails in transit, when `mailprocessing.deduplication.enabled=false`.
+| `tmail-mail-processing-0` … `tmail-mail-processing-3`
+|===
+
+Without `tmail.blobstore.shards`, the very same configuration yields the layout deployments already have, unchanged:
+
+|===
+| Logical bucket | Physical S3 bucket
+
+| `blobs` | `blobs`
+| `jmap-uploads` | `tmail-jmap-uploads`
+| `tmail-deleted-message-vault` | `tmail-tmail-deleted-message-vault`
+| `mail-processing` | `tmail-mail-processing`
+|===
+
+Note that `objectstorage.namespace` is the one bucket the S3 connector leaves unprefixed, and that this exemption
+only holds for its exact name: once sharded, `blobs-0` is no longer the namespace and thus does get the prefix. A
+consequence is that `objectstorage.namespace.read.fallback` no longer matches anything once sharding is on.
+
+Listings - including the ones driven by the deduplication garbage collector - transparently merge every shard, with a
+concurrency of 2. Sharding sits at the very bottom of the blob store layers, and thus also applies to the secondary
+blob store when one is configured.
 
 [WARNING]
 ====
@@ -119,8 +179,9 @@ The shard count is *written in stone*. Changing it on a non-empty deployment rel
 bucket, making the already written blobs unreachable. Pick it once, at install time, out of the volume the deployment
 is expected to reach.
 
-Omitting `tmail.blobstore.shards` disables sharding entirely, which is the behaviour of deployments predating this
-option. The option is only honoured by S3 backed deployments.
+Mind also the total bucket count: every logical bucket is multiplied by the shard count, so those four become 1024
+buckets at 256 shards. Ceph caps the number of buckets a user owns with `rgw_max_buckets` (1000 by default), which
+needs raising accordingly.
 ====
 
 Note that Ceph auto-resharding should be turned off, and the bucket index sharded at the right size, for this to hold.

--- a/tmail-backend/apps/distributed/pom.xml
+++ b/tmail-backend/apps/distributed/pom.xml
@@ -43,6 +43,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>sharded-blob-store</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blob-guice</artifactId>
         </dependency>
         <dependency>

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
@@ -73,8 +74,6 @@ import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
 class DistributedBlobStoreBucketShardingTest {
     private static final int SHARD_COUNT = 4;
     private static final int BLOBS_PER_BUCKET = 16;
-    /** {@code objectstorage.bucketPrefix} */
-    private static final String BUCKET_PREFIX = "tmail-";
 
     /** The default bucket, holding mailbox content. Named after {@code objectstorage.namespace}. */
     private static final BucketName DEFAULT_BUCKET = BucketName.of("blobs");
@@ -93,6 +92,12 @@ class DistributedBlobStoreBucketShardingTest {
      * the random ones {@code AwsS3BlobStoreExtension} uses, so that physical bucket names can be asserted upon.
      */
     static class FixedNamesAwsS3BlobStoreExtension implements GuiceModuleTestExtension {
+        private final String bucketPrefix;
+
+        FixedNamesAwsS3BlobStoreExtension(String bucketPrefix) {
+            this.bucketPrefix = bucketPrefix;
+        }
+
         @Override
         public void beforeAll(ExtensionContext extensionContext) {
             DockerAwsS3Singleton.singleton.dockerAwsS3();
@@ -109,7 +114,7 @@ class DistributedBlobStoreBucketShardingTest {
                 .authConfiguration(authConfiguration)
                 .region(DockerAwsS3Container.REGION)
                 .defaultBucketName(DEFAULT_BUCKET)
-                .bucketPrefix(BUCKET_PREFIX)
+                .bucketPrefix(bucketPrefix)
                 .build();
 
             return binder -> {
@@ -163,7 +168,7 @@ class DistributedBlobStoreBucketShardingTest {
         }
     }
 
-    private static JamesServerExtension serverExtension(Optional<BucketSharding> bucketSharding) {
+    private static JamesServerExtension serverExtension(String bucketPrefix, Optional<BucketSharding> bucketSharding) {
         return new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
             DistributedJamesConfiguration.builder()
                 .workingDirectory(tmpDir)
@@ -183,7 +188,7 @@ class DistributedBlobStoreBucketShardingTest {
             .extension(new CassandraExtension())
             .extension(new RabbitMQExtension())
             .extension(new RedisExtension())
-            .extension(new FixedNamesAwsS3BlobStoreExtension())
+            .extension(new FixedNamesAwsS3BlobStoreExtension(bucketPrefix))
             .server(configuration -> DistributedServer.createServer(configuration)
                 .overrideWith(new LinagoraTestJMAPServerModule())
                 .overrideWith(binder -> binder.bind(new TypeLiteral<Optional<BucketSharding>>() {})
@@ -195,28 +200,52 @@ class DistributedBlobStoreBucketShardingTest {
             .build();
     }
 
+    /**
+     * Each case runs under its own {@code objectstorage.bucketPrefix}: the docker S3 is shared by the whole test
+     * run, and the three layouts would otherwise land on top of one another.
+     */
     @Nested
     class WithFourShards {
         @RegisterExtension
-        static JamesServerExtension testExtension = serverExtension(Optional.of(new BucketSharding(SHARD_COUNT)));
+        static JamesServerExtension testExtension = serverExtension("allshards-",
+            Optional.of(new BucketSharding(SHARD_COUNT)));
 
         @Test
         void everyLogicalBucketShouldBeSplitInFourPhysicalBuckets(GuiceJamesServer server) {
             assertThat(server.getProbe(BucketLayoutProbe.class).bucketsCreatedByFillingEveryLogicalBucket())
                 .containsExactlyInAnyOrder(
+                    "allshards-blobs-0", "allshards-blobs-1", "allshards-blobs-2", "allshards-blobs-3",
+                    "allshards-jmap-uploads-0", "allshards-jmap-uploads-1",
+                    "allshards-jmap-uploads-2", "allshards-jmap-uploads-3",
+                    "allshards-tmail-deleted-message-vault-0", "allshards-tmail-deleted-message-vault-1",
+                    "allshards-tmail-deleted-message-vault-2", "allshards-tmail-deleted-message-vault-3",
+                    "allshards-mail-processing-0", "allshards-mail-processing-1",
+                    "allshards-mail-processing-2", "allshards-mail-processing-3");
+        }
+    }
+
+    @Nested
+    class WithFourShardsAndOmittedBuckets {
+        @RegisterExtension
+        static JamesServerExtension testExtension = serverExtension("tmail-",
+            Optional.of(new BucketSharding(SHARD_COUNT, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET))));
+
+        @Test
+        void omittedBucketsShouldKeepTheirUnshardedPhysicalName(GuiceJamesServer server) {
+            assertThat(server.getProbe(BucketLayoutProbe.class).bucketsCreatedByFillingEveryLogicalBucket())
+                .containsExactlyInAnyOrder(
                     "tmail-blobs-0", "tmail-blobs-1", "tmail-blobs-2", "tmail-blobs-3",
-                    "tmail-jmap-uploads-0", "tmail-jmap-uploads-1", "tmail-jmap-uploads-2", "tmail-jmap-uploads-3",
                     "tmail-tmail-deleted-message-vault-0", "tmail-tmail-deleted-message-vault-1",
                     "tmail-tmail-deleted-message-vault-2", "tmail-tmail-deleted-message-vault-3",
-                    "tmail-mail-processing-0", "tmail-mail-processing-1",
-                    "tmail-mail-processing-2", "tmail-mail-processing-3");
+                    "tmail-jmap-uploads",
+                    "tmail-mail-processing");
         }
     }
 
     @Nested
     class WithoutSharding {
         @RegisterExtension
-        static JamesServerExtension testExtension = serverExtension(Optional.empty());
+        static JamesServerExtension testExtension = serverExtension("noshards-", Optional.empty());
 
         @Test
         void everyLogicalBucketShouldKeepItsUnshardedPhysicalName(GuiceJamesServer server) {
@@ -224,9 +253,9 @@ class DistributedBlobStoreBucketShardingTest {
                 .containsExactlyInAnyOrder(
                     // the default bucket is the namespace, and as such is the one bucket left unprefixed
                     "blobs",
-                    "tmail-jmap-uploads",
-                    "tmail-tmail-deleted-message-vault",
-                    "tmail-mail-processing");
+                    "noshards-jmap-uploads",
+                    "noshards-tmail-deleted-message-vault",
+                    "noshards-mail-processing");
         }
     }
 }

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
@@ -1,0 +1,232 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.james.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.GuiceModuleTestExtension;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.SearchConfiguration;
+import org.apache.james.backends.redis.RedisExtension;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.blob.objectstorage.aws.AwsS3AuthConfiguration;
+import org.apache.james.blob.objectstorage.aws.DockerAwsS3Container;
+import org.apache.james.blob.objectstorage.aws.DockerAwsS3Singleton;
+import org.apache.james.blob.objectstorage.aws.Region;
+import org.apache.james.blob.objectstorage.aws.S3BlobStoreConfiguration;
+import org.apache.james.blob.objectstorage.aws.S3ClientFactory;
+import org.apache.james.blob.objectstorage.aws.S3RequestOption;
+import org.apache.james.utils.GuiceProbe;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
+import com.linagora.tmail.blob.sharding.BucketSharding;
+import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
+import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+
+/**
+ * End to end picture of the physical S3 bucket layout, over the four logical buckets a Twake Mail deployment writes
+ * to, with and without applicative sharding.
+ *
+ * <p>The logical bucket names are fixed here so that the expected physical names can be spelled out. Note that the
+ * default bucket - the {@code objectstorage.namespace} - is the one bucket S3 does not prefix, an exemption that only
+ * holds as long as its name is left untouched: once sharded, {@code blobs-0} is no longer the namespace and thus does
+ * get the prefix.</p>
+ */
+class DistributedBlobStoreBucketShardingTest {
+    private static final int SHARD_COUNT = 4;
+    private static final int BLOBS_PER_BUCKET = 16;
+    /** {@code objectstorage.bucketPrefix} */
+    private static final String BUCKET_PREFIX = "tmail-";
+
+    /** The default bucket, holding mailbox content. Named after {@code objectstorage.namespace}. */
+    private static final BucketName DEFAULT_BUCKET = BucketName.of("blobs");
+    /** JMAP uploads. */
+    private static final BucketName UPLOADS_BUCKET = BucketName.of("jmap-uploads");
+    /** Deleted message vault. */
+    private static final BucketName VAULT_BUCKET = BucketName.of("tmail-deleted-message-vault");
+    /** Mails in transit, when {@code mailprocessing.deduplication.enabled} is false. */
+    private static final BucketName MAIL_PROCESSING_BUCKET = BucketName.of("mail-processing");
+
+    private static final List<BucketName> LOGICAL_BUCKETS =
+        ImmutableList.of(DEFAULT_BUCKET, UPLOADS_BUCKET, VAULT_BUCKET, MAIL_PROCESSING_BUCKET);
+
+    /**
+     * Binds the object storage onto the shared docker S3, with a chosen prefix and default bucket name rather than
+     * the random ones {@code AwsS3BlobStoreExtension} uses, so that physical bucket names can be asserted upon.
+     */
+    static class FixedNamesAwsS3BlobStoreExtension implements GuiceModuleTestExtension {
+        @Override
+        public void beforeAll(ExtensionContext extensionContext) {
+            DockerAwsS3Singleton.singleton.dockerAwsS3();
+        }
+
+        @Override
+        public Module getModule() {
+            AwsS3AuthConfiguration authConfiguration = AwsS3AuthConfiguration.builder()
+                .endpoint(DockerAwsS3Singleton.singleton.getEndpoint())
+                .accessKeyId(DockerAwsS3Container.ACCESS_KEY_ID)
+                .secretKey(DockerAwsS3Container.SECRET_ACCESS_KEY)
+                .build();
+            S3BlobStoreConfiguration configuration = S3BlobStoreConfiguration.builder()
+                .authConfiguration(authConfiguration)
+                .region(DockerAwsS3Container.REGION)
+                .defaultBucketName(DEFAULT_BUCKET)
+                .bucketPrefix(BUCKET_PREFIX)
+                .build();
+
+            return binder -> {
+                binder.bind(BucketName.class).toInstance(DEFAULT_BUCKET);
+                binder.bind(Region.class).toInstance(DockerAwsS3Container.REGION);
+                binder.bind(AwsS3AuthConfiguration.class).toInstance(authConfiguration);
+                binder.bind(S3BlobStoreConfiguration.class).toInstance(configuration);
+                binder.bind(S3RequestOption.class).toInstance(S3RequestOption.DEFAULT);
+            };
+        }
+    }
+
+    public static class BucketLayoutProbe implements GuiceProbe {
+        private final BlobStoreDAO blobStoreDAO;
+        private final S3ClientFactory s3ClientFactory;
+
+        @Inject
+        public BucketLayoutProbe(BlobStoreDAO blobStoreDAO, S3ClientFactory s3ClientFactory) {
+            this.blobStoreDAO = blobStoreDAO;
+            this.s3ClientFactory = s3ClientFactory;
+        }
+
+        /**
+         * The docker S3 is shared by the whole test run, so what this server created is the difference between the
+         * two listings rather than the whole bucket list.
+         */
+        List<String> bucketsCreatedByFillingEveryLogicalBucket() {
+            List<String> before = physicalBuckets();
+            fillEveryLogicalBucket();
+            return physicalBuckets().stream()
+                .filter(bucket -> !before.contains(bucket))
+                .collect(ImmutableList.toImmutableList());
+        }
+
+        private void fillEveryLogicalBucket() {
+            Flux.fromIterable(LOGICAL_BUCKETS)
+                .concatMap(bucketName -> Flux.range(0, BLOBS_PER_BUCKET)
+                    .concatMap(i -> blobStoreDAO.save(bucketName,
+                        new PlainBlobId(bucketName.asString() + "-blob-" + i),
+                        BlobStoreDAO.BytesBlob.of("payload " + i))))
+                .then()
+                .block();
+        }
+
+        List<String> physicalBuckets() {
+            return Mono.fromFuture(() -> s3ClientFactory.get().listBuckets())
+                .flatMapIterable(ListBucketsResponse::buckets)
+                .map(Bucket::name)
+                .collectList()
+                .block();
+        }
+    }
+
+    private static JamesServerExtension serverExtension(Optional<BucketSharding> bucketSharding) {
+        return new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
+            DistributedJamesConfiguration.builder()
+                .workingDirectory(tmpDir)
+                .configurationFromClasspath()
+                .blobStore(BlobStoreConfiguration.builder()
+                    .s3()
+                    .noSecondaryS3BlobStore()
+                    .disableCache()
+                    .deduplication()
+                    .noCryptoConfig()
+                    .disableSingleSave())
+                .eventBusKeysChoice(EventBusKeysChoice.REDIS)
+                .searchConfiguration(SearchConfiguration.openSearch())
+                .firebaseModuleChooserConfiguration(FirebaseModuleChooserConfiguration.DISABLED)
+                .build())
+            .extension(new DockerOpenSearchExtension())
+            .extension(new CassandraExtension())
+            .extension(new RabbitMQExtension())
+            .extension(new RedisExtension())
+            .extension(new FixedNamesAwsS3BlobStoreExtension())
+            .server(configuration -> DistributedServer.createServer(configuration)
+                .overrideWith(new LinagoraTestJMAPServerModule())
+                .overrideWith(binder -> binder.bind(new TypeLiteral<Optional<BucketSharding>>() {})
+                    .toInstance(bucketSharding))
+                .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
+                    .addBinding()
+                    .to(BucketLayoutProbe.class)))
+            .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+            .build();
+    }
+
+    @Nested
+    class WithFourShards {
+        @RegisterExtension
+        static JamesServerExtension testExtension = serverExtension(Optional.of(new BucketSharding(SHARD_COUNT)));
+
+        @Test
+        void everyLogicalBucketShouldBeSplitInFourPhysicalBuckets(GuiceJamesServer server) {
+            assertThat(server.getProbe(BucketLayoutProbe.class).bucketsCreatedByFillingEveryLogicalBucket())
+                .containsExactlyInAnyOrder(
+                    "tmail-blobs-0", "tmail-blobs-1", "tmail-blobs-2", "tmail-blobs-3",
+                    "tmail-jmap-uploads-0", "tmail-jmap-uploads-1", "tmail-jmap-uploads-2", "tmail-jmap-uploads-3",
+                    "tmail-tmail-deleted-message-vault-0", "tmail-tmail-deleted-message-vault-1",
+                    "tmail-tmail-deleted-message-vault-2", "tmail-tmail-deleted-message-vault-3",
+                    "tmail-mail-processing-0", "tmail-mail-processing-1",
+                    "tmail-mail-processing-2", "tmail-mail-processing-3");
+        }
+    }
+
+    @Nested
+    class WithoutSharding {
+        @RegisterExtension
+        static JamesServerExtension testExtension = serverExtension(Optional.empty());
+
+        @Test
+        void everyLogicalBucketShouldKeepItsUnshardedPhysicalName(GuiceJamesServer server) {
+            assertThat(server.getProbe(BucketLayoutProbe.class).bucketsCreatedByFillingEveryLogicalBucket())
+                .containsExactlyInAnyOrder(
+                    // the default bucket is the namespace, and as such is the one bucket left unprefixed
+                    "blobs",
+                    "tmail-jmap-uploads",
+                    "tmail-tmail-deleted-message-vault",
+                    "tmail-mail-processing");
+        }
+    }
+}

--- a/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
+++ b/tmail-backend/apps/distributed/src/test/java/com/linagora/tmail/james/app/DistributedBlobStoreBucketShardingTest.java
@@ -48,12 +48,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
-import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.tmail.blob.guice.BlobStoreConfiguration;
-import com.linagora.tmail.blob.sharding.BucketSharding;
+import com.linagora.tmail.blob.sharding.TmailBlobStoreShardingConfiguration;
 import com.linagora.tmail.james.jmap.firebase.FirebaseModuleChooserConfiguration;
 import com.linagora.tmail.module.LinagoraTestJMAPServerModule;
 
@@ -168,7 +166,8 @@ class DistributedBlobStoreBucketShardingTest {
         }
     }
 
-    private static JamesServerExtension serverExtension(String bucketPrefix, Optional<BucketSharding> bucketSharding) {
+    private static JamesServerExtension serverExtension(String bucketPrefix,
+                                                        TmailBlobStoreShardingConfiguration shardingConfiguration) {
         return new JamesServerBuilder<DistributedJamesConfiguration>(tmpDir ->
             DistributedJamesConfiguration.builder()
                 .workingDirectory(tmpDir)
@@ -191,8 +190,8 @@ class DistributedBlobStoreBucketShardingTest {
             .extension(new FixedNamesAwsS3BlobStoreExtension(bucketPrefix))
             .server(configuration -> DistributedServer.createServer(configuration)
                 .overrideWith(new LinagoraTestJMAPServerModule())
-                .overrideWith(binder -> binder.bind(new TypeLiteral<Optional<BucketSharding>>() {})
-                    .toInstance(bucketSharding))
+                .overrideWith(binder -> binder.bind(TmailBlobStoreShardingConfiguration.class)
+                    .toInstance(shardingConfiguration))
                 .overrideWith(binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
                     .addBinding()
                     .to(BucketLayoutProbe.class)))
@@ -208,7 +207,7 @@ class DistributedBlobStoreBucketShardingTest {
     class WithFourShards {
         @RegisterExtension
         static JamesServerExtension testExtension = serverExtension("allshards-",
-            Optional.of(new BucketSharding(SHARD_COUNT)));
+            TmailBlobStoreShardingConfiguration.of(SHARD_COUNT));
 
         @Test
         void everyLogicalBucketShouldBeSplitInFourPhysicalBuckets(GuiceJamesServer server) {
@@ -228,7 +227,7 @@ class DistributedBlobStoreBucketShardingTest {
     class WithFourShardsAndOmittedBuckets {
         @RegisterExtension
         static JamesServerExtension testExtension = serverExtension("tmail-",
-            Optional.of(new BucketSharding(SHARD_COUNT, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET))));
+            TmailBlobStoreShardingConfiguration.of(SHARD_COUNT, UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET));
 
         @Test
         void omittedBucketsShouldKeepTheirUnshardedPhysicalName(GuiceJamesServer server) {
@@ -245,7 +244,8 @@ class DistributedBlobStoreBucketShardingTest {
     @Nested
     class WithoutSharding {
         @RegisterExtension
-        static JamesServerExtension testExtension = serverExtension("noshards-", Optional.empty());
+        static JamesServerExtension testExtension = serverExtension("noshards-",
+            TmailBlobStoreShardingConfiguration.DISABLED);
 
         @Test
         void everyLogicalBucketShouldKeepItsUnshardedPhysicalName(GuiceJamesServer server) {

--- a/tmail-backend/blob/sharded-blob-store/pom.xml
+++ b/tmail-backend/blob/sharded-blob-store/pom.xml
@@ -28,46 +28,21 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>blob-guice</artifactId>
-    <name>Twake Mail :: Blob :: BlobGuice</name>
+    <artifactId>sharded-blob-store</artifactId>
+    <name>Twake Mail :: Blob :: ShardedBlobStore</name>
+    <description>Applicative sharding of blob store buckets, allowing Ceph / Rados gateway deployments to
+        keep bucket indexes (omaps) small enough to remain listable.</description>
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>blobid-list</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>secondary-blob-store</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>sharded-blob-store</artifactId>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>blob-api</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>blob-zstd</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-mail-store</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>metrics-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>metrics-tests</artifactId>
+            <artifactId>blob-api</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -75,28 +50,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-core</artifactId>
-            <scope>test</scope>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>apache-james-backends-cassandra</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-guice-common</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -105,21 +66,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-migrationsupport</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tmail-backend/blob/sharded-blob-store/pom.xml
+++ b/tmail-backend/blob/sharded-blob-store/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
@@ -61,6 +65,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- commons-configuration2 logs through commons-logging, needed to read a test blob.properties -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/BucketSharding.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/BucketSharding.java
@@ -1,0 +1,133 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.sharding;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BucketName;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+/**
+ * Maps a James logical {@link BucketName} onto a fixed set of physical buckets, the shard being derived from the
+ * {@link BlobId}.
+ *
+ * <p>S3 compatibility is an API contract, not a behaviour contract: a Ceph / Rados gateway bucket is backed by
+ * sharded omap indexes that should not hold much more than 100K entries each. Holding billions of objects in a
+ * single bucket would require tens of thousands of index shards, and an <strong>ordered</strong> S3 listing would
+ * then need to merge all of them, which does not hold. Splitting the objects across several buckets keeps each
+ * bucket index within a listable size.</p>
+ *
+ * <p>Physical buckets are named {@code <logical bucket>-<zero padded shard number>}, eg. {@code default-000} up to
+ * {@code default-255} for 256 shards. <strong>The shard count is written in stone</strong>: changing it relocates
+ * every blob and makes the already written ones unreadable. Because blobIds are content addressed, deduplication
+ * and garbage collection still hold within a shard.</p>
+ */
+public record BucketSharding(int shardCount) {
+    public static final String SHARD_COUNT_PROPERTY = "tmail.blobstore.shards";
+    public static final char SEPARATOR = '-';
+
+    /**
+     * Murmur3 is stable across JVMs and Guava releases, which {@link String#hashCode()} guarantees too but with a
+     * far poorer distribution over hexadecimal blobIds.
+     */
+    private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32_fixed();
+
+    /**
+     * @return the sharding configured by {@code -Dtmail.blobstore.shards=256}, or {@link Optional#empty()} when the
+     * property is omitted, in which case no sharding is applied at all.
+     */
+    public static Optional<BucketSharding> fromSystemProperties() {
+        return Optional.ofNullable(System.getProperty(SHARD_COUNT_PROPERTY))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .map(BucketSharding::parse);
+    }
+
+    private static BucketSharding parse(String value) {
+        try {
+            return new BucketSharding(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(SHARD_COUNT_PROPERTY + " must be a positive integer, got " + value, e);
+        }
+    }
+
+    public BucketSharding {
+        Preconditions.checkArgument(shardCount > 0, "%s must be strictly positive", SHARD_COUNT_PROPERTY);
+    }
+
+    public int shardOf(BlobId blobId) {
+        return Math.floorMod(HASH_FUNCTION.hashString(blobId.asString(), StandardCharsets.UTF_8).asInt(), shardCount);
+    }
+
+    public BucketName physicalBucket(BucketName logicalBucket, BlobId blobId) {
+        return physicalBucket(logicalBucket, shardOf(blobId));
+    }
+
+    public BucketName physicalBucket(BucketName logicalBucket, int shard) {
+        return BucketName.of(logicalBucket.asString() + SEPARATOR + format(shard));
+    }
+
+    public List<BucketName> physicalBuckets(BucketName logicalBucket) {
+        return IntStream.range(0, shardCount)
+            .mapToObj(shard -> physicalBucket(logicalBucket, shard))
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Reverses {@link #physicalBucket(BucketName, int)}.
+     *
+     * @return {@link Optional#empty()} for buckets that do not belong to this layout: the underlying object storage
+     * may well hold buckets written before sharding was turned on, or by other tools.
+     */
+    public Optional<BucketName> logicalBucket(BucketName physicalBucket) {
+        String value = physicalBucket.asString();
+        int separatorPosition = value.length() - shardWidth() - 1;
+        if (separatorPosition <= 0 || value.charAt(separatorPosition) != SEPARATOR) {
+            return Optional.empty();
+        }
+        return parseShard(value.substring(separatorPosition + 1))
+            .filter(shard -> shard < shardCount)
+            .map(shard -> BucketName.of(value.substring(0, separatorPosition)));
+    }
+
+    private Optional<Integer> parseShard(String suffix) {
+        try {
+            return Optional.of(Integer.parseUnsignedInt(suffix));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String format(int shard) {
+        String asString = Integer.toString(shard);
+        return "0".repeat(shardWidth() - asString.length()) + asString;
+    }
+
+    private int shardWidth() {
+        return Integer.toString(shardCount - 1).length();
+    }
+}

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/BucketSharding.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/BucketSharding.java
@@ -21,13 +21,16 @@ package com.linagora.tmail.blob.sharding;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
@@ -45,10 +48,16 @@ import com.google.common.hash.Hashing;
  * {@code default-255} for 256 shards. <strong>The shard count is written in stone</strong>: changing it relocates
  * every blob and makes the already written ones unreadable. Because blobIds are content addressed, deduplication
  * and garbage collection still hold within a shard.</p>
+ *
+ * <p>Buckets that stay small enough to be listed as they are - the JMAP uploads and the mails in transit, say - can
+ * be left out of the layout entirely, and are then stored under their plain name.</p>
  */
-public record BucketSharding(int shardCount) {
+public record BucketSharding(int shardCount, Set<BucketName> omittedBuckets) {
     public static final String SHARD_COUNT_PROPERTY = "tmail.blobstore.shards";
+    public static final String OMITTED_BUCKETS_PROPERTY = "tmail.blobstore.shards.ommited.buckets";
     public static final char SEPARATOR = '-';
+
+    private static final Splitter OMITTED_BUCKETS_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     /**
      * Murmur3 is stable across JVMs and Guava releases, which {@link String#hashCode()} guarantees too but with a
@@ -57,26 +66,45 @@ public record BucketSharding(int shardCount) {
     private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32_fixed();
 
     /**
-     * @return the sharding configured by {@code -Dtmail.blobstore.shards=256}, or {@link Optional#empty()} when the
-     * property is omitted, in which case no sharding is applied at all.
+     * @return the sharding configured by {@code -Dtmail.blobstore.shards=256} and
+     * {@code -Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing}, or {@link Optional#empty()} when
+     * the shard count property is omitted, in which case no sharding is applied at all.
      */
     public static Optional<BucketSharding> fromSystemProperties() {
         return Optional.ofNullable(System.getProperty(SHARD_COUNT_PROPERTY))
             .map(String::trim)
             .filter(value -> !value.isEmpty())
-            .map(BucketSharding::parse);
+            .map(shardCount -> parse(shardCount, System.getProperty(OMITTED_BUCKETS_PROPERTY, "")));
     }
 
-    private static BucketSharding parse(String value) {
+    private static BucketSharding parse(String shardCount, String omittedBuckets) {
         try {
-            return new BucketSharding(Integer.parseInt(value));
+            return new BucketSharding(Integer.parseInt(shardCount), parseOmittedBuckets(omittedBuckets));
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(SHARD_COUNT_PROPERTY + " must be a positive integer, got " + value, e);
+            throw new IllegalArgumentException(SHARD_COUNT_PROPERTY + " must be a positive integer, got " + shardCount, e);
         }
+    }
+
+    private static Set<BucketName> parseOmittedBuckets(String omittedBuckets) {
+        return OMITTED_BUCKETS_SPLITTER.splitToStream(omittedBuckets)
+            .map(BucketName::of)
+            .collect(ImmutableSet.toImmutableSet());
+    }
+
+    public BucketSharding(int shardCount) {
+        this(shardCount, ImmutableSet.of());
     }
 
     public BucketSharding {
         Preconditions.checkArgument(shardCount > 0, "%s must be strictly positive", SHARD_COUNT_PROPERTY);
+        omittedBuckets = ImmutableSet.copyOf(omittedBuckets);
+    }
+
+    /**
+     * @return whether this bucket is left out of the layout, and thus stored under its plain name.
+     */
+    public boolean isOmitted(BucketName logicalBucket) {
+        return omittedBuckets.contains(logicalBucket);
     }
 
     public int shardOf(BlobId blobId) {
@@ -84,6 +112,9 @@ public record BucketSharding(int shardCount) {
     }
 
     public BucketName physicalBucket(BucketName logicalBucket, BlobId blobId) {
+        if (isOmitted(logicalBucket)) {
+            return logicalBucket;
+        }
         return physicalBucket(logicalBucket, shardOf(blobId));
     }
 
@@ -92,18 +123,24 @@ public record BucketSharding(int shardCount) {
     }
 
     public List<BucketName> physicalBuckets(BucketName logicalBucket) {
+        if (isOmitted(logicalBucket)) {
+            return ImmutableList.of(logicalBucket);
+        }
         return IntStream.range(0, shardCount)
             .mapToObj(shard -> physicalBucket(logicalBucket, shard))
             .collect(ImmutableList.toImmutableList());
     }
 
     /**
-     * Reverses {@link #physicalBucket(BucketName, int)}.
+     * Reverses {@link #physicalBuckets(BucketName)}.
      *
      * @return {@link Optional#empty()} for buckets that do not belong to this layout: the underlying object storage
      * may well hold buckets written before sharding was turned on, or by other tools.
      */
     public Optional<BucketName> logicalBucket(BucketName physicalBucket) {
+        if (isOmitted(physicalBucket)) {
+            return Optional.of(physicalBucket);
+        }
         String value = physicalBucket.asString();
         int separatorPosition = value.length() - shardWidth() - 1;
         if (separatorPosition <= 0 || value.charAt(separatorPosition) != SEPARATOR) {

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAO.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAO.java
@@ -28,17 +28,21 @@ import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.ObjectNotFoundException;
 import org.apache.james.blob.api.ObjectStoreIOException;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * Spreads the blobs of a logical bucket over {@link BucketSharding#shardCount()} physical buckets, so that no
- * single Ceph / Rados gateway bucket index grows past the point where an ordered listing stops being affordable.
+ * Spreads the blobs of a logical bucket over {@link TmailBlobStoreShardingConfiguration#shardCount()} physical
+ * buckets, so that no single Ceph / Rados gateway bucket index grows past the point where an ordered listing stops
+ * being affordable.
  *
  * <p>Reads, writes and single deletes are routed to the one bucket owning the blobId. Listings and bucket deletions
  * fan out over every shard.</p>
+ *
+ * @see TmailBlobStoreShardingConfiguration
  */
 public class ShardedBlobStoreDAO implements BlobStoreDAO {
     /**
@@ -49,11 +53,13 @@ public class ShardedBlobStoreDAO implements BlobStoreDAO {
     private static final int DELETION_CONCURRENCY = 8;
 
     private final BlobStoreDAO delegate;
-    private final BucketSharding sharding;
+    private final TmailBlobStoreShardingConfiguration configuration;
 
-    public ShardedBlobStoreDAO(BlobStoreDAO delegate, BucketSharding sharding) {
+    public ShardedBlobStoreDAO(BlobStoreDAO delegate, TmailBlobStoreShardingConfiguration configuration) {
+        Preconditions.checkArgument(configuration.enabled(),
+            "Sharding is disabled, %s should not be wrapped", BlobStoreDAO.class.getSimpleName());
         this.delegate = delegate;
-        this.sharding = sharding;
+        this.configuration = configuration;
     }
 
     @Override
@@ -94,7 +100,7 @@ public class ShardedBlobStoreDAO implements BlobStoreDAO {
 
     @Override
     public Mono<Void> deleteBucket(BucketName bucketName) {
-        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+        return Flux.fromIterable(configuration.physicalBuckets(bucketName))
             .flatMap(delegate::deleteBucket, DELETION_CONCURRENCY)
             .then();
     }
@@ -102,23 +108,23 @@ public class ShardedBlobStoreDAO implements BlobStoreDAO {
     @Override
     public Flux<BucketName> listBuckets() {
         return Flux.from(delegate.listBuckets())
-            .flatMap(physicalBucket -> Mono.justOrEmpty(sharding.logicalBucket(physicalBucket)))
+            .flatMap(physicalBucket -> Mono.justOrEmpty(configuration.logicalBucket(physicalBucket)))
             .distinct();
     }
 
     @Override
     public Flux<BlobId> listBlobs(BucketName bucketName) {
-        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+        return Flux.fromIterable(configuration.physicalBuckets(bucketName))
             .flatMap(delegate::listBlobs, LISTING_CONCURRENCY);
     }
 
     @Override
     public Flux<BlobId> listBlobs(BucketName bucketName, String prefix) {
-        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+        return Flux.fromIterable(configuration.physicalBuckets(bucketName))
             .flatMap(physicalBucket -> delegate.listBlobs(physicalBucket, prefix), LISTING_CONCURRENCY);
     }
 
     private BucketName shard(BucketName bucketName, BlobId blobId) {
-        return sharding.physicalBucket(bucketName, blobId);
+        return configuration.physicalBucket(bucketName, blobId);
     }
 }

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAO.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAO.java
@@ -1,0 +1,124 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.sharding;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.ObjectStoreIOException;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Spreads the blobs of a logical bucket over {@link BucketSharding#shardCount()} physical buckets, so that no
+ * single Ceph / Rados gateway bucket index grows past the point where an ordered listing stops being affordable.
+ *
+ * <p>Reads, writes and single deletes are routed to the one bucket owning the blobId. Listings and bucket deletions
+ * fan out over every shard.</p>
+ */
+public class ShardedBlobStoreDAO implements BlobStoreDAO {
+    /**
+     * Listing a shard already pages through a whole bucket index: fanning out aggressively would multiply the
+     * pressure put on the Rados gateway by as many shards.
+     */
+    private static final int LISTING_CONCURRENCY = 2;
+    private static final int DELETION_CONCURRENCY = 8;
+
+    private final BlobStoreDAO delegate;
+    private final BucketSharding sharding;
+
+    public ShardedBlobStoreDAO(BlobStoreDAO delegate, BucketSharding sharding) {
+        this.delegate = delegate;
+        this.sharding = sharding;
+    }
+
+    @Override
+    public InputStreamBlob read(BucketName bucketName, BlobId blobId) throws ObjectStoreIOException, ObjectNotFoundException {
+        return delegate.read(shard(bucketName, blobId), blobId);
+    }
+
+    @Override
+    public Mono<InputStreamBlob> readReactive(BucketName bucketName, BlobId blobId) {
+        return Mono.from(delegate.readReactive(shard(bucketName, blobId), blobId));
+    }
+
+    @Override
+    public Mono<BytesBlob> readBytes(BucketName bucketName, BlobId blobId) {
+        return Mono.from(delegate.readBytes(shard(bucketName, blobId), blobId));
+    }
+
+    @Override
+    public Mono<Void> save(BucketName bucketName, BlobId blobId, Blob blob) {
+        return Mono.from(delegate.save(shard(bucketName, blobId), blobId, blob));
+    }
+
+    @Override
+    public Mono<Void> delete(BucketName bucketName, BlobId blobId) {
+        return Mono.from(delegate.delete(shard(bucketName, blobId), blobId));
+    }
+
+    @Override
+    public Mono<Void> delete(BucketName bucketName, Collection<BlobId> blobIds) {
+        Map<BucketName, ImmutableList<BlobId>> perShard = blobIds.stream()
+            .collect(Collectors.groupingBy(blobId -> shard(bucketName, blobId),
+                ImmutableList.toImmutableList()));
+
+        return Flux.fromIterable(perShard.entrySet())
+            .flatMap(entry -> delegate.delete(entry.getKey(), entry.getValue()), DELETION_CONCURRENCY)
+            .then();
+    }
+
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+            .flatMap(delegate::deleteBucket, DELETION_CONCURRENCY)
+            .then();
+    }
+
+    @Override
+    public Flux<BucketName> listBuckets() {
+        return Flux.from(delegate.listBuckets())
+            .flatMap(physicalBucket -> Mono.justOrEmpty(sharding.logicalBucket(physicalBucket)))
+            .distinct();
+    }
+
+    @Override
+    public Flux<BlobId> listBlobs(BucketName bucketName) {
+        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+            .flatMap(delegate::listBlobs, LISTING_CONCURRENCY);
+    }
+
+    @Override
+    public Flux<BlobId> listBlobs(BucketName bucketName, String prefix) {
+        return Flux.fromIterable(sharding.physicalBuckets(bucketName))
+            .flatMap(physicalBucket -> delegate.listBlobs(physicalBucket, prefix), LISTING_CONCURRENCY);
+    }
+
+    private BucketName shard(BucketName bucketName, BlobId blobId) {
+        return sharding.physicalBucket(bucketName, blobId);
+    }
+}

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfiguration.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfiguration.java
@@ -132,6 +132,25 @@ public record TmailBlobStoreShardingConfiguration(int shardCount, Set<BucketName
     }
 
     /**
+     * Adapts omitted bucket names to a delegate receiving suffixed logical bucket names.
+     *
+     * <p>The secondary blob store appends its suffix before invoking its delegate, while omitted buckets are
+     * configured using their original logical names. Without applying the same suffix here, an omitted bucket such
+     * as {@code jmap-uploads} would be received as {@code jmap-uploads-copy}, fail the omission check, and be
+     * unexpectedly sharded on the secondary store.</p>
+     */
+    public TmailBlobStoreShardingConfiguration forBucketSuffix(String bucketSuffix) {
+        Preconditions.checkNotNull(bucketSuffix, "bucketSuffix");
+        if (bucketSuffix.isEmpty()) {
+            return this;
+        }
+        return new TmailBlobStoreShardingConfiguration(shardCount,
+            omittedBuckets.stream()
+                .map(bucket -> BucketName.of(bucket.asString() + bucketSuffix))
+                .collect(ImmutableSet.toImmutableSet()));
+    }
+
+    /**
      * @return whether this bucket is left out of the layout, and thus stored under its plain name.
      */
     public boolean isOmitted(BucketName logicalBucket) {
@@ -139,22 +158,31 @@ public record TmailBlobStoreShardingConfiguration(int shardCount, Set<BucketName
     }
 
     public int shardOf(BlobId blobId) {
+        Preconditions.checkState(enabled(), "Cannot compute a shard when sharding is disabled");
         return Math.floorMod(HASH_FUNCTION.hashString(blobId.asString(), StandardCharsets.UTF_8).asInt(), shardCount);
     }
 
     public BucketName physicalBucket(BucketName logicalBucket, BlobId blobId) {
-        if (isOmitted(logicalBucket)) {
+        if (!enabled() || isOmitted(logicalBucket)) {
             return logicalBucket;
         }
         return physicalBucket(logicalBucket, shardOf(blobId));
     }
 
     public BucketName physicalBucket(BucketName logicalBucket, int shard) {
+        if (!enabled()) {
+            return logicalBucket;
+        }
+        Preconditions.checkArgument(shard >= 0 && shard < shardCount,
+            "Shard must be between 0 and %s, got %s", shardCount - 1, shard);
+        if (isOmitted(logicalBucket)) {
+            return logicalBucket;
+        }
         return BucketName.of(logicalBucket.asString() + SEPARATOR + format(shard));
     }
 
     public List<BucketName> physicalBuckets(BucketName logicalBucket) {
-        if (isOmitted(logicalBucket)) {
+        if (!enabled() || isOmitted(logicalBucket)) {
             return ImmutableList.of(logicalBucket);
         }
         return IntStream.range(0, shardCount)
@@ -169,7 +197,7 @@ public record TmailBlobStoreShardingConfiguration(int shardCount, Set<BucketName
      * may well hold buckets written before sharding was turned on, or by other tools.
      */
     public Optional<BucketName> logicalBucket(BucketName physicalBucket) {
-        if (isOmitted(physicalBucket)) {
+        if (!enabled() || isOmitted(physicalBucket)) {
             return Optional.of(physicalBucket);
         }
         String value = physicalBucket.asString();

--- a/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfiguration.java
+++ b/tmail-backend/blob/sharded-blob-store/src/main/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfiguration.java
@@ -23,20 +23,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import org.apache.commons.configuration2.Configuration;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BucketName;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
 /**
- * Maps a James logical {@link BucketName} onto a fixed set of physical buckets, the shard being derived from the
- * {@link BlobId}.
+ * How a James logical {@link BucketName} is spread over a fixed set of physical buckets, the shard being derived from
+ * the {@link BlobId}.
  *
  * <p>S3 compatibility is an API contract, not a behaviour contract: a Ceph / Rados gateway bucket is backed by
  * sharded omap indexes that should not hold much more than 100K entries each. Holding billions of objects in a
@@ -45,19 +46,33 @@ import com.google.common.hash.Hashing;
  * bucket index within a listable size.</p>
  *
  * <p>Physical buckets are named {@code <logical bucket>-<zero padded shard number>}, eg. {@code default-000} up to
- * {@code default-255} for 256 shards. <strong>The shard count is written in stone</strong>: changing it relocates
- * every blob and makes the already written ones unreadable. Because blobIds are content addressed, deduplication
- * and garbage collection still hold within a shard.</p>
+ * {@code default-255} for 256 shards. Because blobIds are content addressed, deduplication and garbage collection
+ * still hold within a shard.</p>
  *
- * <p>Buckets that stay small enough to be listed as they are - the JMAP uploads and the mails in transit, say - can
- * be left out of the layout entirely, and are then stored under their plain name.</p>
+ * <p>Read from <code>blob.properties</code>:</p>
+ *
+ * <pre>
+ * tmail.blobstore.shards=256
+ * tmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing
+ * </pre>
+ *
+ * <p><strong>Both are written in stone</strong>: changing the shard count, or moving a bucket in or out of the
+ * omitted list, relocates blobs onto another bucket and makes the already written ones unreachable.</p>
+ *
+ * @param shardCount        how many physical buckets a logical bucket is spread over, {@link #NO_SHARDING} to store
+ *                          every bucket under its plain name
+ * @param omittedBuckets    logical buckets left out of the layout, small enough to be listed as they are, and thus
+ *                          stored under their plain name
  */
-public record BucketSharding(int shardCount, Set<BucketName> omittedBuckets) {
-    public static final String SHARD_COUNT_PROPERTY = "tmail.blobstore.shards";
-    public static final String OMITTED_BUCKETS_PROPERTY = "tmail.blobstore.shards.ommited.buckets";
-    public static final char SEPARATOR = '-';
+public record TmailBlobStoreShardingConfiguration(int shardCount, Set<BucketName> omittedBuckets) {
+    public static final int NO_SHARDING = 0;
+    public static final TmailBlobStoreShardingConfiguration DISABLED =
+        new TmailBlobStoreShardingConfiguration(NO_SHARDING, ImmutableSet.of());
 
-    private static final Splitter OMITTED_BUCKETS_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    static final String SHARD_COUNT_PROPERTY = "tmail.blobstore.shards";
+    static final String OMITTED_BUCKETS_PROPERTY = "tmail.blobstore.shards.ommited.buckets";
+
+    public static final char SEPARATOR = '-';
 
     /**
      * Murmur3 is stable across JVMs and Guava releases, which {@link String#hashCode()} guarantees too but with a
@@ -65,39 +80,55 @@ public record BucketSharding(int shardCount, Set<BucketName> omittedBuckets) {
      */
     private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32_fixed();
 
-    /**
-     * @return the sharding configured by {@code -Dtmail.blobstore.shards=256} and
-     * {@code -Dtmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing}, or {@link Optional#empty()} when
-     * the shard count property is omitted, in which case no sharding is applied at all.
-     */
-    public static Optional<BucketSharding> fromSystemProperties() {
-        return Optional.ofNullable(System.getProperty(SHARD_COUNT_PROPERTY))
+    public static TmailBlobStoreShardingConfiguration from(Configuration configuration) {
+        int shardCount = Optional.ofNullable(configuration.getString(SHARD_COUNT_PROPERTY, null))
             .map(String::trim)
             .filter(value -> !value.isEmpty())
-            .map(shardCount -> parse(shardCount, System.getProperty(OMITTED_BUCKETS_PROPERTY, "")));
+            .map(TmailBlobStoreShardingConfiguration::parseShardCount)
+            .orElse(NO_SHARDING);
+
+        if (shardCount == NO_SHARDING) {
+            return DISABLED;
+        }
+        return new TmailBlobStoreShardingConfiguration(shardCount,
+            omittedBuckets(configuration.getStringArray(OMITTED_BUCKETS_PROPERTY)));
     }
 
-    private static BucketSharding parse(String shardCount, String omittedBuckets) {
+    private static int parseShardCount(String shardCount) {
         try {
-            return new BucketSharding(Integer.parseInt(shardCount), parseOmittedBuckets(omittedBuckets));
+            return Integer.parseInt(shardCount);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(SHARD_COUNT_PROPERTY + " must be a positive integer, got " + shardCount, e);
         }
     }
 
-    private static Set<BucketName> parseOmittedBuckets(String omittedBuckets) {
-        return OMITTED_BUCKETS_SPLITTER.splitToStream(omittedBuckets)
+    /**
+     * James reads {@code blob.properties} with a comma list delimiter, so the property already reaches us split.
+     * Values are trimmed nonetheless, blank ones dropped, so that {@code a, b} and {@code a,b,} both work.
+     */
+    private static Set<BucketName> omittedBuckets(String... omittedBuckets) {
+        return Stream.of(omittedBuckets)
+            .map(String::trim)
+            .filter(bucketName -> !bucketName.isEmpty())
             .map(BucketName::of)
             .collect(ImmutableSet.toImmutableSet());
     }
 
-    public BucketSharding(int shardCount) {
-        this(shardCount, ImmutableSet.of());
+    public static TmailBlobStoreShardingConfiguration of(int shardCount) {
+        return new TmailBlobStoreShardingConfiguration(shardCount, ImmutableSet.of());
     }
 
-    public BucketSharding {
-        Preconditions.checkArgument(shardCount > 0, "%s must be strictly positive", SHARD_COUNT_PROPERTY);
+    public static TmailBlobStoreShardingConfiguration of(int shardCount, BucketName... omittedBuckets) {
+        return new TmailBlobStoreShardingConfiguration(shardCount, ImmutableSet.copyOf(omittedBuckets));
+    }
+
+    public TmailBlobStoreShardingConfiguration {
+        Preconditions.checkArgument(shardCount >= NO_SHARDING, "%s cannot be negative", SHARD_COUNT_PROPERTY);
         omittedBuckets = ImmutableSet.copyOf(omittedBuckets);
+    }
+
+    public boolean enabled() {
+        return shardCount > NO_SHARDING;
     }
 
     /**

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/BucketShardingTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/BucketShardingTest.java
@@ -1,0 +1,141 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.sharding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.TestBlobId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class BucketShardingTest {
+    private static final BucketName BUCKET = BucketName.of("blobs");
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(BucketSharding.SHARD_COUNT_PROPERTY);
+    }
+
+    @Test
+    void physicalBucketShouldZeroPadTheShardNumber() {
+        BucketSharding sharding = new BucketSharding(256);
+
+        assertThat(sharding.physicalBuckets(BUCKET))
+            .startsWith(BucketName.of("blobs-000"), BucketName.of("blobs-001"))
+            .endsWith(BucketName.of("blobs-255"))
+            .hasSize(256);
+    }
+
+    @Test
+    void physicalBucketShouldNotPadBeyondTheShardCountWidth() {
+        BucketSharding sharding = new BucketSharding(10);
+
+        assertThat(sharding.physicalBuckets(BUCKET))
+            .containsExactly(BucketName.of("blobs-0"), BucketName.of("blobs-1"), BucketName.of("blobs-2"),
+                BucketName.of("blobs-3"), BucketName.of("blobs-4"), BucketName.of("blobs-5"),
+                BucketName.of("blobs-6"), BucketName.of("blobs-7"), BucketName.of("blobs-8"),
+                BucketName.of("blobs-9"));
+    }
+
+    @Test
+    void logicalBucketShouldReverPhysicalBucket() {
+        BucketSharding sharding = new BucketSharding(256);
+
+        assertThat(sharding.physicalBuckets(BUCKET)
+            .stream()
+            .map(sharding::logicalBucket)
+            .distinct())
+            .containsExactly(Optional.of(BUCKET));
+    }
+
+    @Test
+    void logicalBucketShouldRejectBucketsOutOfTheLayout() {
+        BucketSharding sharding = new BucketSharding(256);
+
+        assertThat(sharding.logicalBucket(BucketName.of("blobs"))).isEmpty();
+        assertThat(sharding.logicalBucket(BucketName.of("blobs-1"))).isEmpty();
+        assertThat(sharding.logicalBucket(BucketName.of("blobs-abc"))).isEmpty();
+        assertThat(sharding.logicalBucket(BucketName.of("blobs-999"))).isEmpty();
+        assertThat(sharding.logicalBucket(BucketName.of("-000"))).isEmpty();
+    }
+
+    @Test
+    void shardOfShouldBeStableAcrossCalls() {
+        BucketSharding sharding = new BucketSharding(256);
+        TestBlobId blobId = new TestBlobId("2b8b46e9-1a1e-4a4a-bb0a-3f4a3f37a1e0");
+
+        assertThat(sharding.shardOf(blobId)).isEqualTo(sharding.shardOf(blobId));
+    }
+
+    @Test
+    void shardOfShouldSpreadBlobIdsEvenly() {
+        int shardCount = 256;
+        int blobCount = 256 * 400;
+        BucketSharding sharding = new BucketSharding(shardCount);
+
+        Map<Integer, Long> perShard = IntStream.range(0, blobCount)
+            .mapToObj(i -> new TestBlobId("d6f0c1a5b2e34" + i))
+            .collect(Collectors.groupingBy(sharding::shardOf, Collectors.counting()));
+
+        assertThat(perShard).hasSize(shardCount);
+        assertThat(perShard.values()).allSatisfy(count -> assertThat(count).isBetween(300L, 500L));
+    }
+
+    @Test
+    void shardCountShouldBeStrictlyPositive() {
+        assertThatThrownBy(() -> new BucketSharding(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new BucketSharding(-1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatCode(() -> new BucketSharding(1)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void fromSystemPropertiesShouldBeEmptyWhenPropertyIsOmitted() {
+        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    }
+
+    @Test
+    void fromSystemPropertiesShouldBeEmptyWhenPropertyIsBlank() {
+        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "  ");
+
+        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    }
+
+    @Test
+    void fromSystemPropertiesShouldReadTheShardCount() {
+        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
+
+        assertThat(BucketSharding.fromSystemProperties()).contains(new BucketSharding(256));
+    }
+
+    @Test
+    void fromSystemPropertiesShouldThrowOnInvalidShardCount() {
+        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "invalid");
+
+        assertThatThrownBy(BucketSharding::fromSystemProperties)
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/BucketShardingTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/BucketShardingTest.java
@@ -22,8 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -32,12 +34,22 @@ import org.apache.james.blob.api.TestBlobId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 class BucketShardingTest {
     private static final BucketName BUCKET = BucketName.of("blobs");
+
+    /** The four logical buckets a distributed Twake Mail deployment writes to. */
+    private static final BucketName UPLOADS_BUCKET = BucketName.of("jmap-uploads");
+    private static final BucketName VAULT_BUCKET = BucketName.of("tmail-deleted-message-vault");
+    private static final BucketName MAIL_PROCESSING_BUCKET = BucketName.of("mail-processing");
+    private static final Set<BucketName> TMAIL_BUCKETS =
+        ImmutableSet.of(BUCKET, UPLOADS_BUCKET, VAULT_BUCKET, MAIL_PROCESSING_BUCKET);
 
     @AfterEach
     void tearDown() {
         System.clearProperty(BucketSharding.SHARD_COUNT_PROPERTY);
+        System.clearProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY);
     }
 
     @Test
@@ -129,6 +141,105 @@ class BucketShardingTest {
         System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
 
         assertThat(BucketSharding.fromSystemProperties()).contains(new BucketSharding(256));
+    }
+
+    @Test
+    void omittedBucketShouldNotBeSharded() {
+        BucketSharding sharding = new BucketSharding(256, ImmutableSet.of(BUCKET));
+
+        assertThat(sharding.physicalBuckets(BUCKET)).containsExactly(BUCKET);
+        assertThat(sharding.physicalBucket(BUCKET, new TestBlobId("blob-1"))).isEqualTo(BUCKET);
+    }
+
+    @Test
+    void omittedBucketShouldBeItsOwnLogicalBucket() {
+        BucketSharding sharding = new BucketSharding(256, ImmutableSet.of(BUCKET));
+
+        assertThat(sharding.logicalBucket(BUCKET)).contains(BUCKET);
+    }
+
+    @Test
+    void omittingABucketShouldNotAffectTheOthers() {
+        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(BucketName.of("jmap-uploads")));
+
+        assertThat(sharding.physicalBuckets(BUCKET))
+            .containsExactly(BucketName.of("blobs-0"), BucketName.of("blobs-1"),
+                BucketName.of("blobs-2"), BucketName.of("blobs-3"));
+    }
+
+    @Test
+    void fromSystemPropertiesShouldDefaultToNoOmittedBucket() {
+        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
+
+        assertThat(BucketSharding.fromSystemProperties()).contains(new BucketSharding(256, ImmutableSet.of()));
+    }
+
+    @Test
+    void fromSystemPropertiesShouldReadOmittedBuckets() {
+        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
+        System.setProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY, "jmap-uploads, mail-processing");
+
+        assertThat(BucketSharding.fromSystemProperties())
+            .contains(new BucketSharding(256, ImmutableSet.of(
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing"))));
+    }
+
+    @Test
+    void fromSystemPropertiesShouldIgnoreOmittedBucketsWhenShardingIsOff() {
+        System.setProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY, "jmap-uploads");
+
+        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    }
+
+    /**
+     * Worked example over the four logical buckets of a Twake Mail deployment, sharded four ways, with the two
+     * buckets that stay small enough to be listed as they are left out.
+     *
+     * <p>The object storage connector then resolves those into actual bucket names, which for S3 also means
+     * prepending {@code objectstorage.bucketPrefix} - see {@code DistributedBlobStoreBucketShardingTest} in the
+     * distributed app for the end to end picture.</p>
+     */
+    @Test
+    void fourShardsOverTmailBucketsShouldYieldTheDocumentedLayout() {
+        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET));
+
+        assertThat(TMAIL_BUCKETS.stream()
+            .collect(Collectors.toMap(BucketName::asString, sharding::physicalBuckets)))
+            .containsExactlyInAnyOrderEntriesOf(Map.of(
+                "blobs", List.of(BucketName.of("blobs-0"), BucketName.of("blobs-1"),
+                    BucketName.of("blobs-2"), BucketName.of("blobs-3")),
+                "tmail-deleted-message-vault", List.of(BucketName.of("tmail-deleted-message-vault-0"),
+                    BucketName.of("tmail-deleted-message-vault-1"), BucketName.of("tmail-deleted-message-vault-2"),
+                    BucketName.of("tmail-deleted-message-vault-3")),
+                "jmap-uploads", List.of(UPLOADS_BUCKET),
+                "mail-processing", List.of(MAIL_PROCESSING_BUCKET)));
+    }
+
+    @Test
+    void everyTmailBucketShouldBeReadBackFromItsShards() {
+        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET));
+
+        assertThat(TMAIL_BUCKETS.stream()
+            .flatMap(logicalBucket -> sharding.physicalBuckets(logicalBucket).stream())
+            .map(sharding::logicalBucket)
+            .flatMap(Optional::stream)
+            .collect(ImmutableSet.toImmutableSet()))
+            .containsExactlyInAnyOrderElementsOf(TMAIL_BUCKETS);
+    }
+
+    /**
+     * Guards the sample size used by {@code DistributedBlobStoreBucketShardingTest}: sixteen blobs are enough for
+     * every one of the four shards of every one of those buckets to be actually created.
+     */
+    @Test
+    void sixteenBlobsShouldReachEveryShardOfEveryTmailBucket() {
+        BucketSharding sharding = new BucketSharding(4);
+
+        TMAIL_BUCKETS.forEach(logicalBucket -> assertThat(IntStream.range(0, 16)
+            .mapToObj(i -> new TestBlobId(logicalBucket.asString() + "-blob-" + i))
+            .map(blobId -> sharding.physicalBucket(logicalBucket, blobId))
+            .collect(ImmutableSet.toImmutableSet()))
+            .containsExactlyInAnyOrderElementsOf(sharding.physicalBuckets(logicalBucket)));
     }
 
     @Test

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
@@ -163,6 +163,31 @@ class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlob
     }
 
     @Test
+    void secondaryOmittedBucketShouldSupportListingAndBulkDeletion() {
+        // SecondaryBlobStoreDAO appends "-copy" before delegating. Adapt omissions as production wiring does.
+        BucketName secondaryBucket = BucketName.of(TEST_BUCKET_NAME.asString() + "-copy");
+        ShardedBlobStoreDAO secondary = new ShardedBlobStoreDAO(delegate,
+            TmailBlobStoreShardingConfiguration.of(SHARDING.shardCount(), TEST_BUCKET_NAME)
+                .forBucketSuffix("-copy"));
+        List<BlobId> blobIds = someBlobIds(100);
+        blobIds.forEach(blobId -> Mono.from(secondary.save(secondaryBucket, blobId, SHORT_BYTEARRAY)).block());
+
+        // An omitted secondary bucket stays as one physical bucket while exposing all its blobs.
+        assertThat(Flux.from(secondary.listBlobs(secondaryBucket)).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(blobIds);
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .containsExactly(secondaryBucket);
+
+        // GC bulk-deletes listed IDs, so listing and deletion must resolve to the same physical bucket.
+        Mono.from(secondary.delete(secondaryBucket, blobIds)).block();
+
+        assertThat(Flux.from(secondary.listBlobs(secondaryBucket)).collectList().block())
+            .isEmpty();
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
     void listBucketsShouldIgnoreBucketsNotBelongingToTheShardingLayout() {
         BlobId blobId = new TestBlobId("blob-1");
         Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block();

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
@@ -38,13 +38,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlobStoreDAOContract {
-    private static final BucketSharding SHARDING = new BucketSharding(8);
+    private static final TmailBlobStoreShardingConfiguration SHARDING = TmailBlobStoreShardingConfiguration.of(8);
 
     private MemoryBlobStoreDAO delegate;
     private ShardedBlobStoreDAO testee;
@@ -130,7 +129,7 @@ class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlob
     @Test
     void omittedBucketShouldBeStoredUnderItsPlainName() {
         ShardedBlobStoreDAO omittingTestBucket = new ShardedBlobStoreDAO(delegate,
-            new BucketSharding(SHARDING.shardCount(), ImmutableSet.of(TEST_BUCKET_NAME)));
+            TmailBlobStoreShardingConfiguration.of(SHARDING.shardCount(), TEST_BUCKET_NAME));
         List<BlobId> blobIds = someBlobIds(100);
 
         blobIds.forEach(blobId -> Mono.from(omittingTestBucket.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
@@ -146,7 +145,7 @@ class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlob
     @Test
     void omittedBucketShouldNotAffectTheShardedOnes() {
         ShardedBlobStoreDAO omittingCustomBucket = new ShardedBlobStoreDAO(delegate,
-            new BucketSharding(SHARDING.shardCount(), ImmutableSet.of(CUSTOM_BUCKET_NAME)));
+            TmailBlobStoreShardingConfiguration.of(SHARDING.shardCount(), CUSTOM_BUCKET_NAME));
         List<BlobId> blobIds = someBlobIds(100);
 
         blobIds.forEach(blobId -> {

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
@@ -18,6 +18,7 @@
 
 package com.linagora.tmail.blob.sharding;
 
+import static org.apache.james.blob.api.BlobStoreDAOFixture.CUSTOM_BUCKET_NAME;
 import static org.apache.james.blob.api.BlobStoreDAOFixture.SHORT_BYTEARRAY;
 import static org.apache.james.blob.api.BlobStoreDAOFixture.TEST_BUCKET_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -123,6 +125,42 @@ class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlob
 
         assertThat(Flux.from(testee.listBlobs(TEST_BUCKET_NAME)).collectList().block())
             .isEmpty();
+    }
+
+    @Test
+    void omittedBucketShouldBeStoredUnderItsPlainName() {
+        ShardedBlobStoreDAO omittingTestBucket = new ShardedBlobStoreDAO(delegate,
+            new BucketSharding(SHARDING.shardCount(), ImmutableSet.of(TEST_BUCKET_NAME)));
+        List<BlobId> blobIds = someBlobIds(100);
+
+        blobIds.forEach(blobId -> Mono.from(omittingTestBucket.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .containsExactly(TEST_BUCKET_NAME);
+        assertThat(Flux.from(omittingTestBucket.listBlobs(TEST_BUCKET_NAME)).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(blobIds);
+        assertThat(Flux.from(omittingTestBucket.listBuckets()).collectList().block())
+            .containsExactly(TEST_BUCKET_NAME);
+    }
+
+    @Test
+    void omittedBucketShouldNotAffectTheShardedOnes() {
+        ShardedBlobStoreDAO omittingCustomBucket = new ShardedBlobStoreDAO(delegate,
+            new BucketSharding(SHARDING.shardCount(), ImmutableSet.of(CUSTOM_BUCKET_NAME)));
+        List<BlobId> blobIds = someBlobIds(100);
+
+        blobIds.forEach(blobId -> {
+            Mono.from(omittingCustomBucket.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block();
+            Mono.from(omittingCustomBucket.save(CUSTOM_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block();
+        });
+
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(ImmutableList.<BucketName>builder()
+                .addAll(SHARDING.physicalBuckets(TEST_BUCKET_NAME))
+                .add(CUSTOM_BUCKET_NAME)
+                .build());
+        assertThat(Flux.from(omittingCustomBucket.listBuckets()).collectList().block())
+            .containsExactlyInAnyOrder(TEST_BUCKET_NAME, CUSTOM_BUCKET_NAME);
     }
 
     @Test

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/ShardedBlobStoreDAOTest.java
@@ -1,0 +1,143 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.sharding;
+
+import static org.apache.james.blob.api.BlobStoreDAOFixture.SHORT_BYTEARRAY;
+import static org.apache.james.blob.api.BlobStoreDAOFixture.TEST_BUCKET_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStoreDAO;
+import org.apache.james.blob.api.BlobStoreDAOContract;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.MetadataAwareBlobStoreDAOContract;
+import org.apache.james.blob.api.TestBlobId;
+import org.apache.james.blob.memory.MemoryBlobStoreDAO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class ShardedBlobStoreDAOTest implements BlobStoreDAOContract, MetadataAwareBlobStoreDAOContract {
+    private static final BucketSharding SHARDING = new BucketSharding(8);
+
+    private MemoryBlobStoreDAO delegate;
+    private ShardedBlobStoreDAO testee;
+
+    @BeforeEach
+    void setUp() {
+        delegate = new MemoryBlobStoreDAO();
+        testee = new ShardedBlobStoreDAO(delegate, SHARDING);
+    }
+
+    @Override
+    public BlobStoreDAO testee() {
+        return testee;
+    }
+
+    @Override
+    @Disabled("Not supported by the underlying memory blob store")
+    public void listBucketsShouldReturnBucketsWithNoBlob() {
+
+    }
+
+    @Test
+    void saveShouldWriteToTheShardOwningTheBlobId() {
+        BlobId blobId = new TestBlobId("blob-1");
+
+        Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block();
+
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .containsExactly(SHARDING.physicalBucket(TEST_BUCKET_NAME, blobId));
+    }
+
+    @Test
+    void severalBlobsShouldLandInSeveralPhysicalBuckets() {
+        List<BlobId> blobIds = someBlobIds(100);
+        blobIds.forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(SHARDING.physicalBuckets(TEST_BUCKET_NAME));
+    }
+
+    @Test
+    void listBlobsShouldMergeEveryShard() {
+        List<BlobId> blobIds = someBlobIds(100);
+        blobIds.forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        assertThat(Flux.from(testee.listBlobs(TEST_BUCKET_NAME)).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(blobIds);
+    }
+
+    @Test
+    void listBlobsWithPrefixShouldMergeEveryShard() {
+        List<BlobId> recoveryBlobIds = IntStream.range(0, 100)
+            .mapToObj(i -> (BlobId) new TestBlobId(BlobStoreDAO.RECOVERY_BLOB_PREFIX + i))
+            .collect(ImmutableList.toImmutableList());
+        recoveryBlobIds.forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+        someBlobIds(100).forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        assertThat(Flux.from(testee.listBlobs(TEST_BUCKET_NAME, BlobStoreDAO.RECOVERY_BLOB_PREFIX)).collectList().block())
+            .containsExactlyInAnyOrderElementsOf(recoveryBlobIds);
+    }
+
+    @Test
+    void deleteBucketShouldDeleteEveryShard() {
+        someBlobIds(100).forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        Mono.from(testee.deleteBucket(TEST_BUCKET_NAME)).block();
+
+        assertThat(Flux.from(delegate.listBuckets()).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void deleteSeveralBlobsShouldSpanOverShards() {
+        List<BlobId> blobIds = someBlobIds(100);
+        blobIds.forEach(blobId -> Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block());
+
+        Mono.from(testee.delete(TEST_BUCKET_NAME, blobIds)).block();
+
+        assertThat(Flux.from(testee.listBlobs(TEST_BUCKET_NAME)).collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void listBucketsShouldIgnoreBucketsNotBelongingToTheShardingLayout() {
+        BlobId blobId = new TestBlobId("blob-1");
+        Mono.from(testee.save(TEST_BUCKET_NAME, blobId, SHORT_BYTEARRAY)).block();
+        Mono.from(delegate.save(BucketName.of("legacy-unsharded"), blobId, SHORT_BYTEARRAY)).block();
+
+        assertThat(Flux.from(testee.listBuckets()).collectList().block())
+            .containsExactly(TEST_BUCKET_NAME);
+    }
+
+    private List<BlobId> someBlobIds(int count) {
+        return IntStream.range(0, count)
+            .mapToObj(i -> (BlobId) new TestBlobId("blob-" + i))
+            .collect(ImmutableList.toImmutableList());
+    }
+}

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfigurationTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfigurationTest.java
@@ -19,9 +19,9 @@
 package com.linagora.tmail.blob.sharding;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,14 +29,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.TestBlobId;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-class BucketShardingTest {
+class TmailBlobStoreShardingConfigurationTest {
     private static final BucketName BUCKET = BucketName.of("blobs");
 
     /** The four logical buckets a distributed Twake Mail deployment writes to. */
@@ -46,15 +48,17 @@ class BucketShardingTest {
     private static final Set<BucketName> TMAIL_BUCKETS =
         ImmutableSet.of(BUCKET, UPLOADS_BUCKET, VAULT_BUCKET, MAIL_PROCESSING_BUCKET);
 
-    @AfterEach
-    void tearDown() {
-        System.clearProperty(BucketSharding.SHARD_COUNT_PROPERTY);
-        System.clearProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY);
+    /** Built the way James' {@code PropertiesProvider} does, comma list delimiter included. */
+    private static Configuration blobProperties(String... lines) throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.setListDelimiterHandler(new DefaultListDelimiterHandler(','));
+        configuration.read(new StringReader(String.join("\n", lines)));
+        return configuration;
     }
 
     @Test
     void physicalBucketShouldZeroPadTheShardNumber() {
-        BucketSharding sharding = new BucketSharding(256);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256);
 
         assertThat(sharding.physicalBuckets(BUCKET))
             .startsWith(BucketName.of("blobs-000"), BucketName.of("blobs-001"))
@@ -64,7 +68,7 @@ class BucketShardingTest {
 
     @Test
     void physicalBucketShouldNotPadBeyondTheShardCountWidth() {
-        BucketSharding sharding = new BucketSharding(10);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(10);
 
         assertThat(sharding.physicalBuckets(BUCKET))
             .containsExactly(BucketName.of("blobs-0"), BucketName.of("blobs-1"), BucketName.of("blobs-2"),
@@ -75,7 +79,7 @@ class BucketShardingTest {
 
     @Test
     void logicalBucketShouldReverPhysicalBucket() {
-        BucketSharding sharding = new BucketSharding(256);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256);
 
         assertThat(sharding.physicalBuckets(BUCKET)
             .stream()
@@ -86,7 +90,7 @@ class BucketShardingTest {
 
     @Test
     void logicalBucketShouldRejectBucketsOutOfTheLayout() {
-        BucketSharding sharding = new BucketSharding(256);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256);
 
         assertThat(sharding.logicalBucket(BucketName.of("blobs"))).isEmpty();
         assertThat(sharding.logicalBucket(BucketName.of("blobs-1"))).isEmpty();
@@ -97,7 +101,7 @@ class BucketShardingTest {
 
     @Test
     void shardOfShouldBeStableAcrossCalls() {
-        BucketSharding sharding = new BucketSharding(256);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256);
         TestBlobId blobId = new TestBlobId("2b8b46e9-1a1e-4a4a-bb0a-3f4a3f37a1e0");
 
         assertThat(sharding.shardOf(blobId)).isEqualTo(sharding.shardOf(blobId));
@@ -107,7 +111,7 @@ class BucketShardingTest {
     void shardOfShouldSpreadBlobIdsEvenly() {
         int shardCount = 256;
         int blobCount = 256 * 400;
-        BucketSharding sharding = new BucketSharding(shardCount);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(shardCount);
 
         Map<Integer, Long> perShard = IntStream.range(0, blobCount)
             .mapToObj(i -> new TestBlobId("d6f0c1a5b2e34" + i))
@@ -117,35 +121,34 @@ class BucketShardingTest {
         assertThat(perShard.values()).allSatisfy(count -> assertThat(count).isBetween(300L, 500L));
     }
 
+
     @Test
-    void shardCountShouldBeStrictlyPositive() {
-        assertThatThrownBy(() -> new BucketSharding(0)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new BucketSharding(-1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatCode(() -> new BucketSharding(1)).doesNotThrowAnyException();
+    void fromShouldBeDisabledWhenPropertyIsOmitted() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("implementation=s3")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
     }
 
     @Test
-    void fromSystemPropertiesShouldBeEmptyWhenPropertyIsOmitted() {
-        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    void fromShouldBeDisabledWhenPropertyIsBlank() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("tmail.blobstore.shards=")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
     }
 
     @Test
-    void fromSystemPropertiesShouldBeEmptyWhenPropertyIsBlank() {
-        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "  ");
-
-        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    void disabledShouldNotBeEnabled() {
+        assertThat(TmailBlobStoreShardingConfiguration.DISABLED.enabled()).isFalse();
     }
 
     @Test
-    void fromSystemPropertiesShouldReadTheShardCount() {
-        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
-
-        assertThat(BucketSharding.fromSystemProperties()).contains(new BucketSharding(256));
+    void fromShouldReadTheShardCount() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("tmail.blobstore.shards=256")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256));
+        assertThat(TmailBlobStoreShardingConfiguration.of(256).enabled()).isTrue();
     }
 
     @Test
     void omittedBucketShouldNotBeSharded() {
-        BucketSharding sharding = new BucketSharding(256, ImmutableSet.of(BUCKET));
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256, BUCKET);
 
         assertThat(sharding.physicalBuckets(BUCKET)).containsExactly(BUCKET);
         assertThat(sharding.physicalBucket(BUCKET, new TestBlobId("blob-1"))).isEqualTo(BUCKET);
@@ -153,14 +156,14 @@ class BucketShardingTest {
 
     @Test
     void omittedBucketShouldBeItsOwnLogicalBucket() {
-        BucketSharding sharding = new BucketSharding(256, ImmutableSet.of(BUCKET));
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256, BUCKET);
 
         assertThat(sharding.logicalBucket(BUCKET)).contains(BUCKET);
     }
 
     @Test
     void omittingABucketShouldNotAffectTheOthers() {
-        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(BucketName.of("jmap-uploads")));
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4, BucketName.of("jmap-uploads"));
 
         assertThat(sharding.physicalBuckets(BUCKET))
             .containsExactly(BucketName.of("blobs-0"), BucketName.of("blobs-1"),
@@ -168,27 +171,25 @@ class BucketShardingTest {
     }
 
     @Test
-    void fromSystemPropertiesShouldDefaultToNoOmittedBucket() {
-        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
-
-        assertThat(BucketSharding.fromSystemProperties()).contains(new BucketSharding(256, ImmutableSet.of()));
+    void fromShouldDefaultToNoOmittedBucket() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("tmail.blobstore.shards=256")).omittedBuckets())
+            .isEmpty();
     }
 
     @Test
-    void fromSystemPropertiesShouldReadOmittedBuckets() {
-        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "256");
-        System.setProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY, "jmap-uploads, mail-processing");
-
-        assertThat(BucketSharding.fromSystemProperties())
-            .contains(new BucketSharding(256, ImmutableSet.of(
-                BucketName.of("jmap-uploads"), BucketName.of("mail-processing"))));
+    void fromShouldReadOmittedBuckets() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads, mail-processing")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
     }
 
     @Test
-    void fromSystemPropertiesShouldIgnoreOmittedBucketsWhenShardingIsOff() {
-        System.setProperty(BucketSharding.OMITTED_BUCKETS_PROPERTY, "jmap-uploads");
-
-        assertThat(BucketSharding.fromSystemProperties()).isEmpty();
+    void fromShouldIgnoreOmittedBucketsWhenShardingIsOff() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties(
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
     }
 
     /**
@@ -201,7 +202,7 @@ class BucketShardingTest {
      */
     @Test
     void fourShardsOverTmailBucketsShouldYieldTheDocumentedLayout() {
-        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET));
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4, UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET);
 
         assertThat(TMAIL_BUCKETS.stream()
             .collect(Collectors.toMap(BucketName::asString, sharding::physicalBuckets)))
@@ -217,7 +218,7 @@ class BucketShardingTest {
 
     @Test
     void everyTmailBucketShouldBeReadBackFromItsShards() {
-        BucketSharding sharding = new BucketSharding(4, ImmutableSet.of(UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET));
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4, UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET);
 
         assertThat(TMAIL_BUCKETS.stream()
             .flatMap(logicalBucket -> sharding.physicalBuckets(logicalBucket).stream())
@@ -233,7 +234,7 @@ class BucketShardingTest {
      */
     @Test
     void sixteenBlobsShouldReachEveryShardOfEveryTmailBucket() {
-        BucketSharding sharding = new BucketSharding(4);
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4);
 
         TMAIL_BUCKETS.forEach(logicalBucket -> assertThat(IntStream.range(0, 16)
             .mapToObj(i -> new TestBlobId(logicalBucket.asString() + "-blob-" + i))
@@ -243,10 +244,16 @@ class BucketShardingTest {
     }
 
     @Test
-    void fromSystemPropertiesShouldThrowOnInvalidShardCount() {
-        System.setProperty(BucketSharding.SHARD_COUNT_PROPERTY, "invalid");
+    void fromShouldThrowOnInvalidShardCount() throws Exception {
+        Configuration configuration = blobProperties("tmail.blobstore.shards=invalid");
 
-        assertThatThrownBy(BucketSharding::fromSystemProperties)
+        assertThatThrownBy(() -> TmailBlobStoreShardingConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shardCountShouldRejectNegativeValues() {
+        assertThatThrownBy(() -> TmailBlobStoreShardingConfiguration.of(-1))
             .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfigurationTest.java
+++ b/tmail-backend/blob/sharded-blob-store/src/test/java/com/linagora/tmail/blob/sharding/TmailBlobStoreShardingConfigurationTest.java
@@ -78,7 +78,7 @@ class TmailBlobStoreShardingConfigurationTest {
     }
 
     @Test
-    void logicalBucketShouldReverPhysicalBucket() {
+    void logicalBucketShouldReversePhysicalBucketMapping() {
         TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(256);
 
         assertThat(sharding.physicalBuckets(BUCKET)
@@ -121,7 +121,6 @@ class TmailBlobStoreShardingConfigurationTest {
         assertThat(perShard.values()).allSatisfy(count -> assertThat(count).isBetween(300L, 500L));
     }
 
-
     @Test
     void fromShouldBeDisabledWhenPropertyIsOmitted() throws Exception {
         assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("implementation=s3")))
@@ -140,6 +139,33 @@ class TmailBlobStoreShardingConfigurationTest {
     }
 
     @Test
+    void disabledPhysicalBucketShouldPreserveLogicalBucket() {
+        assertThat(TmailBlobStoreShardingConfiguration.DISABLED.physicalBucket(BUCKET, new TestBlobId("blob-1")))
+            .isEqualTo(BUCKET);
+        assertThat(TmailBlobStoreShardingConfiguration.DISABLED.physicalBucket(BUCKET, 0))
+            .isEqualTo(BUCKET);
+    }
+
+    @Test
+    void disabledPhysicalBucketsShouldPreserveLogicalBucket() {
+        assertThat(TmailBlobStoreShardingConfiguration.DISABLED.physicalBuckets(BUCKET))
+            .containsExactly(BUCKET);
+    }
+
+    @Test
+    void disabledLogicalBucketShouldPreservePhysicalBucket() {
+        assertThat(TmailBlobStoreShardingConfiguration.DISABLED.logicalBucket(BUCKET))
+            .contains(BUCKET);
+    }
+
+    @Test
+    void shardOfShouldRejectDisabledSharding() {
+        assertThatThrownBy(() -> TmailBlobStoreShardingConfiguration.DISABLED.shardOf(new TestBlobId("blob-1")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Cannot compute a shard when sharding is disabled");
+    }
+
+    @Test
     void fromShouldReadTheShardCount() throws Exception {
         assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties("tmail.blobstore.shards=256")))
             .isEqualTo(TmailBlobStoreShardingConfiguration.of(256));
@@ -152,6 +178,7 @@ class TmailBlobStoreShardingConfigurationTest {
 
         assertThat(sharding.physicalBuckets(BUCKET)).containsExactly(BUCKET);
         assertThat(sharding.physicalBucket(BUCKET, new TestBlobId("blob-1"))).isEqualTo(BUCKET);
+        assertThat(sharding.physicalBucket(BUCKET, 0)).isEqualTo(BUCKET);
     }
 
     @Test
@@ -186,10 +213,28 @@ class TmailBlobStoreShardingConfigurationTest {
     }
 
     @Test
+    void fromShouldIgnoreBlankOmittedBucketEntries() throws Exception {
+        assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads, , mail-processing,")))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
+    }
+
+    @Test
     void fromShouldIgnoreOmittedBucketsWhenShardingIsOff() throws Exception {
         assertThat(TmailBlobStoreShardingConfiguration.from(blobProperties(
             "tmail.blobstore.shards.ommited.buckets=jmap-uploads")))
             .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
+    }
+
+    @Test
+    void forBucketSuffixShouldAdaptOmittedBuckets() {
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4, UPLOADS_BUCKET, MAIL_PROCESSING_BUCKET);
+
+        assertThat(sharding.forBucketSuffix("-copy"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(4,
+                BucketName.of("jmap-uploads-copy"), BucketName.of("mail-processing-copy")));
     }
 
     /**
@@ -254,6 +299,26 @@ class TmailBlobStoreShardingConfigurationTest {
     @Test
     void shardCountShouldRejectNegativeValues() {
         assertThatThrownBy(() -> TmailBlobStoreShardingConfiguration.of(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void physicalBucketShouldRejectShardOutsideLayout() {
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4);
+
+        assertThatThrownBy(() -> sharding.physicalBucket(BUCKET, -1))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> sharding.physicalBucket(BUCKET, 4))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void omittedPhysicalBucketShouldRejectShardOutsideLayout() {
+        TmailBlobStoreShardingConfiguration sharding = TmailBlobStoreShardingConfiguration.of(4, BUCKET);
+
+        assertThatThrownBy(() -> sharding.physicalBucket(BUCKET, -1))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> sharding.physicalBucket(BUCKET, 4))
             .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
@@ -18,11 +18,13 @@
 
 package com.linagora.tmail.blob.guice;
 
+import java.io.FileNotFoundException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.blob.aes.AESBlobStoreDAO;
 import org.apache.james.blob.aes.CryptoConfig;
 import org.apache.james.blob.api.BlobId;
@@ -53,6 +55,7 @@ import org.apache.james.modules.blobstore.BlobDeduplicationGCModule;
 import org.apache.james.modules.blobstore.validation.EventsourcingStorageStrategy;
 import org.apache.james.modules.blobstore.validation.StorageStrategyModule;
 import org.apache.james.modules.mailbox.BlobStoreAPIModule;
+import org.apache.james.modules.mailbox.ConfigurationComponent;
 import org.apache.james.modules.mailbox.DefaultBucketModule;
 import org.apache.james.modules.objectstorage.S3BlobStoreModule;
 import org.apache.james.modules.objectstorage.S3BucketModule;
@@ -60,6 +63,9 @@ import org.apache.james.server.blob.deduplication.DeDuplicationBlobStore;
 import org.apache.james.server.blob.deduplication.PassThroughBlobStore;
 import org.apache.james.server.blob.deduplication.StorageStrategy;
 import org.apache.james.server.core.MissingArgumentException;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -79,12 +85,14 @@ import com.linagora.tmail.blob.blobid.list.SingleSaveBlobStoreDAO;
 import com.linagora.tmail.blob.blobid.list.postgres.PostgresSingleSaveBlobStoreModule;
 import com.linagora.tmail.blob.secondaryblobstore.FailedBlobOperationListener;
 import com.linagora.tmail.blob.secondaryblobstore.SecondaryBlobStoreDAO;
-import com.linagora.tmail.blob.sharding.BucketSharding;
 import com.linagora.tmail.blob.sharding.ShardedBlobStoreDAO;
+import com.linagora.tmail.blob.sharding.TmailBlobStoreShardingConfiguration;
 
 import modules.BlobPostgresModule;
 
 public class BlobStoreModulesChooser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlobStoreModulesChooser.class);
+
     public static final String INITIAL_BLOBSTORE_DAO = "initial_blobstore_dao";
     public static final String MAYBE_SECONDARY_BLOBSTORE = "maybe_secondary_blob_store_dao";
     public static final String MAYBE_ENCRYPTION_BLOBSTORE = "maybe_encryption_blob_store_dao";
@@ -105,8 +113,9 @@ public class BlobStoreModulesChooser {
         @Provides
         @Singleton
         @Named(INITIAL_BLOBSTORE_DAO)
-        BlobStoreDAO provideInitialBlobStoreDAO(S3BlobStoreDAO s3BlobStoreDAO, Optional<BucketSharding> bucketSharding) {
-            return maybeShard(s3BlobStoreDAO, bucketSharding);
+        BlobStoreDAO provideInitialBlobStoreDAO(S3BlobStoreDAO s3BlobStoreDAO,
+                                                TmailBlobStoreShardingConfiguration shardingConfiguration) {
+            return maybeShard(s3BlobStoreDAO, shardingConfiguration);
         }
 
         @Provides
@@ -155,24 +164,34 @@ public class BlobStoreModulesChooser {
 
     /**
      * Applicative sharding of the object storage buckets, needed to keep Ceph / Rados gateway bucket indexes small
-     * enough to stay listable. Off unless {@code -Dtmail.blobstore.shards} is set, and only applied to S3 backed
-     * deployments.
+     * enough to stay listable. Off unless {@code tmail.blobstore.shards} is set in {@code blob.properties}, and only
+     * applied to S3 backed deployments.
      *
      * <p>Sharding sits at the very bottom of the blobStore mille-feuille: the layers above it (secondary blob store,
      * encryption, compression, single save) need to keep reasoning in terms of logical buckets.</p>
+     *
+     * @see TmailBlobStoreShardingConfiguration
      */
     static class ShardingModule extends AbstractModule {
         @Provides
         @Singleton
-        Optional<BucketSharding> provideBucketSharding() {
-            return BucketSharding.fromSystemProperties();
+        TmailBlobStoreShardingConfiguration shardingConfiguration(PropertiesProvider propertiesProvider) {
+            try {
+                return TmailBlobStoreShardingConfiguration.from(propertiesProvider.getConfigurations(ConfigurationComponent.NAMES));
+            } catch (FileNotFoundException e) {
+                LOGGER.warn("Could not find {} configuration file, not sharding the object storage buckets", ConfigurationComponent.NAME);
+                return TmailBlobStoreShardingConfiguration.DISABLED;
+            } catch (ConfigurationException e) {
+                throw new RuntimeException("Failed reading " + ConfigurationComponent.NAME + " configuration file", e);
+            }
         }
     }
 
-    private static BlobStoreDAO maybeShard(BlobStoreDAO blobStoreDAO, Optional<BucketSharding> bucketSharding) {
-        return bucketSharding
-            .<BlobStoreDAO>map(sharding -> new ShardedBlobStoreDAO(blobStoreDAO, sharding))
-            .orElse(blobStoreDAO);
+    private static BlobStoreDAO maybeShard(BlobStoreDAO blobStoreDAO, TmailBlobStoreShardingConfiguration shardingConfiguration) {
+        if (shardingConfiguration.enabled()) {
+            return new ShardedBlobStoreDAO(blobStoreDAO, shardingConfiguration);
+        }
+        return blobStoreDAO;
     }
 
     static class BaseObjectStorageModule extends AbstractModule {
@@ -206,11 +225,11 @@ public class BlobStoreModulesChooser {
                                                 MetricFactory metricFactory,
                                                 GaugeRegistry gaugeRegistry,
                                                 S3RequestOption s3RequestOption,
-                                                Optional<BucketSharding> bucketSharding) {
+                                                TmailBlobStoreShardingConfiguration shardingConfiguration) {
             S3ClientFactory s3SecondaryClientFactory = new S3ClientFactory(secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(),
                 () -> new JamesS3MetricPublisher(metricFactory, gaugeRegistry, "secondary_s3"));
             return maybeShard(new S3BlobStoreDAO(s3SecondaryClientFactory, secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(), blobIdFactory, s3RequestOption),
-                bucketSharding);
+                shardingConfiguration);
         }
 
         @ProvidesIntoSet

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
@@ -228,8 +228,10 @@ public class BlobStoreModulesChooser {
                                                 TmailBlobStoreShardingConfiguration shardingConfiguration) {
             S3ClientFactory s3SecondaryClientFactory = new S3ClientFactory(secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(),
                 () -> new JamesS3MetricPublisher(metricFactory, gaugeRegistry, "secondary_s3"));
+            // SecondaryBlobStoreDAO adds the suffix before calling this DAO. Mirror it in omitted bucket names so
+            // the omission configuration remains expressed with the original logical names.
             return maybeShard(new S3BlobStoreDAO(s3SecondaryClientFactory, secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(), blobIdFactory, s3RequestOption),
-                shardingConfiguration);
+                shardingConfiguration.forBucketSuffix(secondaryS3BlobStoreConfiguration.secondaryBucketSuffix()));
         }
 
         @ProvidesIntoSet

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
@@ -79,6 +79,8 @@ import com.linagora.tmail.blob.blobid.list.SingleSaveBlobStoreDAO;
 import com.linagora.tmail.blob.blobid.list.postgres.PostgresSingleSaveBlobStoreModule;
 import com.linagora.tmail.blob.secondaryblobstore.FailedBlobOperationListener;
 import com.linagora.tmail.blob.secondaryblobstore.SecondaryBlobStoreDAO;
+import com.linagora.tmail.blob.sharding.BucketSharding;
+import com.linagora.tmail.blob.sharding.ShardedBlobStoreDAO;
 
 import modules.BlobPostgresModule;
 
@@ -97,10 +99,14 @@ public class BlobStoreModulesChooser {
             install(new S3BlobStoreModule());
             install(new S3BucketModule());
 
-            bind(BlobStoreDAO.class)
-                .annotatedWith(Names.named(INITIAL_BLOBSTORE_DAO))
-                .to(S3BlobStoreDAO.class)
-                .in(Scopes.SINGLETON);
+            bind(S3BlobStoreDAO.class).in(Scopes.SINGLETON);
+        }
+
+        @Provides
+        @Singleton
+        @Named(INITIAL_BLOBSTORE_DAO)
+        BlobStoreDAO provideInitialBlobStoreDAO(S3BlobStoreDAO s3BlobStoreDAO, Optional<BucketSharding> bucketSharding) {
+            return maybeShard(s3BlobStoreDAO, bucketSharding);
         }
 
         @Provides
@@ -147,6 +153,28 @@ public class BlobStoreModulesChooser {
         }
     }
 
+    /**
+     * Applicative sharding of the object storage buckets, needed to keep Ceph / Rados gateway bucket indexes small
+     * enough to stay listable. Off unless {@code -Dtmail.blobstore.shards} is set, and only applied to S3 backed
+     * deployments.
+     *
+     * <p>Sharding sits at the very bottom of the blobStore mille-feuille: the layers above it (secondary blob store,
+     * encryption, compression, single save) need to keep reasoning in terms of logical buckets.</p>
+     */
+    static class ShardingModule extends AbstractModule {
+        @Provides
+        @Singleton
+        Optional<BucketSharding> provideBucketSharding() {
+            return BucketSharding.fromSystemProperties();
+        }
+    }
+
+    private static BlobStoreDAO maybeShard(BlobStoreDAO blobStoreDAO, Optional<BucketSharding> bucketSharding) {
+        return bucketSharding
+            .<BlobStoreDAO>map(sharding -> new ShardedBlobStoreDAO(blobStoreDAO, sharding))
+            .orElse(blobStoreDAO);
+    }
+
     static class BaseObjectStorageModule extends AbstractModule {
         @Provides
         @Singleton
@@ -177,10 +205,12 @@ public class BlobStoreModulesChooser {
         BlobStoreDAO getSecondaryS3BlobStoreDAO(BlobId.Factory blobIdFactory,
                                                 MetricFactory metricFactory,
                                                 GaugeRegistry gaugeRegistry,
-                                                S3RequestOption s3RequestOption) {
+                                                S3RequestOption s3RequestOption,
+                                                Optional<BucketSharding> bucketSharding) {
             S3ClientFactory s3SecondaryClientFactory = new S3ClientFactory(secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(),
                 () -> new JamesS3MetricPublisher(metricFactory, gaugeRegistry, "secondary_s3"));
-            return new S3BlobStoreDAO(s3SecondaryClientFactory, secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(), blobIdFactory, s3RequestOption);
+            return maybeShard(new S3BlobStoreDAO(s3SecondaryClientFactory, secondaryS3BlobStoreConfiguration.s3BlobStoreConfiguration(), blobIdFactory, s3RequestOption),
+                bucketSharding);
         }
 
         @ProvidesIntoSet
@@ -364,6 +394,7 @@ public class BlobStoreModulesChooser {
 
     public static List<Module> chooseModules(BlobStoreConfiguration blobStoreConfiguration, SingleSaveDeclarationModule.BackedStorage backedSingleSaveStorage) {
         return ImmutableList.<Module>builder()
+            .add(new ShardingModule())
             .add(chooseBlobStoreDAOModule(blobStoreConfiguration.implementation()))
             .add(chooseSecondaryObjectStorageModule(blobStoreConfiguration.maybeSecondaryS3BlobStoreConfiguration()))
             .add(chooseEncryptionModule(blobStoreConfiguration.cryptoConfig()))

--- a/tmail-backend/pom.xml
+++ b/tmail-backend/pom.xml
@@ -40,6 +40,7 @@
 
         <module>blob/blobid-list</module>
         <module>blob/secondary-blob-store</module>
+        <module>blob/sharded-blob-store</module>
 
         <module>combined-identity</module>
 
@@ -262,6 +263,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>secondary-blob-store</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>sharded-blob-store</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable S3 bucket sharding to distribute blob storage across physical buckets.
  - Supports configurable shard counts and selected buckets that remain unsharded.
  - Blob listings, reads, writes, and deletions continue to operate through logical buckets.
  - Sharding applies to primary and secondary S3-backed storage.

- **Documentation**
  - Added configuration guidance, bucket layout examples, limits, immutability requirements, and Ceph resharding notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->