### PR TITLE
ISSUE-2619 BlobIdList DAO should not cache duplicated headers

### DIFF
--- a/tmail-backend/blob/blobid-list/pom.xml
+++ b/tmail-backend/blob/blobid-list/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-backends-postgres</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
@@ -24,6 +24,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobIdEntropy;
 import org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver;
 import org.apache.james.server.blob.deduplication.GenerationAware;
+import org.apache.james.server.blob.deduplication.MinIOGenerationAwareBlobId;
 
 /**
  * Tells the header blobs apart from the content addressed blobs the {@link BlobIdList} exists for.
@@ -42,9 +43,8 @@ import org.apache.james.server.blob.deduplication.GenerationAware;
 public class HeaderBlobIdPredicate implements Predicate<BlobId> {
     /** What closes the family and the generation: {@code _} for a generation aware id, {@code /} for its MinIO flavour. */
     private static final String GENERATION_SEPARATORS = "_/";
-    /** The MinIO flavour also spreads the first two characters of the payload into folders. */
-    private static final String FOLDER_SEPARATOR = "/";
-    private static final String NO_SEPARATOR = "";
+    /** The MinIO flavour also spreads the first two characters of the payload into as many folders. */
+    private static final int MINIO_FOLDER_SEPARATORS = 2;
     private static final int NONE = -1;
 
     private final int contentAddressedPayloadLength;
@@ -63,17 +63,18 @@ public class HeaderBlobIdPredicate implements Predicate<BlobId> {
 
     /**
      * A generation aware id spells out a {@code family_generation_} prefix, and its MinIO flavour further spreads the
-     * first two characters of the payload into folders: neither is payload. Any other id is payload throughout, and
-     * digits or slashes it happens to spell out are to be counted like any other characters.
+     * first two characters of the payload into folders: neither is payload. Anything else is, slashes included, as
+     * standard Base64 spells them out.
      */
     private static int payloadLengthOf(BlobId blobId) {
         String id = blobId.asString();
-        if (!(blobId instanceof GenerationAware)) {
-            return id.length();
+        if (blobId instanceof MinIOGenerationAwareBlobId) {
+            return withoutGenerationPrefix(id).length() - MINIO_FOLDER_SEPARATORS;
         }
-        return withoutGenerationPrefix(id)
-            .replace(FOLDER_SEPARATOR, NO_SEPARATOR)
-            .length();
+        if (blobId instanceof GenerationAware) {
+            return withoutGenerationPrefix(id).length();
+        }
+        return id.length();
     }
 
     /**

--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobIdEntropy;
 import org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver;
+import org.apache.james.server.blob.deduplication.GenerationAware;
 
 /**
  * Tells the header blobs apart from the content addressed blobs the {@link BlobIdList} exists for.
@@ -56,20 +57,28 @@ public class HeaderBlobIdPredicate implements Predicate<BlobId> {
 
     @Override
     public boolean test(BlobId blobId) {
-        String id = blobId.asString();
-
-        return id.endsWith(ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX)
-            && payloadOf(id).length() > contentAddressedPayloadLength;
-    }
-
-    private String payloadOf(String id) {
-        return withoutGenerationPrefix(id)
-            .replace(FOLDER_SEPARATOR, NO_SEPARATOR);
+        return blobId.asString().endsWith(ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX)
+            && payloadLengthOf(blobId) > contentAddressedPayloadLength;
     }
 
     /**
-     * Drops the {@code family_generation_} an id is prefixed with once it is generation aware, leaving an id that
-     * carries no such prefix untouched.
+     * A generation aware id spells out a {@code family_generation_} prefix, and its MinIO flavour further spreads the
+     * first two characters of the payload into folders: neither is payload. Any other id is payload throughout, and
+     * digits or slashes it happens to spell out are to be counted like any other characters.
+     */
+    private static int payloadLengthOf(BlobId blobId) {
+        String id = blobId.asString();
+        if (!(blobId instanceof GenerationAware)) {
+            return id.length();
+        }
+        return withoutGenerationPrefix(id)
+            .replace(FOLDER_SEPARATOR, NO_SEPARATOR)
+            .length();
+    }
+
+    /**
+     * Drops the {@code family_generation_} a generation aware id is prefixed with, leaving one that carries no such
+     * prefix untouched.
      */
     private static String withoutGenerationPrefix(String id) {
         int afterFamily = separatorClosingNumberAt(id, 0);

--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicate.java
@@ -1,0 +1,104 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.blobid.list;
+
+import java.util.function.Predicate;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobIdEntropy;
+import org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver;
+
+/**
+ * Tells the header blobs apart from the content addressed blobs the {@link BlobIdList} exists for.
+ *
+ * <p>{@link ContentRecoveryMessageContentSaver} writes headers under a random id carrying the
+ * {@code _hdr} suffix: such an id is unique by construction, is never recomputed, and would thus only
+ * ever add a row no later save can hit. Bodies and attachments, being content addressed, are the ones a
+ * second save actually collides with, and the list is kept for them.</p>
+ *
+ * <p>The suffix alone does not spot a header: the encoding of an id spells out {@code _}, {@code h},
+ * {@code d} and {@code r} like any other characters, so a content addressed id can end with those four.
+ * What sets a header apart is that its suffix sits on top of a whole payload, so that once the family
+ * and generation prefix is stripped it is longer than the encoding of the configured entropy, which is
+ * all a content addressed id ever is.</p>
+ */
+public class HeaderBlobIdPredicate implements Predicate<BlobId> {
+    /** What closes the family and the generation: {@code _} for a generation aware id, {@code /} for its MinIO flavour. */
+    private static final String GENERATION_SEPARATORS = "_/";
+    /** The MinIO flavour also spreads the first two characters of the payload into folders. */
+    private static final String FOLDER_SEPARATOR = "/";
+    private static final String NO_SEPARATOR = "";
+    private static final int NONE = -1;
+
+    private final int contentAddressedPayloadLength;
+
+    public HeaderBlobIdPredicate(BlobId.Factory blobIdFactory) {
+        this.contentAddressedPayloadLength = blobIdFactory.encoding()
+            .encode(new byte[BlobIdEntropy.entropyBytes()])
+            .length();
+    }
+
+    @Override
+    public boolean test(BlobId blobId) {
+        String id = blobId.asString();
+
+        return id.endsWith(ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX)
+            && payloadOf(id).length() > contentAddressedPayloadLength;
+    }
+
+    private String payloadOf(String id) {
+        return withoutGenerationPrefix(id)
+            .replace(FOLDER_SEPARATOR, NO_SEPARATOR);
+    }
+
+    /**
+     * Drops the {@code family_generation_} an id is prefixed with once it is generation aware, leaving an id that
+     * carries no such prefix untouched.
+     */
+    private static String withoutGenerationPrefix(String id) {
+        int afterFamily = separatorClosingNumberAt(id, 0);
+        if (afterFamily == NONE) {
+            return id;
+        }
+        int afterGeneration = separatorClosingNumberAt(id, afterFamily + 1);
+        if (afterGeneration == NONE) {
+            return id;
+        }
+        return id.substring(afterGeneration + 1);
+    }
+
+    /**
+     * The index of the separator closing the non empty run of digits starting at {@code from}, or {@link #NONE} when
+     * no such run is closed there.
+     */
+    private static int separatorClosingNumberAt(String id, int from) {
+        int index = from;
+        while (index < id.length() && Character.isDigit(id.charAt(index))) {
+            index++;
+        }
+        boolean closesANumber = index > from
+            && index < id.length()
+            && GENERATION_SEPARATORS.indexOf(id.charAt(index)) != NONE;
+
+        if (closesANumber) {
+            return index;
+        }
+        return NONE;
+    }
+}

--- a/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
+++ b/tmail-backend/blob/blobid-list/src/main/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreDAO.java
@@ -19,6 +19,7 @@
 package com.linagora.tmail.blob.blobid.list;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStoreDAO;
@@ -34,13 +35,16 @@ public class SingleSaveBlobStoreDAO implements BlobStoreDAO {
     private final BlobStoreDAO blobStoreDAO;
     private final BlobIdList blobIdList;
     private final BucketName defaultBucketName;
+    private final Predicate<BlobId> isHeaderBlob;
 
     public SingleSaveBlobStoreDAO(BlobStoreDAO blobStoreDAO,
                                   BlobIdList blobIdList,
-                                  BucketName defaultBucketName) {
+                                  BucketName defaultBucketName,
+                                  BlobId.Factory blobIdFactory) {
         this.blobStoreDAO = blobStoreDAO;
         this.blobIdList = blobIdList;
         this.defaultBucketName = defaultBucketName;
+        this.isHeaderBlob = new HeaderBlobIdPredicate(blobIdFactory);
     }
 
     @Override
@@ -60,7 +64,7 @@ public class SingleSaveBlobStoreDAO implements BlobStoreDAO {
 
     @Override
     public Mono<Void> save(BucketName bucketName, BlobId blobId, Blob blob) {
-        if (defaultBucketName.equals(bucketName)) {
+        if (isDeduplicated(bucketName, blobId)) {
             return Mono.from(blobIdList.isStored(blobId))
                 .flatMap(isStored -> {
                     if (isStored) {
@@ -73,6 +77,13 @@ public class SingleSaveBlobStoreDAO implements BlobStoreDAO {
         } else {
             return Mono.from(blobStoreDAO.save(bucketName, blobId, blob));
         }
+    }
+
+    /**
+     * Header blobs, unique by construction, are left out of the list: see {@link HeaderBlobIdPredicate}.
+     */
+    private boolean isDeduplicated(BucketName bucketName, BlobId blobId) {
+        return defaultBucketName.equals(bucketName) && !isHeaderBlob.test(blobId);
     }
 
     @Override

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
@@ -1,0 +1,95 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.blobid.list;
+
+import static org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobIdEntropy;
+import org.apache.james.blob.api.PlainBlobId;
+import org.apache.james.server.blob.deduplication.GenerationAwareBlobId;
+import org.apache.james.server.blob.deduplication.MinIOGenerationAwareBlobId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HeaderBlobIdPredicateTest {
+    /**
+     * A content addressed id whose payload ends with the four characters of the header suffix: the
+     * encoding spells them out like any others, so only the length tells it apart from a header.
+     */
+    private static BlobId contentAddressedIdEndingWithHeaderSuffix(BlobId.Factory blobIdFactory) {
+        int payloadLength = blobIdFactory.encoding().encode(new byte[BlobIdEntropy.entropyBytes()]).length();
+        return blobIdFactory.of("A".repeat(payloadLength - HEADER_BLOB_ID_SUFFIX.length()) + HEADER_BLOB_ID_SUFFIX);
+    }
+
+    abstract static class Contract {
+        abstract BlobId.Factory blobIdFactory();
+
+        private HeaderBlobIdPredicate testee() {
+            return new HeaderBlobIdPredicate(blobIdFactory());
+        }
+
+        @Test
+        void shouldAcceptHeaderBlobs() {
+            assertThat(testee().test(blobIdFactory().random().withSuffix(HEADER_BLOB_ID_SUFFIX)))
+                .isTrue();
+        }
+
+        @Test
+        void shouldRejectContentAddressedBlobs() {
+            assertThat(testee().test(blobIdFactory().random()))
+                .isFalse();
+        }
+
+        @Test
+        void shouldRejectContentAddressedBlobsEndingWithTheHeaderSuffix() {
+            assertThat(testee().test(contentAddressedIdEndingWithHeaderSuffix(blobIdFactory())))
+                .isFalse();
+        }
+    }
+
+    @Nested
+    class Plain extends Contract {
+        @Override
+        BlobId.Factory blobIdFactory() {
+            return new PlainBlobId.Factory();
+        }
+    }
+
+    @Nested
+    class GenerationAware extends Contract {
+        @Override
+        BlobId.Factory blobIdFactory() {
+            return new GenerationAwareBlobId.Factory(Clock.systemUTC(), new PlainBlobId.Factory(),
+                GenerationAwareBlobId.Configuration.DEFAULT);
+        }
+    }
+
+    @Nested
+    class MinIOGenerationAware extends Contract {
+        @Override
+        BlobId.Factory blobIdFactory() {
+            return new MinIOGenerationAwareBlobId.Factory(Clock.systemUTC(),
+                GenerationAwareBlobId.Configuration.DEFAULT, new PlainBlobId.Factory());
+        }
+    }
+}

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
@@ -37,14 +37,24 @@ class HeaderBlobIdPredicateTest {
      * encoding spells them out like any others, so only the length tells it apart from a header.
      */
     private static BlobId contentAddressedIdEndingWithHeaderSuffix(BlobId.Factory blobIdFactory) {
-        int payloadLength = blobIdFactory.encoding().encode(new byte[BlobIdEntropy.entropyBytes()]).length();
-        return blobIdFactory.of("A".repeat(payloadLength - HEADER_BLOB_ID_SUFFIX.length()) + HEADER_BLOB_ID_SUFFIX);
+        return blobIdFactory.of("A".repeat(payloadLength(blobIdFactory) - HEADER_BLOB_ID_SUFFIX.length())
+            + HEADER_BLOB_ID_SUFFIX);
+    }
+
+    /** A header id whose payload happens to open on {@code payloadPrefix}. */
+    private static BlobId headerIdWithPayloadOpeningOn(BlobId.Factory blobIdFactory, String payloadPrefix) {
+        return blobIdFactory.of(payloadPrefix + "A".repeat(payloadLength(blobIdFactory) - payloadPrefix.length()))
+            .withSuffix(HEADER_BLOB_ID_SUFFIX);
+    }
+
+    private static int payloadLength(BlobId.Factory blobIdFactory) {
+        return blobIdFactory.encoding().encode(new byte[BlobIdEntropy.entropyBytes()]).length();
     }
 
     abstract static class Contract {
         abstract BlobId.Factory blobIdFactory();
 
-        private HeaderBlobIdPredicate testee() {
+        HeaderBlobIdPredicate testee() {
             return new HeaderBlobIdPredicate(blobIdFactory());
         }
 
@@ -72,6 +82,20 @@ class HeaderBlobIdPredicateTest {
         @Override
         BlobId.Factory blobIdFactory() {
             return new PlainBlobId.Factory();
+        }
+
+        @Test
+        void shouldAcceptHeaderBlobsWhosePayloadOpensOnAGenerationPrefix() {
+            // A plain id carries no family and no generation: `12_34_` is payload here, and counts as such.
+            assertThat(testee().test(headerIdWithPayloadOpeningOn(blobIdFactory(), "12_34_")))
+                .isTrue();
+        }
+
+        @Test
+        void shouldAcceptHeaderBlobsWhosePayloadOpensOnFolderSeparators() {
+            // Only the MinIO flavour spreads a payload into folders: slashes are payload here.
+            assertThat(testee().test(headerIdWithPayloadOpeningOn(blobIdFactory(), "a/b/c/d/")))
+                .isTrue();
         }
     }
 

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/HeaderBlobIdPredicateTest.java
@@ -106,6 +106,13 @@ class HeaderBlobIdPredicateTest {
             return new GenerationAwareBlobId.Factory(Clock.systemUTC(), new PlainBlobId.Factory(),
                 GenerationAwareBlobId.Configuration.DEFAULT);
         }
+
+        @Test
+        void shouldAcceptHeaderBlobsWhosePayloadSpellsOutSlashes() {
+            // Standard Base64 spells out slashes: only the MinIO flavour injects folder separators.
+            assertThat(testee().test(headerIdWithPayloadOpeningOn(blobIdFactory(), "a/b/c/d/")))
+                .isTrue();
+        }
     }
 
     @Nested

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
@@ -22,7 +22,8 @@ import java.time.Duration
 import java.util.UUID
 
 import org.apache.james.blob.api.BlobStoreDAOFixture.{SHORT_BYTEARRAY, TEST_BUCKET_NAME}
-import org.apache.james.blob.api.{BlobId, BlobStoreDAOContract, BucketName, ObjectStoreException}
+import org.apache.james.blob.api.{BlobId, BlobIdEntropy, BlobStoreDAOContract, BucketName, ObjectStoreException}
+import org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX
 import org.apache.james.util.concurrency.ConcurrentTestRunner
 import org.assertj.core.api.Assertions.{assertThat, assertThatCode, assertThatThrownBy}
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
@@ -162,6 +163,41 @@ trait SingleSaveBlobStoreContract extends BlobStoreDAOContract {
 
     assertThat(SMono.fromPublisher(testee.readBytes(defaultBucketName, blobId)).block().payload())
       .isEqualTo(SHORT_BYTEARRAY.payload())
+  }
+
+  @Test
+  def saveShouldNotListHeaderBlobs(): Unit = {
+    val blobId: BlobId = blobIdFactory.random().withSuffix(HEADER_BLOB_ID_SUFFIX)
+    SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
+
+    assertThat(SMono.fromPublisher(blobIdList.isStored(blobId)).block()).isFalse
+  }
+
+  @Test
+  def saveShouldStoreHeaderBlobs(): Unit = {
+    val blobId: BlobId = blobIdFactory.random().withSuffix(HEADER_BLOB_ID_SUFFIX)
+    SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
+
+    assertThat(SMono.fromPublisher(testee.readBytes(defaultBucketName, blobId)).block().payload())
+      .isEqualTo(SHORT_BYTEARRAY.payload())
+  }
+
+  @Test
+  def saveShouldOverwriteHeaderBlobs(): Unit = {
+    val blobId: BlobId = blobIdFactory.random().withSuffix(HEADER_BLOB_ID_SUFFIX)
+    SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
+
+    assertThatCode(() => SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block())
+      .doesNotThrowAnyException()
+  }
+
+  @Test
+  def saveShouldListContentAddressedBlobsEndingWithTheHeaderSuffix(): Unit = {
+    val payloadLength: Int = blobIdFactory.encoding().encode(new Array[Byte](BlobIdEntropy.entropyBytes())).length
+    val blobId: BlobId = blobIdFactory.of("A" * (payloadLength - HEADER_BLOB_ID_SUFFIX.length) + HEADER_BLOB_ID_SUFFIX)
+    SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
+
+    assertThat(SMono.fromPublisher(blobIdList.isStored(blobId)).block()).isTrue
   }
 
   @Test

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreContract.scala
@@ -21,7 +21,7 @@ package com.linagora.tmail.blob.blobid.list
 import java.time.Duration
 import java.util.UUID
 
-import org.apache.james.blob.api.BlobStoreDAOFixture.{SHORT_BYTEARRAY, TEST_BUCKET_NAME}
+import org.apache.james.blob.api.BlobStoreDAOFixture.{ELEVEN_KILOBYTES, SHORT_BYTEARRAY, TEST_BUCKET_NAME}
 import org.apache.james.blob.api.{BlobId, BlobIdEntropy, BlobStoreDAOContract, BucketName, ObjectStoreException}
 import org.apache.james.mailbox.cassandra.mail.ContentRecoveryMessageContentSaver.HEADER_BLOB_ID_SUFFIX
 import org.apache.james.util.concurrency.ConcurrentTestRunner
@@ -187,8 +187,10 @@ trait SingleSaveBlobStoreContract extends BlobStoreDAOContract {
     val blobId: BlobId = blobIdFactory.random().withSuffix(HEADER_BLOB_ID_SUFFIX)
     SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block()
 
-    assertThatCode(() => SMono.fromPublisher(testee.save(defaultBucketName, blobId, SHORT_BYTEARRAY)).block())
+    assertThatCode(() => SMono.fromPublisher(testee.save(defaultBucketName, blobId, ELEVEN_KILOBYTES)).block())
       .doesNotThrowAnyException()
+    assertThat(SMono.fromPublisher(testee.readBytes(defaultBucketName, blobId)).block().payload())
+      .isEqualTo(ELEVEN_KILOBYTES.payload())
   }
 
   @Test

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/SingleSaveBlobStoreTest.java
@@ -49,7 +49,7 @@ public class SingleSaveBlobStoreTest implements SingleSaveBlobStoreContract {
     void setUp(CassandraCluster cassandra) {
         CassandraBlobIdListDAO cassandraBlobIdListDAO = new CassandraBlobIdListDAO(cassandra.getConf());
         cassandraBlobIdList = new CassandraBlobIdList(cassandraBlobIdListDAO);
-        blobStoreDAO = new SingleSaveBlobStoreDAO(new MemoryBlobStoreDAO(), cassandraBlobIdList, defaultBucketName());
+        blobStoreDAO = new SingleSaveBlobStoreDAO(new MemoryBlobStoreDAO(), cassandraBlobIdList, defaultBucketName(), blobIdFactory());
     }
 
     @Override

--- a/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/postgres/PostgresSingleSaveBlobStoreTest.java
+++ b/tmail-backend/blob/blobid-list/src/test/java/com/linagora/tmail/blob/blobid/list/postgres/PostgresSingleSaveBlobStoreTest.java
@@ -26,7 +26,7 @@ public class PostgresSingleSaveBlobStoreTest implements SingleSaveBlobStoreContr
     @BeforeEach
     void setUp() {
         postgresBlobIdList = new PostgresBlobIdList(new PostgresBlobIdListDAO(postgresExtension.getDefaultPostgresExecutor()));
-        blobStoreDAO = new SingleSaveBlobStoreDAO(new MemoryBlobStoreDAO(), postgresBlobIdList, defaultBucketName());
+        blobStoreDAO = new SingleSaveBlobStoreDAO(new MemoryBlobStoreDAO(), postgresBlobIdList, defaultBucketName(), blobIdFactory());
     }
 
     @Override

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreModulesChooser.java
@@ -336,8 +336,9 @@ public class BlobStoreModulesChooser {
         @Named(MAYBE_SINGLE_SAVE_BLOBSTORE)
         BlobStoreDAO provideSingleSaveBlobStoreDAO(@Named(MAYBE_COMPRESSION_BLOBSTORE) BlobStoreDAO blobStoreDAO,
                                                    BlobIdList blobIdList,
-                                                   BucketName defaultBucketName) {
-            return new SingleSaveBlobStoreDAO(blobStoreDAO, blobIdList, defaultBucketName);
+                                                   BucketName defaultBucketName,
+                                                   BlobId.Factory blobIdFactory) {
+            return new SingleSaveBlobStoreDAO(blobStoreDAO, blobIdList, defaultBucketName, blobIdFactory);
         }
     }
 

--- a/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/guice/TmailBlobStoreShardingConfigurationReadingTest.java
+++ b/tmail-backend/guice/blob-guice/src/test/java/com/linagora/tmail/blob/guice/TmailBlobStoreShardingConfigurationReadingTest.java
@@ -1,0 +1,154 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.tmail.blob.guice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.modules.mailbox.ConfigurationComponent;
+import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.apache.james.utils.PropertiesProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.linagora.tmail.blob.sharding.TmailBlobStoreShardingConfiguration;
+
+/**
+ * Reads the sharding configuration off an actual <code>blob.properties</code> file, through the very
+ * {@link PropertiesProvider} the server uses.
+ *
+ * <p>James reads properties with a comma list delimiter, and hands them over wrapped in a
+ * {@code DelegatedPropertiesConfiguration} that splits and strips quotes once more. A plain
+ * {@code PropertiesConfiguration} does neither, so a unit test built on one would not tell us anything about
+ * {@code tmail.blobstore.shards.ommited.buckets}, the one property here holding a list.</p>
+ */
+class TmailBlobStoreShardingConfigurationReadingTest {
+    @TempDir
+    File workingDirectory;
+
+    private TmailBlobStoreShardingConfiguration blobProperties(String... lines) throws Exception {
+        File configurationDirectory = new File(workingDirectory, "conf");
+        Files.createDirectories(configurationDirectory.toPath());
+        Files.writeString(new File(configurationDirectory, ConfigurationComponent.NAME + ".properties").toPath(),
+            String.join("\n", lines), StandardCharsets.UTF_8);
+
+        return TmailBlobStoreShardingConfiguration.from(propertiesProvider().getConfigurations(ConfigurationComponent.NAMES));
+    }
+
+    private PropertiesProvider propertiesProvider() {
+        Configuration configuration = Configuration.builder()
+            .workingDirectory(workingDirectory)
+            .build();
+        return new PropertiesProvider(new FileSystemImpl(configuration.directories()), configuration.configurationPath());
+    }
+
+    @Test
+    void shouldBeDisabledWhenShardCountIsNotSet() throws Exception {
+        assertThat(blobProperties("implementation=s3"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
+    }
+
+    @Test
+    void shouldReadTheShardCount() throws Exception {
+        assertThat(blobProperties("tmail.blobstore.shards=256"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256));
+    }
+
+    @Test
+    void shouldNotFailWhenOmittedBucketsIsNotSet() throws Exception {
+        assertThat(blobProperties("tmail.blobstore.shards=256").omittedBuckets())
+            .isEmpty();
+    }
+
+    @Test
+    void shouldReadASingleOmittedBucket() throws Exception {
+        assertThat(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256, BucketName.of("jmap-uploads")));
+    }
+
+    @Test
+    void shouldReadEveryCommaSeparatedOmittedBucket() throws Exception {
+        assertThat(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
+    }
+
+    @Test
+    void shouldTrimOmittedBuckets() throws Exception {
+        assertThat(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets= jmap-uploads ,  mail-processing "))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
+    }
+
+    @Test
+    void shouldIgnoreEmptyOmittedBuckets() throws Exception {
+        assertThat(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads,,mail-processing,"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
+    }
+
+    @Test
+    void shouldSupportOmittedBucketsSpreadOverSeveralLines() throws Exception {
+        assertThat(blobProperties(
+            "tmail.blobstore.shards=256",
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads",
+            "tmail.blobstore.shards.ommited.buckets=mail-processing"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.of(256,
+                BucketName.of("jmap-uploads"), BucketName.of("mail-processing")));
+    }
+
+    /**
+     * Pins down why the omitted buckets are read as an array: {@code getString} would silently return the first
+     * bucket only, leaving the others sharded with no error whatsoever.
+     */
+    @Test
+    void readingOmittedBucketsAsAStringShouldLoseAllButTheFirst() throws Exception {
+        File configurationDirectory = new File(workingDirectory, "conf");
+        Files.createDirectories(configurationDirectory.toPath());
+        Files.writeString(new File(configurationDirectory, ConfigurationComponent.NAME + ".properties").toPath(),
+            "tmail.blobstore.shards.ommited.buckets=jmap-uploads,mail-processing", StandardCharsets.UTF_8);
+
+        org.apache.commons.configuration2.Configuration blobProperties = propertiesProvider()
+            .getConfigurations(ConfigurationComponent.NAMES);
+
+        assertThat(blobProperties.getString("tmail.blobstore.shards.ommited.buckets"))
+            .isEqualTo("jmap-uploads");
+        assertThat(blobProperties.getStringArray("tmail.blobstore.shards.ommited.buckets"))
+            .containsExactly("jmap-uploads", "mail-processing");
+    }
+
+    @Test
+    void shouldBeDisabledWhenBlobPropertiesHoldsNothingRelevant() throws Exception {
+        assertThat(blobProperties("objectstorage.namespace=blobs", "objectstorage.bucketPrefix=tmail-"))
+            .isEqualTo(TmailBlobStoreShardingConfiguration.DISABLED);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Header blobs are now stored and retrieved correctly without being added to the blob ID list.
  * Re-saving header blobs now writes the latest content instead of applying content-addressed deduplication.
  * Content-addressed blobs remain correctly tracked, including IDs ending with header suffix characters.

* **Tests**
  * Added coverage for header blob detection across supported blob ID formats.
  * Added validation for shard configuration parsing, including omitted buckets and multi-line settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->