### PR TITLE
[Documentation] Fix AddHeader -> SetMimeheader

### DIFF
--- a/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
+++ b/docs/modules/ROOT/pages/tmail-backend/configure/extra-mailet.adoc
@@ -211,7 +211,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 *Minimal — uses configured userBase and default stop words:*
 
 ....
-<mailet match="SuspiciousDisplayName" class="AddHeader">
+<mailet match="SuspiciousDisplayName" class="SetMimeHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
 </mailet>
@@ -220,7 +220,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 *Explicit userBase:*
 
 ....
-<mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader">
+<mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="SetMimeHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
 </mailet>
@@ -230,7 +230,7 @@ SuspiciousDisplayName[=<userBase>][?stopWords=<csv>]
 
 ....
 <mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr,Prof"
-        class="AddHeader">
+        class="SetMimeHeader">
   <name>X-Suspicious-DisplayName</name>
   <value>true</value>
 </mailet>
@@ -270,7 +270,7 @@ No condition parameter is required. The list of local domains is taken directly 
 server's configured domain list.
 
 ....
-<mailet match="SuspiciousDomainInDisplayName" class="AddHeader">
+<mailet match="SuspiciousDomainInDisplayName" class="SetMimeHeader">
   <name>X-Suspicious-Domain</name>
   <value>true</value>
 </mailet>

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDisplayName.java
@@ -57,15 +57,15 @@ import com.unboundid.ldap.sdk.SearchScope;
  * <p>Configuration:</p>
  * <pre><code>
  * &lt;!-- userBase from LdapRepositoryConfiguration, default stop words --&gt;
- * &lt;mailet match="SuspiciousDisplayName" class="AddHeader"&gt;
+ * &lt;mailet match="SuspiciousDisplayName" class="SetMimeHeader"&gt;
  *   &lt;name&gt;X-Suspicious-DisplayName&lt;/name&gt;&lt;value&gt;true&lt;/value&gt;
  * &lt;/mailet&gt;
  *
  * &lt;!-- explicit userBase --&gt;
- * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="AddHeader"&gt; ... &lt;/mailet&gt;
+ * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org" class="SetMimeHeader"&gt; ... &lt;/mailet&gt;
  *
  * &lt;!-- explicit userBase + custom stop words --&gt;
- * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr" class="AddHeader"&gt;
+ * &lt;mailet match="SuspiciousDisplayName=ou=people,dc=james,dc=org?stopWords=Mr,Mme,Mrs,Dr" class="SetMimeHeader"&gt;
  *   ...
  * &lt;/mailet&gt;
  * </code></pre>

--- a/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
+++ b/tmail-backend/mailets/src/main/java/com/linagora/tmail/mailet/SuspiciousDomainInDisplayName.java
@@ -51,7 +51,7 @@ import com.google.common.collect.ImmutableList;
  *
  * <p>No configuration parameter is required:</p>
  * <pre><code>
- * &lt;mailet matcher="SuspiciousDomainInDisplayName" class="AddHeader"&gt;
+ * &lt;mailet matcher="SuspiciousDomainInDisplayName" class="SetMimeHeader"&gt;
  *   &lt;name&gt;X-Suspicious-Domain&lt;/name&gt;&lt;value&gt;true&lt;/value&gt;
  * &lt;/mailet&gt;
  * </code></pre>


### PR DESCRIPTION
AddHeader is a legacy mailet that does not exist and was replaced by SetMimeHeader.

Just fixing the doc around it, could be misleading :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples for suspicious display names and domains to use the current MIME header-setting mailet.
  - Aligned inline guidance and documentation snippets with the recommended header configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->